### PR TITLE
feat: make HPA usable with any qualified Kubernetes resource

### DIFF
--- a/new-frontiers/replicaset-patterns/katalog.yaml
+++ b/new-frontiers/replicaset-patterns/katalog.yaml
@@ -24,7 +24,7 @@ spec:
       resync: 30s
 
       operatorBox:
-        onReconcile:
+        onCreate:
           replicaSets:
             - name: "{{ .metadata.name }}-{{ .item }}"
               image: "{{ .spec.image }}"
@@ -32,3 +32,17 @@ spec:
               forEach:
                 field: spec.regions
                 as: item
+              reconcile: true
+          hpa:
+            - name: "{{ .metadata.name }}-{{ .item }}-hpa"
+              minReplicas: 1
+              maxReplicas: 10
+              targetCPUUtilizationPercentage: 50
+              scaleTargetRef:
+                apiVersion: apps/v1
+                kind: ReplicaSet
+                name: "{{ .metadata.name }}-{{ .item }}"
+              forEach:
+                field: spec.regions
+                as: item
+              reconcile: true

--- a/pkg/katalog/parser.go
+++ b/pkg/katalog/parser.go
@@ -150,6 +150,15 @@ func (k *Katalog) ValidateConfig(kfg *konfig.Konfig) (*Katalog, error) {
 		return nil, err
 	}
 
+	// -------------------------------------------------------------------------
+	// 13. Validate HPA Reference
+	// -------------------------------------------------------------------------
+	if err := k.validateHPAReference(); err != nil {
+		return nil, err
+	}
+
+	// 14. Validate Notify Teams
+
 	return k, nil
 }
 

--- a/pkg/katalog/validate.go
+++ b/pkg/katalog/validate.go
@@ -497,7 +497,7 @@ func (k *Katalog) validateNamespaceProtection() error {
 //	y   = years (365d)
 func (k *Katalog) validateTimeDuration() error {
 	for name, crd := range k.enabledCRDs {
-		if !crd.HasAnySecrets() {
+		if !crd.HasAnyHooks() || !crd.HasAnySecrets() {
 			continue
 		}
 
@@ -505,7 +505,7 @@ func (k *Katalog) validateTimeDuration() error {
 			for _, s := range crd.OperatorBox.OnCreate.Secrets {
 				if s.RotateAfter != "" {
 					if _, err := orktypes.ParseRotationDuration(s.RotateAfter); err != nil {
-						return durationError(name, s.Name, "validFor", s.RotateAfter, err)
+						return durationError(name, s.Name, "rotateAfter", s.RotateAfter, err)
 					}
 				}
 				// Check per-secret TLS presence
@@ -521,7 +521,7 @@ func (k *Katalog) validateTimeDuration() error {
 			for _, s := range crd.OperatorBox.OnReconcile.Secrets {
 				if s.RotateAfter != "" {
 					if _, err := orktypes.ParseRotationDuration(s.RotateAfter); err != nil {
-						return durationError(name, s.Name, "validFor", s.RotateAfter, err)
+						return durationError(name, s.Name, "rotateAfter", s.RotateAfter, err)
 					}
 				}
 				// Check per-secret TLS presence
@@ -548,6 +548,76 @@ func durationError(crdName, secretName, field, value string, err error) error {
 			"Examples: 30d, 2w, 3mo, 1y",
 		value, crdName, secretName, field, err,
 	)
+}
+
+// validateHPAReference ensures that every HPA declaration has a valid ScaleTargetRef.
+// Fail-fast: the first invalid reference returns an error immediately.
+func (k *Katalog) validateHPAReference() error {
+	for crdName, crd := range k.enabledCRDs {
+		if !crd.HasAnyHooks() || !crd.HasAnyHPA() {
+			continue
+		}
+
+		// onCreate
+		if crd.HasOnCreate() {
+			for _, h := range crd.OperatorBox.OnCreate.HorizontalPodAutoscalers {
+				if err := validateOneHPARef(crdName, h.Name, h.ScaleTargetRef); err != nil {
+					return err
+				}
+			}
+		}
+
+		// onReconcile
+		if crd.HasOnReconcile() {
+			for _, h := range crd.OperatorBox.OnReconcile.HorizontalPodAutoscalers {
+				if err := validateOneHPARef(crdName, h.Name, h.ScaleTargetRef); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateOneHPARef(crdName, hpaName string, ref orktypes.ScaleTargetRef) error {
+	if ref.APIVersion == "" {
+		return fmt.Errorf(
+			"invalid HPA ScaleTargetRef in CRD %q (hpa %q): missing apiVersion\n\n"+
+				"Example:\n"+
+				"  ScaleTargetRef:\n"+
+				"    apiVersion: apps/v1\n"+
+				"    kind: Deployment\n"+
+				"    name: my-app",
+			crdName, hpaName,
+		)
+	}
+
+	if ref.Kind == "" {
+		return fmt.Errorf(
+			"invalid HPA ScaleTargetRef in CRD %q (hpa %q): missing kind\n\n"+
+				"Example:\n"+
+				"  ScaleTargetRef:\n"+
+				"    apiVersion: apps/v1\n"+
+				"    kind: ReplicaSet\n"+
+				"    name: my-app",
+			crdName, hpaName,
+		)
+	}
+
+	if ref.Name == "" {
+		return fmt.Errorf(
+			"invalid HPA ScaleTargetRef in CRD %q (hpa %q): missing name\n\n"+
+				"Example:\n"+
+				"  ScaleTargetRef:\n"+
+				"    apiVersion: apps/v1\n"+
+				"    kind: StatefulSet\n"+
+				"    name: my-app",
+			crdName, hpaName,
+		)
+	}
+
+	return nil
 }
 
 // validateNotifyTeams checks that teams declared under notify actually exist in this katalog context

--- a/pkg/orkestra-registry/hpas/hpa.go
+++ b/pkg/orkestra-registry/hpas/hpa.go
@@ -161,19 +161,19 @@ func DeleteIfOwned(ctx context.Context, kube *kubeclient.Kubeclient,
 // All template expressions must be evaluated before calling here.
 func Resolve(src orktypes.HPATemplateSource, ownerName string) ResolvedHPASpec {
 	spec := ResolvedHPASpec{
-		Name:          src.Name,
-		Namespace:     src.Namespace,
-		DeploymentRef: src.DeploymentRef,
-		MinReplicas:   1,
-		MaxReplicas:   1,
-		Labels:        make(map[string]string),
+		Name:           src.Name,
+		Namespace:      src.Namespace,
+		ScaleTargetRef: src.ScaleTargetRef,
+		MinReplicas:    1,
+		MaxReplicas:    1,
+		Labels:         make(map[string]string),
 	}
 
 	if spec.Name == "" {
 		spec.Name = ownerName + "-hpa"
 	}
-	if spec.DeploymentRef == "" {
-		spec.DeploymentRef = ownerName
+	if spec.ScaleTargetRef.Name == "" {
+		spec.ScaleTargetRef.Name = ownerName
 	}
 
 	if src.MinReplicas != "" {
@@ -237,9 +237,9 @@ func buildHPA(owner domain.Object, spec ResolvedHPASpec, namespace string) *auto
 		},
 		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
 			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
-				APIVersion: "apps/v1",
-				Kind:       "Deployment",
-				Name:       spec.DeploymentRef,
+				APIVersion: spec.ScaleTargetRef.APIVersion,
+				Kind:       spec.ScaleTargetRef.Kind,
+				Name:       spec.ScaleTargetRef.Name,
 			},
 			MinReplicas: &minR,
 			MaxReplicas: spec.MaxReplicas,

--- a/pkg/orkestra-registry/hpas/types.go
+++ b/pkg/orkestra-registry/hpas/types.go
@@ -1,6 +1,10 @@
 // pkg/orkestra-registry/hpas/types.go
 package hpas
 
+import (
+	orktypes "github.com/orkspace/orkestra/pkg/types"
+)
+
 // ResolvedHPASpec is the fully resolved HorizontalPodAutoscaler specification.
 // All template expressions have been evaluated before this struct is populated.
 // Passed directly to Create, Update, and Delete.
@@ -11,8 +15,9 @@ type ResolvedHPASpec struct {
 	// Namespace — target namespace.
 	Namespace string
 
-	// DeploymentRef — name of the Deployment this HPA scales.
-	DeploymentRef string
+	// ScaleTargetRef — the target workload this HPA scales.
+	// Supports Deployment, ReplicaSet, StatefulSet, or any scalable resource.
+	ScaleTargetRef orktypes.ScaleTargetRef
 
 	// MinReplicas — minimum pod replica count. Default: 1.
 	MinReplicas int32

--- a/pkg/orkestra-registry/template/resolver.go
+++ b/pkg/orkestra-registry/template/resolver.go
@@ -821,8 +821,14 @@ func (r *Resolver) ResolveHPATemplate(src orktypes.HPATemplateSource) (orktypes.
 	if resolved.Name, err = r.Resolve(src.Name); err != nil {
 		return resolved, fmt.Errorf("hpa.name: %w", err)
 	}
-	if resolved.DeploymentRef, err = r.Resolve(src.DeploymentRef); err != nil {
-		return resolved, fmt.Errorf("hpa.deploymentRef: %w", err)
+	if resolved.ScaleTargetRef.APIVersion, err = r.Resolve(src.ScaleTargetRef.APIVersion); err != nil {
+		return resolved, fmt.Errorf("hpa.scaledRef.apiVersion: %w", err)
+	}
+	if resolved.ScaleTargetRef.Kind, err = r.Resolve(src.ScaleTargetRef.Kind); err != nil {
+		return resolved, fmt.Errorf("hpa.scaledRef.kind: %w", err)
+	}
+	if resolved.ScaleTargetRef.Name, err = r.Resolve(src.ScaleTargetRef.Name); err != nil {
+		return resolved, fmt.Errorf("hpa.scaledRef.name: %w", err)
 	}
 	if resolved.MinReplicas, err = r.Resolve(src.MinReplicas); err != nil {
 		return resolved, fmt.Errorf("hpa.minReplicas: %w", err)

--- a/pkg/reconciler/run_foreach.go
+++ b/pkg/reconciler/run_foreach.go
@@ -542,7 +542,9 @@ func expandForEachHPAs(
 			expanded.ForEach = nil
 			expanded.Name, _ = ir.Resolve(src.Name)
 			expanded.Namespace, _ = ir.Resolve(src.Namespace)
-			expanded.DeploymentRef, _ = ir.Resolve(src.DeploymentRef)
+			expanded.ScaleTargetRef.APIVersion, _ = ir.Resolve(src.ScaleTargetRef.APIVersion)
+			expanded.ScaleTargetRef.Kind, _ = ir.Resolve(src.ScaleTargetRef.Kind)
+			expanded.ScaleTargetRef.Name, _ = ir.Resolve(src.ScaleTargetRef.Name)
 			expanded.MinReplicas, _ = ir.Resolve(src.MinReplicas)
 			expanded.MaxReplicas, _ = ir.Resolve(src.MaxReplicas)
 			expanded.TargetCPUUtilizationPercentage, _ = ir.Resolve(src.TargetCPUUtilizationPercentage)

--- a/pkg/types/methods.go
+++ b/pkg/types/methods.go
@@ -379,3 +379,16 @@ func (c *CRDEntry) HasAnyTLSSecrets() bool {
 
 	return false
 }
+
+// HasAnyHPA reports whether this CRD defines any HPA defined
+// in either OnCreate or OnReconcile phases.
+func (c *CRDEntry) HasAnyHPA() bool {
+	if c.HasOnCreate() {
+		return c.OperatorBox.OnCreate.HorizontalPodAutoscalers != nil
+	}
+	if c.HasOnReconcile() {
+		return c.OperatorBox.OnReconcile.HorizontalPodAutoscalers != nil
+	}
+
+	return false
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1293,6 +1293,12 @@ type IngressTLSSpec struct {
 
 // ── HorizontalPodAutoscaler ───────────────────────────────────────────────────
 
+type ScaleTargetRef struct {
+	APIVersion string `yaml:"apiVersion" json:"apiVersion"`
+	Kind       string `yaml:"kind" json:"kind"`
+	Name       string `yaml:"name" json:"name"`
+}
+
 // HPATemplateSource declares one HorizontalPodAutoscaler to be managed by Orkestra.
 //
 // Example:
@@ -1316,9 +1322,10 @@ type HPATemplateSource struct {
 	// Namespace — target namespace. Default: CR namespace.
 	Namespace string `yaml:"namespace" json:"namespace,omitempty"`
 
-	// DeploymentRef — name of the Deployment this HPA targets.
+	// ScaleTargetRef — the target workload this HPA scales.
+	// Supports Deployment, ReplicaSet, StatefulSet, or any scalable resource.
 	// Supports template expressions: "{{ .metadata.name }}"
-	DeploymentRef string `yaml:"deploymentRef" json:"deploymentRef,omitempty"`
+	ScaleTargetRef ScaleTargetRef `yaml:"scaleTargetRef" json:"scaleTargetRef,omitempty"`
 
 	// MinReplicas — minimum replica count as a string. Supports template expressions.
 	MinReplicas string `yaml:"minReplicas" json:"minReplicas,omitempty"`


### PR DESCRIPTION
This PR removes the long‑standing Deployment‑only limitation in Orkestra’s HPA implementation and replaces it with a fully generic `scaleTargetRef`, matching native Kubernetes HPA semantics.

HorizontalPodAutoscaler can now target **any scalable Kubernetes resource**, including:

- ReplicaSet  
- Deployment  
- StatefulSet  
- any custom resource exposing the `/scale` subresource  

This aligns Orkestra’s autoscaling model with its new workload architecture, where ReplicaSet is a first‑class primitive.

---

## What’s Included

### Generalized HPA Targeting
- Replace `DeploymentRef` with a full `scaleTargetRef` (apiVersion/kind/name).
- Update resolver, registry, and reconciler to use the generic reference.
- Add validation to ensure `scaleTargetRef` is fully specified.

### Behavior
- HPA creation, reconciliation, and garbage collection now work for any valid Kubernetes scale target.
- Tested with forEach fan‑out targeting ReplicaSets:
  - HPAs created correctly  
  - HPAs reconciled correctly  
  - HPAs garbage‑collected when the CR is deleted  
  - No Deployments required  

### Katalog Support
- Katalog now accepts:

```yaml
scaleTargetRef:
  apiVersion: apps/v1
  kind: ReplicaSet
  name: "{{ .metadata.name }}-{{ .item }}"
```

This matches native Kubernetes HPA syntax and removes the Deployment dependency entirely.

---

## Why This Matters

This change completes the transition to Orkestra’s new workload model:

- ReplicaSet is now a fully supported, scalable primitive.
- HPA no longer assumes Deployment as the only valid target.
- Users can scale any resource that implements the scale subresource.
- Enables clean fan‑out patterns where each ReplicaSet has its own HPA.

This brings Orkestra’s autoscaling capabilities in line with Kubernetes itself and unlocks new orchestration patterns without requiring custom controllers.