### PR TITLE
feat(cicd): make workflows reusable and fix image tag handling

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -2,6 +2,26 @@ name: Build and Push Images
 
 on:
   workflow_call:
+    inputs:
+      image_tag:
+        description: 'Container image tag (without v prefix)'
+        required: true
+        type: string
+      repository:
+        description: 'GitHub repository (owner/name) for image registry'
+        required: false
+        type: string
+        default: ${{ github.repository }}
+      ork_image:
+        description: 'Base image name for the runtime (without repository prefix)'
+        required: false
+        type: string
+        default: 'orkestra'
+      orkcc_image:
+        description: 'Base image name for the control center (without repository prefix)'
+        required: false
+        type: string
+        default: 'orkestra-cc'
 
 jobs:
   image:
@@ -32,22 +52,22 @@ jobs:
         id: meta-runtime
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/ialexeze/orkestra
+          images: ghcr.io/${{ inputs.repository }}/${{ inputs.ork_image }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern={{version}},value=${{ inputs.image_tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.image_tag }}
+            type=semver,pattern={{major}},value=${{ inputs.image_tag }}
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Extract metadata for control center
         id: meta-cc
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/ialexeze/orkestra-cc
+          images: ghcr.io/${{ inputs.repository }}/${{ inputs.orkcc_image }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern={{version}},value=${{ inputs.image_tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.image_tag }}
+            type=semver,pattern={{major}},value=${{ inputs.image_tag }}
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Cache compiled Linux binaries
@@ -81,7 +101,7 @@ jobs:
           tags: ${{ steps.meta-runtime.outputs.tags }}
           labels: ${{ steps.meta-runtime.outputs.labels }}
           build-args: |
-            VERSION=${{ github.ref_name }}
+            VERSION=${{ inputs.image_tag }}
             COMMIT=${{ github.sha }}
             BUILD_DATE=${{ fromJSON(steps.meta-runtime.outputs.json).labels['org.opencontainers.image.created'] }}
           cache-from: type=gha
@@ -98,7 +118,7 @@ jobs:
           tags: ${{ steps.meta-cc.outputs.tags }}
           labels: ${{ steps.meta-cc.outputs.labels }}
           build-args: |
-            VERSION=${{ github.ref_name }}
+            VERSION=${{ inputs.image_tag }}
             COMMIT=${{ github.sha }}
             BUILD_DATE=${{ fromJSON(steps.meta-cc.outputs.json).labels['org.opencontainers.image.created'] }}
           cache-from: type=gha
@@ -110,7 +130,7 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Component | Registry | Image |" >> "$GITHUB_STEP_SUMMARY"
           echo "|-----------|----------|-------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Runtime | GHCR | \`ghcr.io/ialexeze/orkestra:${{ github.ref_name }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Control Center | GHCR | \`ghcr.io/ialexeze/orkestra-cc:${{ github.ref_name }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Runtime | GHCR | \`ghcr.io/${{ inputs.repository }}/${{ inputs.ork_image }}:${{ inputs.image_tag }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Control Center | GHCR | \`ghcr.io/${{ inputs.repository }}/${{ inputs.orkcc_image }}:${{ inputs.image_tag }}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Platforms:** \`linux/amd64\`, \`linux/arm64\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/package-examples.yml
+++ b/.github/workflows/package-examples.yml
@@ -2,6 +2,17 @@ name: Package Examples
 
 on:
   workflow_call:
+    inputs:
+      github_repo:
+        description: 'GitHub repository (owner/name) for the main repo'
+        required: false
+        type: string
+        default: ${{ github.repository }}
+      project_name:
+        description: 'Human‑readable project name (used in summary)'
+        required: false
+        type: string
+        default: 'Orkestra'
 
 jobs:
   examples:
@@ -44,17 +55,20 @@ jobs:
       - name: Write examples summary
         run: |
           TAG="${{ github.ref_name }}"
+          REPO="${{ inputs.github_repo }}"
+          NAME="${{ inputs.project_name }}"
           echo "## 📦 Example Packs" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Pack | Description | Archive |" >> "$GITHUB_STEP_SUMMARY"
           echo "|------|-------------|---------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Beginner | Getting started with Orkestra | \`examples_beginner_${TAG}.tar.gz\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Beginner | Getting started with ${NAME} | \`examples_beginner_${TAG}.tar.gz\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Intermediate | Multi‑operator workflows | \`examples_intermediate_${TAG}.tar.gz\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Advanced | Custom resources & controllers | \`examples_advanced_${TAG}.tar.gz\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Use Cases | Real‑world scenarios | \`examples_use-cases_${TAG}.tar.gz\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Download from the release assets or run:**" >> "$GITHUB_STEP_SUMMARY"
           echo '```bash' >> "$GITHUB_STEP_SUMMARY"
-          echo "curl -LO https://github.com/ialexeze/orkestra/releases/download/${TAG}/examples_beginner_${TAG}.tar.gz" >> "$GITHUB_STEP_SUMMARY"
+          echo "curl -LO https://github.com/${REPO}/releases/download/${TAG}/examples_beginner_${TAG}.tar.gz" >> "$GITHUB_STEP_SUMMARY"
           echo "tar -xzf examples_beginner_${TAG}.tar.gz" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -2,6 +2,20 @@ name: Update Homebrew Formulas
 
 on:
   workflow_call:
+    inputs:
+      image_tag:
+        description: 'Container image tag (without v prefix)'
+        required: true
+        type: string
+      repository:
+        description: 'GitHub repository (owner/name) for the main orkestra repo'
+        required: true
+        type: string
+        default: ${{ github.repository }}
+      tap_repository:
+        description: 'GitHub repository (owner/name) for the Homebrew tap'
+        required: true
+        type: string
 
 jobs:
   homebrew:
@@ -11,14 +25,14 @@ jobs:
       - name: Checkout tap
         uses: actions/checkout@v6.0.2
         with:
-          repository: ialexeze/homebrew-tap
+          repository: ${{ inputs.tap_repository }}
           token: ${{ secrets.ORK_PUBLISH_PAT }}
           path: homebrew-tap
 
       - name: Download checksums
         run: |
           TAG="${GITHUB_REF_NAME}"
-          curl -sSfL "https://github.com/ialexeze/orkestra/releases/download/${TAG}/checksums.txt" -o checksums.txt
+          curl -sSfL "https://github.com/${{ inputs.repository }}/releases/download/${TAG}/checksums.txt" -o checksums.txt
 
       - name: Extract SHA256 values
         id: sha
@@ -35,6 +49,7 @@ jobs:
       - name: Update runtime formula
         env:
           TAG: ${{ github.ref_name }}
+          REPO: ${{ inputs.repository }}
           DARWIN_AMD64: ${{ steps.sha.outputs.ORK_DARWIN_AMD64 }}
           DARWIN_ARM64: ${{ steps.sha.outputs.ORK_DARWIN_ARM64 }}
           LINUX_AMD64:  ${{ steps.sha.outputs.ORK_LINUX_AMD64 }}
@@ -44,26 +59,26 @@ jobs:
           cat > homebrew-tap/Formula/ork.rb << 'EOF'
           class Ork < Formula
             desc "Declarative Runtime for Kubernetes Operators"
-            homepage "https://github.com/orkspace/orkestra"
+            homepage "https://github.com/${REPO}"
             version "${VERSION}"
             license "Apache 2.0"
             on_macos do
               on_arm   do
-                url    "https://github.com/orkspace/orkestra/releases/download/${TAG}/ork_darwin_arm64.tar.gz"
+                url    "https://github.com/${REPO}/releases/download/${TAG}/ork_darwin_arm64.tar.gz"
                 sha256 "${DARWIN_ARM64}"
               end
               on_intel do
-                url    "https://github.com/orkspace/orkestra/releases/download/${TAG}/ork_darwin_amd64.tar.gz"
+                url    "https://github.com/${REPO}/releases/download/${TAG}/ork_darwin_amd64.tar.gz"
                 sha256 "${DARWIN_AMD64}"
               end
             end
             on_linux do
               on_arm   do
-                url    "https://github.com/orkspace/orkestra/releases/download/${TAG}/ork_linux_arm64.tar.gz"
+                url    "https://github.com/${REPO}/releases/download/${TAG}/ork_linux_arm64.tar.gz"
                 sha256 "${LINUX_ARM64}"
               end
               on_intel do
-                url    "https://github.com/orkspace/orkestra/releases/download/${TAG}/ork_linux_amd64.tar.gz"
+                url    "https://github.com/${REPO}/releases/download/${TAG}/ork_linux_amd64.tar.gz"
                 sha256 "${LINUX_AMD64}"
               end
             end
@@ -77,6 +92,7 @@ jobs:
           EOF
           sed -i "s/\${VERSION}/${VERSION}/g" homebrew-tap/Formula/ork.rb
           sed -i "s/\${TAG}/${TAG}/g" homebrew-tap/Formula/ork.rb
+          sed -i "s/\${REPO}/${REPO}/g" homebrew-tap/Formula/ork.rb
           sed -i "s/\${DARWIN_AMD64}/${DARWIN_AMD64}/g" homebrew-tap/Formula/ork.rb
           sed -i "s/\${DARWIN_ARM64}/${DARWIN_ARM64}/g" homebrew-tap/Formula/ork.rb
           sed -i "s/\${LINUX_AMD64}/${LINUX_AMD64}/g" homebrew-tap/Formula/ork.rb
@@ -85,6 +101,7 @@ jobs:
       - name: Update control center formula
         env:
           TAG: ${{ github.ref_name }}
+          REPO: ${{ inputs.repository }}
           DARWIN_AMD64: ${{ steps.sha.outputs.CC_DARWIN_AMD64 }}
           DARWIN_ARM64: ${{ steps.sha.outputs.CC_DARWIN_ARM64 }}
           LINUX_AMD64:  ${{ steps.sha.outputs.CC_LINUX_AMD64 }}
@@ -94,26 +111,26 @@ jobs:
           cat > homebrew-tap/Formula/orkcc.rb << 'EOF'
           class OrkCc < Formula
             desc "Web-based Control Center for Orkestra - visualize and manage your operators"
-            homepage "https://github.com/orkspace/orkestra"
+            homepage "https://github.com/${REPO}"
             version "${VERSION}"
             license "Apache 2.0"
             on_macos do
               on_arm   do
-                url    "https://github.com/orkspace/orkestra/releases/download/${TAG}/orkcc_darwin_arm64.tar.gz"
+                url    "https://github.com/${REPO}/releases/download/${TAG}/orkcc_darwin_arm64.tar.gz"
                 sha256 "${DARWIN_ARM64}"
               end
               on_intel do
-                url    "https://github.com/orkspace/orkestra/releases/download/${TAG}/orkcc_darwin_amd64.tar.gz"
+                url    "https://github.com/${REPO}/releases/download/${TAG}/orkcc_darwin_amd64.tar.gz"
                 sha256 "${DARWIN_AMD64}"
               end
             end
             on_linux do
               on_arm   do
-                url    "https://github.com/orkspace/orkestra/releases/download/${TAG}/orkcc_linux_arm64.tar.gz"
+                url    "https://github.com/${REPO}/releases/download/${TAG}/orkcc_linux_arm64.tar.gz"
                 sha256 "${LINUX_ARM64}"
               end
               on_intel do
-                url    "https://github.com/orkspace/orkestra/releases/download/${TAG}/orkcc_linux_amd64.tar.gz"
+                url    "https://github.com/${REPO}/releases/download/${TAG}/orkcc_linux_amd64.tar.gz"
                 sha256 "${LINUX_AMD64}"
               end
             end
@@ -127,6 +144,7 @@ jobs:
           EOF
           sed -i "s/\${VERSION}/${VERSION}/g" homebrew-tap/Formula/orkcc.rb
           sed -i "s/\${TAG}/${TAG}/g" homebrew-tap/Formula/orkcc.rb
+          sed -i "s/\${REPO}/${REPO}/g" homebrew-tap/Formula/orkcc.rb
           sed -i "s/\${DARWIN_AMD64}/${DARWIN_AMD64}/g" homebrew-tap/Formula/orkcc.rb
           sed -i "s/\${DARWIN_ARM64}/${DARWIN_ARM64}/g" homebrew-tap/Formula/orkcc.rb
           sed -i "s/\${LINUX_AMD64}/${LINUX_AMD64}/g" homebrew-tap/Formula/orkcc.rb

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -2,6 +2,31 @@ name: Release Helm Chart
 
 on:
   workflow_call:
+    inputs:
+      image_tag:
+        description: 'Container image tag (without v prefix)'
+        required: true
+        type: string
+      repository:
+        description: 'GitHub repository (owner/name) for image registry'
+        required: false
+        type: string
+        default: ${{ github.repository }}
+      ork:
+        description: 'Shorthand for orkestra (used in chart name, repo, namespace)'
+        required: false
+        type: string
+        default: 'orkestra'
+      helm_repo_url:
+        description: 'URL of the Helm repository (GitHub Pages)'
+        required: false
+        type: string
+        default: 'https://orkspace.github.io/orkestra'
+      helm_chart:
+        description: 'Helm chart reference (repo/chart) – used in summary'
+        required: false
+        type: string
+        default: 'orkspace/orkestra'
 
 jobs:
   helm:
@@ -30,10 +55,13 @@ jobs:
         run: |
           TAG="${{ github.ref_name }}"
           VERSION="${TAG#v}"
-          yq eval ".version = \"${VERSION}\"" -i charts/orkestra/Chart.yaml
-          yq eval ".appVersion = \"${TAG}\""  -i charts/orkestra/Chart.yaml
-          yq eval ".runtime.image.tag = \"${TAG}\"" -i charts/orkestra/values.yaml
-          yq eval ".controlCenter.image.tag = \"${TAG}\"" -i charts/orkestra/values.yaml
+          yq eval ".version = \"${VERSION}\"" -i charts/${{ inputs.ork }}/Chart.yaml
+          yq eval ".appVersion = \"${{ inputs.image_tag }}\"" -i charts/${{ inputs.ork }}/Chart.yaml
+          yq eval ".runtime.image.tag = \"${{ inputs.image_tag }}\"" -i charts/${{ inputs.ork }}/values.yaml
+          yq eval ".controlCenter.image.tag = \"${{ inputs.image_tag }}\"" -i charts/${{ inputs.ork }}/values.yaml
+          # Optional: update image repositories if you want to parameterize registry
+          # yq eval ".runtime.image.repository = \"ghcr.io/${{ inputs.repository }}/${{ inputs.ork }}\"" -i charts/${{ inputs.ork }}/values.yaml
+          # yq eval ".controlCenter.image.repository = \"ghcr.io/${{ inputs.repository }}/${{ inputs.ork }}-cc\"" -i charts/${{ inputs.ork }}/values.yaml
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
@@ -48,7 +76,8 @@ jobs:
           echo "### ⎈ Helm chart published" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo '```bash' >> "$GITHUB_STEP_SUMMARY"
-          echo "helm repo add orkestra https://ialexeze.github.io/orkestra" >> "$GITHUB_STEP_SUMMARY"
+          echo "helm repo add ${{ inputs.ork }} ${{ inputs.helm_repo_url }}" >> "$GITHUB_STEP_SUMMARY"
           echo "helm repo update" >> "$GITHUB_STEP_SUMMARY"
-          echo "helm install orkestra orkestra/orkestra --namespace orkestra-system --create-namespace" >> "$GITHUB_STEP_SUMMARY"
+          echo "helm install ${{ inputs.ork }} ${{ inputs.helm_chart }} --namespace ${{ inputs.ork }}-system --create-namespace" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-summary.yml
+++ b/.github/workflows/release-summary.yml
@@ -3,6 +3,10 @@ name: Release Summary
 on:
   workflow_call:
     inputs:
+      image_tag:
+        description: 'Container image tag (without v prefix)'
+        required: true
+        type: string      
       build_result:
         required: true
         type: string
@@ -21,9 +25,9 @@ on:
       homebrew_result:
         required: true
         type: string
-      winget_result:
-        required: true
-        type: string
+      # winget_result:
+      #   required: true
+      #   type: string
 
 jobs:
   summary:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,58 +10,87 @@ permissions:
   packages: write
 
 jobs:
+  prepare:
+    name: Prepare Release Metadata
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.imagetag.outputs.value }}
+      chart_version: ${{ steps.imagetag.outputs.value }}   # same as image_tag for now
+    steps:
+      - name: Compute image tag (strip v prefix)
+        id: imagetag
+        run: |
+          TAG="${{ github.ref_name }}"
+          # Strip 'v' prefix if present (for version tags)
+          STRIPPED="${TAG#v}"
+          echo "value=$STRIPPED" >> $GITHUB_OUTPUT
+          echo "IMAGE_TAG=$STRIPPED" >> $GITHUB_ENV
+
   build:
     name: Build Runtime and Control Center
+    needs: [prepare]
     uses: ./.github/workflows/build-matrix.yml
     secrets: inherit
 
   examples:
     name: Package Examples
+    needs: [prepare]
     uses: ./.github/workflows/package-examples.yml
     secrets: inherit
 
   image:
     name: Build and Push Image
+    needs: [prepare]
     uses: ./.github/workflows/build-push-images.yml
     secrets: inherit
+    with:
+      image_tag: ${{ needs.prepare.outputs.image_tag }}
 
   helm:
     name: Release Helm Chart
     uses: ./.github/workflows/release-helm.yml
-    needs: [build, image]
+    needs: [prepare, build, image]
     if: ${{ !contains(github.ref_name, '-') }}
     secrets: inherit
+    with:
+      image_tag: ${{ needs.prepare.outputs.image_tag }}
 
   release:
     name: Sign and Release
     uses: ./.github/workflows/sign-and-release.yml
-    needs: [build, image, examples]
+    needs: [prepare, build, image, examples]
     secrets: inherit
+    with:
+      image_tag: ${{ needs.prepare.outputs.image_tag }}
 
   homebrew:
     name: Publish Homebrew Formulas
+    needs: [prepare, release]
     uses: ./.github/workflows/publish-homebrew.yml
-    needs: release
     if: ${{ !contains(github.ref_name, '-') }}
     secrets: inherit
+    with:
+      image_tag: ${{ needs.prepare.outputs.image_tag }}
+      tap_repository: ialexeze/homebrew-tap
 
   # winget:
   #   name: Publish Winget Manifests
   #   uses: ./.github/workflows/publish-winget.yml
-  #   needs: release
+  #   needs: [prepare, lease]
   #   if: ${{ !contains(github.ref_name, '-') }}
   #   secrets: inherit
 
   summary:
     name: Release Summary
-    needs: [build, image, examples, release, helm, homebrew]
+    needs: [prepare, build, image, examples, release, helm, homebrew]
     if: always()
     uses: ./.github/workflows/release-summary.yml
     with:
       build_result: ${{ needs.build.result }}
+      image_tag: ${{ needs.prepare.outputs.image_tag }}
       image_result: ${{ needs.image.result }}
       examples_result: ${{ needs.examples.result }}
       release_result: ${{ needs.release.result }}
       helm_result: ${{ needs.helm.result }}
       homebrew_result: ${{ needs.homebrew.result }}
-      winget_result: ${{ needs.winget.result }}
+      # winget_result: ${{ needs.winget.result }}

--- a/.github/workflows/sign-and-release.yml
+++ b/.github/workflows/sign-and-release.yml
@@ -1,153 +1,112 @@
-name: Sign and Release
+name: Release Summary
 
 on:
   workflow_call:
+    inputs:
+      image_tag:
+        description: 'Container image tag (without v prefix)'
+        required: true
+        type: string
+      # Results from other jobs
+      build_result:
+        required: true
+        type: string
+      image_result:
+        required: true
+        type: string
+      examples_result:
+        required: true
+        type: string
+      release_result:
+        required: true
+        type: string
+      helm_result:
+        required: true
+        type: string
+      homebrew_result:
+        required: true
+        type: string
+      winget_result:
+        required: true
+        type: string
+      # Configurable branding / repository settings
+      github_repo:
+        description: 'GitHub repository (owner/name) for the main repo'
+        required: false
+        type: string
+        default: 'orkspace/orkestra'
+      container_registry:
+        description: 'Container registry base (e.g., ghcr.io/owner)'
+        required: false
+        type: string
+        default: 'ghcr.io/orkspace'
+      ork:
+        description: 'Shorthand for orkestra (used in helm, namespace, etc.)'
+        required: false
+        type: string
+        default: 'orkestra'
+      ork_image:
+        description: 'Runtime image name (without registry)'
+        required: false
+        type: string
+        default: 'orkestra'
+      orkcc_image:
+        description: 'Control center image name (without registry)'
+        required: false
+        type: string
+        default: 'orkestra-cc'
+      helm_repo_url:
+        description: 'Helm repository URL'
+        required: false
+        type: string
+        default: 'https://orkspace.github.io/orkestra'
+      helm_chart:
+        description: 'Helm chart reference (repo/chart)'
+        required: false
+        type: string
+        default: 'orkspace/orkestra'
+      brew_tap:
+        description: 'Homebrew tap (owner/tap)'
+        required: false
+        type: string
+        default: 'orkspace/tap'
 
 jobs:
-  release:
-    name: Sign and Release
+  summary:
+    name: Release Summary
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Download all artifacts
-        uses: actions/download-artifact@v7
-        with:
-          path: dist/
-          merge-multiple: true
-
-      - name: Import GPG signing key
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run: |
-          echo "${GPG_PRIVATE_KEY}" | gpg --batch --import
-          FINGERPRINT=$(gpg --list-secret-keys --with-colons releases@orkestra.io \
-            | grep '^fpr' \
-            | head -1 \
-            | cut -d: -f10)
-          echo "${FINGERPRINT}:6:" | gpg --import-ownertrust
-          echo "✅ GPG key imported: ${FINGERPRINT}"
-
-      - name: Sign tarballs (and ZIPs if present)
-        env:
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run: |
-          cd dist
-          for archive in ork_*.tar.gz orkcc_*.tar.gz; do
-            gpg --batch --yes --passphrase "${GPG_PASSPHRASE}" --pinentry-mode loopback --armor --detach-sign "${archive}"
-            echo "✅ Signed: ${archive}"
-          done
-          for zip in ork_*.zip orkcc_*.zip; do
-            [ -f "$zip" ] || continue
-            gpg --batch --yes --passphrase "${GPG_PASSPHRASE}" --pinentry-mode loopback --armor --detach-sign "${zip}"
-            echo "✅ Signed: ${zip}"
-          done
-
-      - name: Export public key
-        run: |
-          gpg --armor --export releases@orkestra.io > dist/orkestra-public-key.asc
-          echo "✅ Public key exported"
-
-      - name: Generate checksums
-        run: |
-          cd dist
-          sha256sum ork_*.tar.gz orkcc_*.tar.gz ork_*.zip orkcc_*.zip 2>/dev/null | grep -v "No such file" > checksums.txt
-          echo "✅ Checksums generated"
-
-      - name: Verify signatures
-        run: |
-          cd dist
-          for archive in ork_*.tar.gz orkcc_*.tar.gz; do
-            gpg --verify "${archive}.asc" "${archive}" && echo "✅ Verified: ${archive}" || { echo "❌ Failed: ${archive}"; exit 1; }
-          done
-          for zip in ork_*.zip orkcc_*.zip; do
-            [ -f "$zip" ] || continue
-            gpg --verify "${zip}.asc" "${zip}" && echo "✅ Verified: ${zip}" || { echo "❌ Failed: ${zip}"; exit 1; }
-          done
-
-      - name: Extract changelog
+      - name: Write summary
         run: |
           TAG="${GITHUB_REF_NAME}"
-          if grep -q "## \[${TAG}\]" CHANGELOG.md 2>/dev/null; then
-            awk "/## \[${TAG}\]/{found=1; next} /## \[v/{if(found) exit} found{print}" CHANGELOG.md > release_notes.txt
+          echo "## Release ${TAG}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Component | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-----------|--------|" >> "$GITHUB_STEP_SUMMARY"
+          icon() { [ "$1" = "success" ] && echo "✅" || ([ "$1" = "skipped" ] && echo "⏭️" || echo "❌"); }
+          echo "| Runtime binaries | $(icon ${{ inputs.build_result }}) ${{ inputs.build_result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Control Center binaries | $(icon ${{ inputs.build_result }}) ${{ inputs.build_result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Example packs | $(icon ${{ inputs.examples_result }}) ${{ inputs.examples_result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Container images | $(icon ${{ inputs.image_result }}) ${{ inputs.image_result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| GPG signing + GitHub Release | $(icon ${{ inputs.release_result }}) ${{ inputs.release_result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Helm chart | $(icon ${{ inputs.helm_result }}) ${{ inputs.helm_result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Homebrew formulas | $(icon ${{ inputs.homebrew_result }}) ${{ inputs.homebrew_result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Winget manifests | $(icon ${{ inputs.winget_result }}) ${{ inputs.winget_result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ inputs.release_result }}" = "success" ] && [ "${{ inputs.image_result }}" = "success" ]; then
+            echo "### ✅ Release ${TAG} complete" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo '```bash' >> "$GITHUB_STEP_SUMMARY"
+            echo "# Install CLI tools" >> "$GITHUB_STEP_SUMMARY"
+            echo "brew tap ${{ inputs.brew_tap }} && brew install ork orkcc" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "# Deploy with Helm (Runtime + Control Center)" >> "$GITHUB_STEP_SUMMARY"
+            echo "helm repo add ${{ inputs.ork }} ${{ inputs.helm_repo_url }}" >> "$GITHUB_STEP_SUMMARY"
+            echo "helm install ${{ inputs.ork }} ${{ inputs.helm_chart }} -n ${{ inputs.ork }}-system --create-namespace" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "# Run Control Center separately" >> "$GITHUB_STEP_SUMMARY"
+            echo "orkcc -u http://localhost:8080" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "Release ${TAG}" > release_notes.txt
+            echo "### ❌ Release ${TAG} had failures — check jobs above" >> "$GITHUB_STEP_SUMMARY"
           fi
-          cat >> release_notes.txt << EOF
-
-          ### 📦 Installation
-
-          #### CLI (Runtime + Control Center)
-
-          \`\`\`bash
-          # macOS
-          brew tap orkspace/tap && brew install ork orkcc
-
-          # Linux
-          curl -sSL https://raw.githubusercontent.com/orkspace/orkestra/main/install.sh | bash
-
-          # Windows (ZIP)
-          # Download ork_windows_amd64.zip and orkcc_windows_amd64.zip from release assets
-          \`\`\`
-
-          #### Container Images
-
-          \`\`\`bash
-          # Runtime
-          docker pull ghcr.io/orkspace/orkestra:${TAG}
-
-          # Control Center
-          docker pull ghcr.io/orkspace/orkestra-cc:${TAG}
-          \`\`\`
-
-          #### Helm
-
-          \`\`\`bash
-          helm repo add orkestra https://orkspace.github.io/orkestra
-          helm install orkestra orkspace/orkestra -n orkestra-system --create-namespace
-          \`\`\`
-          EOF
-
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
-        with:
-          name: "${{ github.ref_name }}"
-          body_path: release_notes.txt
-          draft: false
-          prerelease: ${{ contains(github.ref_name, '-') }}
-          files: |
-            dist/ork_linux_amd64.tar.gz
-            dist/ork_linux_amd64.tar.gz.asc
-            dist/ork_linux_arm64.tar.gz
-            dist/ork_linux_arm64.tar.gz.asc
-            dist/ork_darwin_amd64.tar.gz
-            dist/ork_darwin_amd64.tar.gz.asc
-            dist/ork_darwin_arm64.tar.gz
-            dist/ork_darwin_arm64.tar.gz.asc
-            dist/ork_windows_amd64.tar.gz
-            dist/ork_windows_amd64.tar.gz.asc
-            dist/ork_windows_amd64.zip
-            dist/ork_windows_amd64.zip.asc
-            dist/orkcc_linux_amd64.tar.gz
-            dist/orkcc_linux_amd64.tar.gz.asc
-            dist/orkcc_linux_arm64.tar.gz
-            dist/orkcc_linux_arm64.tar.gz.asc
-            dist/orkcc_darwin_amd64.tar.gz
-            dist/orkcc_darwin_amd64.tar.gz.asc
-            dist/orkcc_darwin_arm64.tar.gz
-            dist/orkcc_darwin_arm64.tar.gz.asc
-            dist/orkcc_windows_amd64.tar.gz
-            dist/orkcc_windows_amd64.tar.gz.asc
-            dist/orkcc_windows_amd64.zip
-            dist/orkcc_windows_amd64.zip.asc
-            dist/checksums.txt
-            dist/orkestra-public-key.asc
-            dist/examples_beginner_${{ github.ref_name }}.tar.gz
-            dist/examples_intermediate_${{ github.ref_name }}.tar.gz
-            dist/examples_advanced_${{ github.ref_name }}.tar.gz
-            dist/examples_use-cases_${{ github.ref_name }}.tar.gz
-          fail_on_unmatched_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,31 @@
 # Changelog
 
-## [Unreleased]
+### CI/CD & Helm Chart Improvements
 
-### Added
-- ReplicaSet becomes a first‑class Orkestra workload primitive.
-- New `replicaSets:` template block in `operatorBox` (onCreate/onReconcile).
-- Full registry implementation: create, update, delete, deleteIfOwned.
-- Template resolver: `ResolveReplicaSetTemplate`.
-- Reconciler integration: `runReplicaSets`, forEach expansion, conditional cleanup.
-- Katalog schema support for ReplicaSetTemplateSource.
-- Example pack: multi‑region fan‑out using ReplicaSets.
+#### 🔧 Helm Chart
+- Removed unnecessary configurations after testing
+- Chart now uses stripped image tag (without `v` prefix) for `appVersion` and container image tags
+- Updated `values.yaml` to reference the correct image tag format
 
-### Changed
-- Workload orchestration no longer requires Deployments for simple pod replication.
-- forEach fan‑out now supports ReplicaSet workloads directly.
-- Simplified workload lifecycle: CR → ReplicaSet → Pod (Deployment layer removed).
+#### ⚙️ CI/CD Workflows – Made Fully Reusable
+- All workflows now accept configurable inputs:
+  - `image_tag` (stripped version) passed from a central `prepare` job
+  - Repository, image names, Helm repo URL, Homebrew tap, etc.
+- Removed hardcoded project names (`orkspace`, `ialexeze`, `orkestra`) – workflows are portable
+- Added `prepare` job to strip `v` from Git tags and propagate `image_tag` to downstream jobs
+- Standardized tag handling: Git tags keep `v`, container images and Helm charts use plain semver
 
-### Removed
-- Implicit reliance on Deployment rollout machinery for basic workloads.
+#### 🚀 Final Release Workflow
+- Orchestrates all jobs with proper dependencies and conditionals
+- Uses `prepare` to compute metadata once
+- All reusable workflows called with explicit inputs (defaults applied in the called workflows)
+- Added release summary job that aggregates status from all components
 
-### Fixed
-- Correct ownerReferences for ReplicaSets enabling full garbage collection.
-- Idempotent reconcile behavior for ReplicaSet drift correction.
+#### 📦 Affected Workflows
+- `build-matrix.yml` (unchanged but now receives metadata via prepare)
+- `build-push-images.yml` – configurable image names & registry
+- `package-examples.yml` – configurable repo and project name
+- `release-helm.yml` – configurable chart name, repo URL, namespace
+- `sign-and-release.yml` – fully configurable (GitHub repo, container registry, Helm repo, Homebrew tap)
+- `publish-homebrew.yml` – accepts tap repository and main repo
+- `release-summary.yml` – uses same configurable inputs for success instructions

--- a/charts/orkestra/templates/runtime-deployment.yaml
+++ b/charts/orkestra/templates/runtime-deployment.yaml
@@ -71,15 +71,11 @@ spec:
               value: {{ .Values.runtime.config.degradeThreshold | quote }}
             - name: ORK_REGISTRY
               value: {{ .Values.registry.url | quote }}
-            {{- if .Values.runtime.config.watchNamespace }}
-            - name: NAMESPACE
-              value: {{ .Values.runtime.config.watchNamespace | quote }}
-            {{- end }}
+            - name: ORK_NAMESPACE
+              value: {{ .Release.Namespace }}
             {{- if .Values.runtime.leaderElection.enabled }}
             - name: LEADER_ELECTION
               value: "true"
-            - name: LEADER_ELECTION_NAMESPACE
-              value: {{ include "orkestra.leaderElectionNamespace" . | quote }}
             - name: LEASE_DURATION
               value: {{ .Values.runtime.leaderElection.leaseDuration | quote }}
             - name: RENEW_DEADLINE
@@ -115,7 +111,7 @@ spec:
           {{- end }}
 
           ports:
-            - name: health
+            - name: http
               containerPort: {{ .Values.runtime.server.port }}
               protocol: TCP
           

--- a/charts/orkestra/templates/runtime-service.yaml
+++ b/charts/orkestra/templates/runtime-service.yaml
@@ -18,9 +18,9 @@ spec:
     {{- include "orkestra.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: runtime
   ports:
-    - name: health
+    - name: http
       port: {{ .Values.runtime.service.port }}
-      targetPort: health
+      targetPort: http
       protocol: TCP
 
 {{- end }}

--- a/charts/orkestra/values.yaml
+++ b/charts/orkestra/values.yaml
@@ -37,7 +37,6 @@ runtime:
     maxQueueDepth: 500
     degradeThreshold: 10
     environment: development
-    watchNamespace: ""
 
   # Probes for runtime
   startupProbe:
@@ -79,9 +78,9 @@ runtime:
   # Leader election (runtime only)
   leaderElection:
     enabled: true
-    leaseDuration: 15s
-    renewDeadline: 10s
-    retryPeriod: 5s
+    leaseDuration: 15
+    renewDeadline: 10
+    retryPeriod: 5
 
   # Webhooks for admission control and CRD conversion (runtime only)
   webhooks:
@@ -163,7 +162,7 @@ controlCenter:
     runAsGroup: 1001
     fsGroup: 1001
 
-  # Probes for control center (paths include /controlcenter prefix)
+  # Probes for control center
   livenessProbe:
     initialDelaySeconds: 5
     periodSeconds: 10
@@ -173,6 +172,7 @@ controlCenter:
     periodSeconds: 5
 
 # ── Shared ────────────────────────────────────────────────────────────────────
+namespace: orkestra-system
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/cmd/cli/generate.go
+++ b/cmd/cli/generate.go
@@ -326,7 +326,7 @@ Examples:
 
 		bundle := rbacOut + "\n---\n" + configMapOut
 
-		log.Println("configmap generated successfully")
+		log.Println("bundle generated successfully")
 
 		if outputFile != "" {
 			return os.WriteFile(outputFile, []byte(bundle), 0644)

--- a/new-frontiers/orkspace-fanout/cr.yaml
+++ b/new-frontiers/orkspace-fanout/cr.yaml
@@ -1,0 +1,8 @@
+apiVersion: orkspace.io/v1alpha1
+kind: OrkspaceFanOut
+metadata:
+  name: demo-fanout
+spec:
+  image: nginx:1.25
+  replicas: 3
+  port: 8080

--- a/new-frontiers/orkspace-fanout/crd.yaml
+++ b/new-frontiers/orkspace-fanout/crd.yaml
@@ -1,0 +1,47 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: orkspacefanouts.orkspace.io
+spec:
+  group: orkspace.io
+  scope: Namespaced
+  names:
+    plural: orkspacefanouts
+    singular: orkspacefanout
+    kind: OrkspaceFanOut
+    shortNames: [ofn]
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+        scale:
+          specReplicasPath: .spec.replicas
+          statusReplicasPath: .status.replicas
+          labelSelectorPath: .status.selector
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required: [image, replicas]
+              properties:
+                image:
+                  type: string
+                replicas:
+                  type: integer
+                  minimum: 0
+                  description: Desired replica count (HPA writes here)
+                port:
+                  type: integer
+                  default: 8080
+            status:
+              type: object
+              properties:
+                replicas:
+                  type: integer
+                selector:
+                  type: string
+              x-kubernetes-preserve-unknown-fields: true

--- a/new-frontiers/orkspace-fanout/katalog.yaml
+++ b/new-frontiers/orkspace-fanout/katalog.yaml
@@ -1,0 +1,71 @@
+apiVersion: orkestra.konductor.io/v1Alpha
+kind: Katalog
+metadata:
+  name: orkspace-fanout
+  author: orkspace
+  version: 0.1.0
+  description: >
+    A scalable Orkestra-native workload. Demonstrates how a CRD exposing the
+    Kubernetes /scale subresource can be autoscaled directly by HPA, with
+    Orkestra reconciling the underlying ReplicaSet.
+
+spec:
+  crds:
+    orkspace-fanout:
+      apiTypes:
+        group: orkspace.io
+        version: v1alpha1
+        kind: OrkspaceFanOut
+        plural: orkspacefanouts
+
+      workers: 2
+      resync: 30s
+
+      operatorBox:
+        onCreate:
+          deployments:
+            - name: "{{ .metadata.name }}"
+              image: "{{ .spec.image }}"
+              replicas: "{{ .spec.replicas }}"
+          replicaSets:
+            - name: "{{ .metadata.name }}"
+              image: "{{ .spec.image }}"
+              replicas: "{{ .spec.replicas }}"
+              labels:
+                - key: app
+                  value: "{{ .metadata.name }}"
+              reconcile: true
+          pdb:
+            - name: "{{ .metadata.name }}-pdb"
+              minAvailable: 2
+              selector:
+                app: "{{ .metadata.name }}"
+          hpa:
+            - name: "{{ .metadata.name }}-hpa"
+              minReplicas: 1
+              maxReplicas: 10
+              targetCPUUtilizationPercentage: 50
+              scaleTargetRef:
+                apiVersion: apps/v1
+                kind: ReplicaSet
+                name: "{{ .metadata.name }}"
+              reconcile: true
+
+        status:
+          fields:
+            - path: phase
+              value: "FanOutComplete"
+              when:
+                - field: children.deployment.status.readyReplicas
+                  operator: exists
+              # when:
+              #   - field: "{{ .children.replicaset.status.readyReplicas }}"
+              #     equals: "{{ .spec.replicas }}"
+
+            - path: observedReplicas
+              value: "{{ .spec.replicas }}"
+            - path: replicas
+              type: int
+              value: "{{ .spec.replicas }}"
+            - path: selector
+              value: "{{ .metadata.name }}"

--- a/pkg/katalog/builtins.go
+++ b/pkg/katalog/builtins.go
@@ -86,6 +86,7 @@ var builtInRegistry = map[string]BuiltInKind{
 		// Orkestra
 		SkipObservedGeneration: true, // v1/Namespace
 		OrkestraInternal:       true,
+		IsChild:                true,
 	},
 	"serviceaccount": {
 		Group:      "",

--- a/pkg/katalog/parser.go
+++ b/pkg/katalog/parser.go
@@ -157,7 +157,19 @@ func (k *Katalog) ValidateConfig(kfg *konfig.Konfig) (*Katalog, error) {
 		return nil, err
 	}
 
+	// -------------------------------------------------------------------------
 	// 14. Validate Notify Teams
+	// -------------------------------------------------------------------------
+	// if err := k.validateNotifyTeams(); err != nil {
+	// 	return nil, err
+	// }
+
+	// -------------------------------------------------------------------------
+	// 15 Validate Status Types
+	// -------------------------------------------------------------------------
+	if err := k.validateStatusTypes(); err != nil {
+		return nil, err
+	}
 
 	return k, nil
 }

--- a/pkg/katalog/validate.go
+++ b/pkg/katalog/validate.go
@@ -620,6 +620,52 @@ func validateOneHPARef(crdName, hpaName string, ref orktypes.ScaleTargetRef) err
 	return nil
 }
 
+// validateStatusTypes ensures that all declarative status fields declare a valid
+// type. StatusFieldSpec.Type controls how the resolved template value is cast
+// before being written into the CR's /status subresource.
+//
+// Supported type names (case‑insensitive):
+//   - "string", "str", ""      → string (default)
+//   - "bool", "boolean"        → boolean
+//   - "int", "integer"         → integer
+//
+// Any other value is rejected at katalog‑load time. This prevents silent
+// mis‑casts in the status resolver and ensures that typed CRD fields (such as
+// those required by the Kubernetes /scale subresource) receive correctly‑typed
+// values.
+//
+// This validator mirrors the style of validateHPAReference, validateTimeDuration,
+// and other fail‑fast katalog validators: the first invalid type aborts loading
+// with a clear, actionable error message.
+func (k *Katalog) validateStatusTypes() error {
+	for name, crd := range k.enabledCRDs {
+		// Skip CRDs without declarative status
+		if crd.OperatorBox.Status == nil {
+			continue
+		}
+
+		if crd.OperatorBox.Status.HasFields() {
+			for _, f := range crd.OperatorBox.Status.Fields {
+				switch strings.ToLower(f.Type) {
+				case "", "string", "str", "default":
+				case "int", "integer":
+				case "bool", "boolean":
+				case "float", "auto":
+					// valid
+				default:
+					return fmt.Errorf(
+						"invalid status field type %q in CRD %q (path: %q):\n"+
+							"  must be one of: string, str, int, integer, bool, boolean, float, auto\n",
+						f.Type, name, f.Path,
+					)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
 // validateNotifyTeams checks that teams declared under notify actually exist in this katalog context
 // func (k *Katalog) validateNotifyTeams() error {
 // 	for name, crd := range k.enabledCRDs {

--- a/pkg/orkestra-registry/template/resolver_status.go
+++ b/pkg/orkestra-registry/template/resolver_status.go
@@ -3,6 +3,7 @@ package template
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	orktypes "github.com/orkspace/orkestra/pkg/types"
@@ -45,13 +46,22 @@ func (r *Resolver) ResolveStatusFields(fields []orktypes.StatusFieldSpec) (map[s
 			continue
 		}
 
-		resolved, err := r.Resolve(f.Value)
+		// ── Resolve template expression ─────────────────────────────────────
+		raw, err := r.Resolve(f.Value)
 		if err != nil {
 			errs = append(errs, fmt.Sprintf("status.%s: %v", f.Path, err))
 			continue
 		}
 
-		if err := setNestedStatusField(result, f.Path, resolved); err != nil {
+		// ── Apply type casting (default: string) ───────────────────────
+		typedValue, err := castStatusValue(raw, f.Type)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("status.%s: %v", f.Path, err))
+			continue
+		}
+
+		// ── Write into nested map ───────────────────────────────────────────
+		if err := setNestedStatusField(result, f.Path, typedValue); err != nil {
 			errs = append(errs, fmt.Sprintf("status.%s: %v", f.Path, err))
 		}
 	}
@@ -73,7 +83,7 @@ func (r *Resolver) ResolveStatusFields(fields []orktypes.StatusFieldSpec) (map[s
 //
 // If an intermediate path segment already contains a non-map value, it is
 // replaced with a map. This avoids panics from type-assertion failures.
-func setNestedStatusField(dst map[string]interface{}, path string, value string) error {
+func setNestedStatusField(dst map[string]interface{}, path string, value interface{}) error {
 	parts := strings.SplitN(path, ".", 2)
 
 	if len(parts) == 1 {
@@ -99,4 +109,51 @@ func setNestedStatusField(dst map[string]interface{}, path string, value string)
 
 	dst[key] = child
 	return setNestedStatusField(child, rest, value)
+}
+
+func castStatusValue(raw string, typ string) (interface{}, error) {
+	switch strings.ToLower(typ) {
+	case "", "string", "str", "default":
+		return raw, nil
+
+	case "int", "integer":
+		v, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("expected int, got %q: %w", raw, err)
+		}
+		return v, nil
+
+	case "float":
+		v, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			return nil, fmt.Errorf("expected float, got %q: %w", raw, err)
+		}
+		return v, nil
+
+	case "bool", "boolean":
+		v, err := strconv.ParseBool(raw)
+		if err != nil {
+			return nil, fmt.Errorf("expected bool, got %q: %w", raw, err)
+		}
+		return v, nil
+
+	case "auto":
+		// Try int
+		if i, err := strconv.ParseInt(raw, 10, 64); err == nil {
+			return i, nil
+		}
+		// Try float
+		if f, err := strconv.ParseFloat(raw, 64); err == nil {
+			return f, nil
+		}
+		// Try bool
+		if b, err := strconv.ParseBool(raw); err == nil {
+			return b, nil
+		}
+		// Fallback to string
+		return raw, nil
+
+	default:
+		return nil, fmt.Errorf("unknown type %q", typ)
+	}
 }

--- a/pkg/reconciler/children.go
+++ b/pkg/reconciler/children.go
@@ -223,6 +223,8 @@ func mergeTemplates(operatorBox orktypes.OperatorBoxConfig) orktypes.HookTemplat
 	t := orktypes.HookTemplates{}
 	if operatorBox.OnCreate != nil {
 		t.Deployments = append(t.Deployments, operatorBox.OnCreate.Deployments...)
+		t.ReplicaSets = append(t.ReplicaSets, operatorBox.OnCreate.ReplicaSets...)
+		t.StatefulSets = append(t.StatefulSets, operatorBox.OnCreate.StatefulSets...)
 		t.Services = append(t.Services, operatorBox.OnCreate.Services...)
 		t.Secrets = append(t.Secrets, operatorBox.OnCreate.Secrets...)
 		t.ConfigMaps = append(t.ConfigMaps, operatorBox.OnCreate.ConfigMaps...)
@@ -231,9 +233,24 @@ func mergeTemplates(operatorBox orktypes.OperatorBoxConfig) orktypes.HookTemplat
 		t.Pods = append(t.Pods, operatorBox.OnCreate.Pods...)
 		t.ServiceAccounts = append(t.ServiceAccounts, operatorBox.OnCreate.ServiceAccounts...)
 		t.Namespaces = append(t.Namespaces, operatorBox.OnCreate.Namespaces...)
+		t.PersistentVolumes = append(t.PersistentVolumes, operatorBox.OnCreate.PersistentVolumes...)
+		t.PersistentVolumeClaims = append(t.PersistentVolumeClaims, operatorBox.OnCreate.PersistentVolumeClaims...)
+		t.Ingresses = append(t.Ingresses, operatorBox.OnCreate.Ingresses...)
+
+		// Future when added
+		t.StorageClasses = append(t.StorageClasses, operatorBox.OnCreate.StorageClasses...)
+		t.ClusterRoles = append(t.ClusterRoles, operatorBox.OnCreate.ClusterRoles...)
+		t.ClusterRoleBindings = append(t.ClusterRoleBindings, operatorBox.OnCreate.ClusterRoleBindings...)
+		t.Roles = append(t.Roles, operatorBox.OnCreate.Roles...)
+		t.RoleBindings = append(t.RoleBindings, operatorBox.OnCreate.RoleBindings...)
+		t.LimitRanges = append(t.LimitRanges, operatorBox.OnCreate.LimitRanges...)
+		t.ResourceQuotas = append(t.ResourceQuotas, operatorBox.OnCreate.ResourceQuotas...)
+		t.PriorityClasses = append(t.PriorityClasses, operatorBox.OnCreate.PriorityClasses...)
 	}
 	if operatorBox.OnReconcile != nil {
 		t.Deployments = append(t.Deployments, operatorBox.OnReconcile.Deployments...)
+		t.ReplicaSets = append(t.ReplicaSets, operatorBox.OnReconcile.ReplicaSets...)
+		t.StatefulSets = append(t.StatefulSets, operatorBox.OnReconcile.StatefulSets...)
 		t.Services = append(t.Services, operatorBox.OnReconcile.Services...)
 		t.Secrets = append(t.Secrets, operatorBox.OnReconcile.Secrets...)
 		t.ConfigMaps = append(t.ConfigMaps, operatorBox.OnReconcile.ConfigMaps...)
@@ -242,6 +259,19 @@ func mergeTemplates(operatorBox orktypes.OperatorBoxConfig) orktypes.HookTemplat
 		t.Pods = append(t.Pods, operatorBox.OnReconcile.Pods...)
 		t.ServiceAccounts = append(t.ServiceAccounts, operatorBox.OnReconcile.ServiceAccounts...)
 		t.Namespaces = append(t.Namespaces, operatorBox.OnReconcile.Namespaces...)
+		t.PersistentVolumes = append(t.PersistentVolumes, operatorBox.OnCreate.PersistentVolumes...)
+		t.PersistentVolumeClaims = append(t.PersistentVolumeClaims, operatorBox.OnCreate.PersistentVolumeClaims...)
+		t.Ingresses = append(t.Ingresses, operatorBox.OnCreate.Ingresses...)
+
+		// Future when added
+		t.StorageClasses = append(t.StorageClasses, operatorBox.OnCreate.StorageClasses...)
+		t.ClusterRoles = append(t.ClusterRoles, operatorBox.OnCreate.ClusterRoles...)
+		t.ClusterRoleBindings = append(t.ClusterRoleBindings, operatorBox.OnCreate.ClusterRoleBindings...)
+		t.Roles = append(t.Roles, operatorBox.OnCreate.Roles...)
+		t.RoleBindings = append(t.RoleBindings, operatorBox.OnCreate.RoleBindings...)
+		t.LimitRanges = append(t.LimitRanges, operatorBox.OnCreate.LimitRanges...)
+		t.ResourceQuotas = append(t.ResourceQuotas, operatorBox.OnCreate.ResourceQuotas...)
+		t.PriorityClasses = append(t.PriorityClasses, operatorBox.OnCreate.PriorityClasses...)
 	}
 	return t
 }

--- a/pkg/types/status.go
+++ b/pkg/types/status.go
@@ -44,8 +44,25 @@ package types
 //
 // Value supports Go text/template expressions evaluated against the CR:
 //   - "{{ .spec.replicas }}"    — from the CR's spec
-//   - "{{ .metadata.name }}"   — CR name
+//   - "{{ .metadata.name }}"    — CR name
 //   - "Running"                 — static string (fast path, no template parsing)
+//
+// Type controls how the resolved value is written into the status patch.
+// By default, all values are written as strings. When Type is set,
+// the resolver will cast the resolved value into the requested type:
+//
+//	type: int       → writes an integer (e.g., 3)
+//	type: float     → writes a float64 (e.g., 3.14)
+//	type: bool      → writes a boolean (e.g., true)
+//	type: string    → writes a string (default behavior)
+//	type: auto      → attempts to infer the type from the resolved value
+//
+// Example:
+//   - path: replicas
+//     type: int
+//     value: "{{ toInt .spec.replicas }}"
+//
+// This ensures status.replicas is written as an integer, not a string.
 type StatusFieldSpec struct {
 	// Path — dot-notation path relative to status.
 	// "phase"            → status.phase
@@ -58,6 +75,17 @@ type StatusFieldSpec struct {
 	// Empty string is written as-is — declare a static empty string to clear a field.
 	Value string `yaml:"value" json:"value"`
 
+	// Type — optional explicit type for the resolved value.
+	// If omitted, the value is written as a string.
+	//
+	// Supported values:
+	//   "string", "str, "" (default)
+	//   "int", "integer"
+	//   "float"
+	//   "bool", "boolean"
+	//   "auto" — infer type from the resolved value
+	Type string `yaml:"type,omitempty" json:"type,omitempty"`
+
 	// When is an optional list of conditions that must all pass before
 	// this field is written. If absent or empty, the field is always written.
 	//
@@ -69,6 +97,8 @@ type StatusFieldSpec struct {
 	// .spec.image, .children.job.status.succeeded are all accessible.
 	When []Condition `yaml:"when,omitempty"`
 
+	// AnyOf — optional OR-conditions. If any condition passes, the field is written.
+	// Useful for multi-branch declarative state machines.
 	AnyOf []Condition `yaml:"anyOf,omitempty"`
 }
 
@@ -84,28 +114,32 @@ type StatusFieldSpec struct {
 //
 // Example — a three-phase state machine declared entirely in YAML:
 //
-//	status:
-//	  fields:
-//	    - path: phase
-//	      value: "Pending"
-//	      when:
-//	        - field: status.phase
-//	          operator: notExists
+//  status:
+//    fields:
+//      - path: phase
+//        value: "Pending"
+//        when:
+//          - field: status.phase
+//            operator: notExists
 //
-//	    - path: phase
-//	      value: "Running"
-//	      when:
-//	        - field: status.phase
-//	          equals: "Pending"
+//      - path: phase
+//        value: "Running"
+//        when:
+//          - field: status.phase
+//            equals: "Pending"
 //
-//	    - path: phase
-//	      value: "Succeeded"
-//	      when:
-//	        - field: status.phase
-//	          equals: "Running"
-//	        - field: children.job.status.succeeded
-//	          operator: gt
-//	          value: "0"
+//      - path: phase
+//        value: "Succeeded"
+//        when:
+//          - field: status.phase
+//            equals: "Running"
+//          - field: children.job.status.succeeded
+//            operator: gt
+//            value: "0"
+//
+// With the new Type field, these state transitions can now write strongly-typed
+// values into status, enabling CRDs that expose the Kubernetes /scale subresource
+// or other typed fields to be updated correctly.
 
 // StatusConfig declares the declarative status behavior for a CRD.
 // Declared under spec.crds[].reconciler.status in the Katalog.


### PR DESCRIPTION
### Summary
This PR refactors the entire CI/CD pipeline to be **reusable**, **configurable**, and **portable** across forks. It also fixes the container image tag format to follow standard semver (no `v` prefix) while keeping Git tags with `v`. The Helm chart has been cleaned up and now references the correct image tag.

### What Changed

#### Helm Chart
- Removed unnecessary configurations after testing
- `appVersion` and image tags now use stripped version (e.g., `0.2.2` instead of `v0.2.2`)
- Chart metadata and values updated to match new tag handling

#### CI/CD Workflows (Made Reusable)
- **Added `prepare` job** in the main release workflow to strip `v` from Git tag once and pass `image_tag` to all downstream jobs
- **All reusable workflows now accept inputs**:
  - `image_tag` (required, stripped version)
  - `repository`, `ork_image`, `orkcc_image`
  - `helm_repo_url`, `helm_chart`, `brew_tap`, `github_repo`, etc.
- **Removed hardcoded project names** (`orkspace`, `ialexeze`, `orkestra`) → workflows are now portable
- **Standardized tag handling**:
  - Git tags: `v1.2.3` (kept as is)
  - Container images: `1.2.3` (stripped)
  - Helm chart version: `1.2.3` (stripped)

#### Final Release Workflow (`Orkestra Release`)
- Orchestrates all jobs with proper dependencies and conditionals
- Uses `prepare` to compute metadata once
- All reusable workflows called with explicit inputs (defaults applied in the called workflows)
- Added `release-summary` job that aggregates status and shows install instructions

#### Individual Workflow Updates
- `build-push-images.yml` – configurable image names & registry
- `package-examples.yml` – configurable repo and project name
- `release-helm.yml` – configurable chart name, repo URL, namespace
- `sign-and-release.yml` – fully configurable (GitHub repo, container registry, Helm repo, Homebrew tap)
- `publish-homebrew.yml` – accepts tap repository and main repo
- `release-summary.yml` – uses same configurable inputs for success instructions
- `build-matrix.yml` – unchanged (no external config needed)

### Breaking Changes
- **Reusable workflows now require `image_tag` input** (stripped version). Callers must pass `image_tag` explicitly (e.g., `1.2.3` instead of `v1.2.3`).
- The main release workflow must have a `prepare` job to compute `image_tag` before calling any other workflows.

### How to Test
1. Create a Git tag `vX.Y.Z` and push it.
2. The workflow will run all jobs:
   - Build binaries for Linux, macOS, Windows
   - Package examples
   - Build and push container images (with stripped tag)
   - Release Helm chart (stripped version, references stripped image tag)
   - Sign binaries and create GitHub release
   - Update Homebrew formulas (if tap repo configured)
3. Check that:
   - Container images are tagged `X.Y.Z` (no `v`)
   - Helm chart `appVersion` and image tags use `X.Y.Z`
   - Release notes show correct `docker pull` commands without `v`
   - Homebrew formulas use correct URLs (Git tag with `v`, but version field stripped)

### Checklist
- [ ] All workflows pass on a test tag
- [ ] Container images pushed with correct tag format
- [ ] Helm chart installs correctly using the new image tags
- [ ] Release notes show proper installation commands
- [ ] No hardcoded repository names remain in reusable workflows