### PR TITLE
feat(examples): add polyglot Katalog generation (Python, Go, Node.js)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@ reviews/
 orkestra-certs/
 coverage.out/
 coverage
+node_modules/
 
 # Generated
 zz_generated_rbac.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ rbac.yaml
 bundle.yaml
 configmap.yaml
 DEPLOY.md
+node_modules/
 # Added by ork doctor init
 .orkestra/bundle/
 .orkestra/

--- a/examples/advanced/14-any-language/README.md
+++ b/examples/advanced/14-any-language/README.md
@@ -1,0 +1,118 @@
+# Any Language – Generate an Orkestra Katalog from Python, Go, or Node.js
+
+Orkestra only cares about the final Katalog YAML. You can generate it using any programming language.
+
+This directory contains three language examples that produce identical `katalog.yaml` files, which can then be used to deploy a simple web application (Deployment + Service + optional Ingress) on Kubernetes.
+
+## Prerequisites
+
+- Orkestra CLI installed (`ork`)
+- `kubectl` configured for a cluster (or use `ork deploy --dev` to create a Kind cluster)
+- For each language:
+  - **Python**: `python3` and `pyyaml` (`pip install pyyaml`)
+  - **Go**: `go` and `gopkg.in/yaml.v3` (fetched automatically)
+  - **Node.js**: `node` and `npm`; install `js-yaml` locally (`npm install`)
+
+## Shared files
+
+- `crd.yaml` – CustomResourceDefinition for a `WebApp`
+- `cr.yaml` – Example custom resource (`my-webapp`)
+
+These are the same for all three examples.
+
+## Step 1 – Apply the CRD
+
+```bash
+kubectl apply -f crd.yaml
+```
+
+(You only need to do this once; the CRD is shared.)
+
+## Step 2 – Generate Katalogs using different languages (each to a separate file)
+
+### Python
+
+```bash
+python generate_katalog.py --name my-webapp --image nginx:1.25 --port 8080 --replicas 3 --ingress myapp.example.com > python-katalog.yaml
+```
+
+### Go
+
+```bash
+go run generate_katalog.go -name my-webapp -image nginx:1.25 -port 8080 -replicas 3 -ingress myapp.example.com > go-katalog.yaml
+```
+
+### Node.js
+
+```bash
+npm install   # installs js-yaml
+node generate_katalog.js --name my-webapp --image nginx:1.25 --port 8080 --replicas 3 --ingress myapp.example.com > node-katalog.yaml
+```
+
+## Step 3 – Validate each generated Katalog
+
+```bash
+ork validate -f python-katalog.yaml
+ork validate -f go-katalog.yaml
+ork validate -f node-katalog.yaml
+```
+
+## Step 4 – Run the operator with the first Katalog (e.g., Python)
+
+```bash
+ork run -f python-katalog.yaml
+```
+
+(Keep this terminal open.)
+
+## Step 5 – Apply the custom resource (in another terminal)
+
+```bash
+kubectl apply -f cr.yaml
+```
+
+Watch the operator logs – you should see it creating a Deployment, Service, and optionally an Ingress.
+
+## Step 6 – Verify resources
+
+```bash
+kubectl get deployments,services,ingresses
+```
+
+- Deployment name: `my-webapp-deploy`
+- Service name: `my-webapp-svc`
+- Ingress name: `my-webapp-ingress` (if you used `--ingress`)
+
+## Step 7 – Stop the Python operator (Ctrl+C) and run the Go operator
+
+```bash
+# In the first terminal, stop the Python operator with Ctrl+C
+ork run -f go-katalog.yaml
+```
+
+The operator will continue managing the existing `my-webapp` custom resource – no need to reapply the CR.
+
+## Step 8 – Try Node.js the same way
+
+Stop the Go operator and start the Node.js one:
+
+```bash
+ork run -f node-katalog.yaml
+```
+
+All three produce the same behaviour because they all create the same Katalog structure.
+
+## Cleanup
+
+```bash
+kubectl delete -f cr.yaml
+kubectl delete -f crd.yaml
+# Stop the operator with Ctrl+C
+```
+
+## Why this matters
+
+- **No lock‑in** – Write your operator specification in any language you prefer.
+- **Perfect for CI/CD** – Generate the Katalog dynamically based on environment variables or external APIs.
+- **Learn by analogy** – Use the script that matches your team’s primary language.
+- **Seamless switching** – Orkestra doesn't care which language generated the Katalog; the operator works identically.

--- a/examples/advanced/14-any-language/cr.yaml
+++ b/examples/advanced/14-any-language/cr.yaml
@@ -1,0 +1,9 @@
+apiVersion: web.orkestra.io/v1alpha1
+kind: WebApp
+metadata:
+  name: my-webapp
+  namespace: default
+spec:
+  image: nginx:1.25
+  replicas: 3
+  port: 8080

--- a/examples/advanced/14-any-language/crd.yaml
+++ b/examples/advanced/14-any-language/crd.yaml
@@ -1,0 +1,54 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: webapps.web.orkestra.io
+spec:
+  group: web.orkestra.io
+  names:
+    kind: WebApp
+    plural: webapps
+    singular: webapp
+    shortNames:
+      - wa
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+          properties:
+            spec:
+              type: object
+              required:
+                - image
+              properties:
+                image:
+                  type: string
+                  description: Container image (e.g. nginx:1.25)
+                replicas:
+                  type: integer
+                  minimum: 1
+                  maximum: 20
+                  default: 2
+                  description: Number of replicas
+                port:
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                  default: 80
+                  description: Container port
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  enum: ["Pending", "Running", "Failed"]
+                readyReplicas:
+                  type: integer
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}

--- a/examples/advanced/14-any-language/generate_katalog.go
+++ b/examples/advanced/14-any-language/generate_katalog.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+    "flag"
+    "fmt"
+    "os"
+
+    "gopkg.in/yaml.v3"
+)
+
+type Katalog struct {
+    APIVersion string `yaml:"apiVersion"`
+    Kind       string `yaml:"kind"`
+    Metadata   struct {
+        Name        string `yaml:"name"`
+        Description string `yaml:"description"`
+    } `yaml:"metadata"`
+    Spec struct {
+        CRDs map[string]CRDEntry `yaml:"crds"`
+    } `yaml:"spec"`
+}
+
+type CRDEntry struct {
+    APITypes struct {
+        Group   string `yaml:"group"`
+        Version string `yaml:"version"`
+        Kind    string `yaml:"kind"`
+        Plural  string `yaml:"plural"`
+    } `yaml:"apiTypes"`
+    Workers int    `yaml:"workers"`
+    Resync  string `yaml:"resync"`
+    OperatorBox struct {
+        Default    bool `yaml:"default"`
+        OnCreate   struct {
+            Deployments []Deployment `yaml:"deployments"`
+            Services    []Service    `yaml:"services"`
+            Ingresses   []Ingress    `yaml:"ingresses,omitempty"`
+        } `yaml:"onCreate"`
+    } `yaml:"operatorBox"`
+}
+
+type Deployment struct {
+    Name      string `yaml:"name"`
+    Image     string `yaml:"image"`
+    Replicas  string `yaml:"replicas"`
+    Port      int    `yaml:"port"`
+    Reconcile bool   `yaml:"reconcile"`
+}
+
+type Service struct {
+    Name       string `yaml:"name"`
+    Port       int    `yaml:"port"`
+    TargetPort int    `yaml:"targetPort"`
+    Reconcile  bool   `yaml:"reconcile"`
+}
+
+type Ingress struct {
+    Name          string `yaml:"name"`
+    Host          string `yaml:"host"`
+    ServiceName   string `yaml:"serviceName"`
+    ServicePort   int    `yaml:"servicePort"`
+    IngressClass  string `yaml:"ingressClass"`
+    Reconcile     bool   `yaml:"reconcile"`
+}
+
+func generateKatalog(appName, image string, port, replicas int, ingressHost string) *Katalog {
+    k := &Katalog{}
+    k.APIVersion = "orkestra.orkspace.io/v1"
+    k.Kind = "Katalog"
+    k.Metadata.Name = appName + "-operator"
+    k.Metadata.Description = fmt.Sprintf("Generated Katalog for %s", appName)
+
+    crd := CRDEntry{
+        Workers: 2,
+        Resync:  "30s",
+    }
+    crd.APITypes.Group = "web.orkestra.io"
+    crd.APITypes.Version = "v1alpha1"
+    crd.APITypes.Kind = "WebApp"
+    crd.APITypes.Plural = "webapps"
+    crd.OperatorBox.Default = true
+
+    // Deployment
+    crd.OperatorBox.OnCreate.Deployments = []Deployment{
+        {
+            Name:      "{{ .metadata.name }}-deploy",
+            Image:     image,
+            Replicas:  fmt.Sprintf("%d", replicas),
+            Port:      port,
+            Reconcile: true,
+        },
+    }
+
+    // Service
+    crd.OperatorBox.OnCreate.Services = []Service{
+        {
+            Name:       "{{ .metadata.name }}-svc",
+            Port:       port,
+            TargetPort: port,
+            Reconcile:  true,
+        },
+    }
+
+    // Ingress (optional)
+    if ingressHost != "" {
+        crd.OperatorBox.OnCreate.Ingresses = []Ingress{
+            {
+                Name:         "{{ .metadata.name }}-ingress",
+                Host:         ingressHost,
+                ServiceName:  "{{ .metadata.name }}-svc",
+                ServicePort:  port,
+                IngressClass: "nginx",
+                Reconcile:    true,
+            },
+        }
+    }
+
+    k.Spec.CRDs = map[string]CRDEntry{appName: crd}
+    return k
+}
+
+func main() {
+    appName := flag.String("name", "myapp", "Application name")
+    image := flag.String("image", "nginx:1.25", "Container image")
+    port := flag.Int("port", 8080, "Container port")
+    replicas := flag.Int("replicas", 2, "Number of replicas")
+    ingressHost := flag.String("ingress", "", "Ingress host (optional)")
+    flag.Parse()
+
+    k := generateKatalog(*appName, *image, *port, *replicas, *ingressHost)
+
+    enc := yaml.NewEncoder(os.Stdout)
+    enc.SetIndent(2)
+    if err := enc.Encode(k); err != nil {
+        fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+        os.Exit(1)
+    }
+}

--- a/examples/advanced/14-any-language/generate_katalog.js
+++ b/examples/advanced/14-any-language/generate_katalog.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const yaml = require('js-yaml');
+
+function generateKatalog(appName, image, port, replicas, ingressHost) {
+  const katalog = {
+    apiVersion: 'orkestra.orkspace.io/v1',
+    kind: 'Katalog',
+    metadata: {
+      name: `${appName}-operator`,
+      description: `Generated Katalog for ${appName}`,
+    },
+    spec: {
+      crds: {
+        [appName]: {
+          apiTypes: {
+            group: 'web.orkestra.io',
+            version: 'v1alpha1',
+            kind: 'WebApp',
+            plural: 'webapps',
+          },
+          workers: 2,
+          resync: '30s',
+          operatorBox: {
+            default: true,
+            onCreate: {
+              deployments: [
+                {
+                  name: '{{ .metadata.name }}-deploy',
+                  image: image,
+                  replicas: String(replicas),
+                  port: port,
+                  reconcile: true,
+                },
+              ],
+              services: [
+                {
+                  name: '{{ .metadata.name }}-svc',
+                  port: port,
+                  targetPort: port,
+                  reconcile: true,
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  };
+
+  if (ingressHost) {
+    katalog.spec.crds[appName].operatorBox.onCreate.ingresses = [
+      {
+        name: '{{ .metadata.name }}-ingress',
+        host: ingressHost,
+        serviceName: '{{ .metadata.name }}-svc',
+        servicePort: port,
+        ingressClass: 'nginx',
+        reconcile: true,
+      },
+    ];
+  }
+
+  return katalog;
+}
+
+// Command line argument parsing
+const args = process.argv.slice(2);
+const options = {
+  name: 'myapp',
+  image: 'nginx:1.25',
+  port: 8080,
+  replicas: 2,
+  ingress: '',
+};
+
+for (let i = 0; i < args.length; i++) {
+  switch (args[i]) {
+    case '--name': options.name = args[++i]; break;
+    case '--image': options.image = args[++i]; break;
+    case '--port': options.port = parseInt(args[++i], 10); break;
+    case '--replicas': options.replicas = parseInt(args[++i], 10); break;
+    case '--ingress': options.ingress = args[++i]; break;
+    default: console.error(`Unknown option: ${args[i]}`); process.exit(1);
+  }
+}
+
+const k = generateKatalog(options.name, options.image, options.port, options.replicas, options.ingress);
+console.log(yaml.dump(k, { indent: 2 }));

--- a/examples/advanced/14-any-language/generate_katalog.py
+++ b/examples/advanced/14-any-language/generate_katalog.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+import yaml
+import sys
+
+def generate_katalog(app_name, image, port, replicas=2, ingress_host=""):
+    """
+    Generates an Orkestra Katalog YAML for a basic web app.
+    """
+    katalog = {
+        "apiVersion": "orkestra.orkspace.io/v1",
+        "kind": "Katalog",
+        "metadata": {
+            "name": f"{app_name}-operator",
+            "description": f"Generated Katalog for {app_name}"
+        },
+        "spec": {
+            "crds": {
+                f"{app_name}": {
+                    "apiTypes": {
+                        "group": "web.orkestra.io",
+                        "version": "v1alpha1",
+                        "kind": "WebApp",
+                        "plural": "webapps"
+                    },
+                    "workers": 2,
+                    "resync": "30s",
+                    "operatorBox": {
+                        "default": True,
+                        "onCreate": {
+                            "deployments": [
+                                {
+                                    "name": "{{ .metadata.name }}-deploy",
+                                    "image": image,
+                                    "replicas": str(replicas),
+                                    "port": port,
+                                    "reconcile": True
+                                }
+                            ],
+                            "services": [
+                                {
+                                    "name": "{{ .metadata.name }}-svc",
+                                    "port": port,
+                                    "targetPort": port,
+                                    "reconcile": True
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    # Conditionally add Ingress if host provided
+    if ingress_host:
+        ingress = {
+            "ingresses": [
+                {
+                    "name": "{{ .metadata.name }}-ingress",
+                    "host": ingress_host,
+                    "serviceName": "{{ .metadata.name }}-svc",
+                    "servicePort": port,
+                    "ingressClass": "nginx",
+                    "reconcile": True
+                }
+            ]
+        }
+        # Add ingress block under operatorBox.onCreate
+        katalog["spec"]["crds"][app_name]["operatorBox"]["onCreate"].update(ingress)
+
+    return katalog
+
+if __name__ == "__main__":
+    # Example usage – could read from environment or CLI args
+    app = "myapp"
+    img = "nginx:1.25"
+    p = 8080
+    replicas = 3
+    host = "myapp.example.com"   # set to empty string to skip Ingress
+
+    k = generate_katalog(app, img, p, replicas, host)
+    yaml.dump(k, sys.stdout, default_flow_style=False)
+

--- a/examples/advanced/14-any-language/package-lock.json
+++ b/examples/advanced/14-any-language/package-lock.json
@@ -1,0 +1,34 @@
+{
+  "name": "unknown",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "unknown",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "js-yaml": "^4.1.1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    }
+  }
+}

--- a/examples/advanced/14-any-language/package.json
+++ b/examples/advanced/14-any-language/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "unknown",
+  "version": "1.0.0",
+  "description": "",
+  "main": "generate_katalog.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "js-yaml": "^4.1.1"
+  }
+}


### PR DESCRIPTION
## Pull Request: Add polyglot Katalog generation example (Python, Go, Node.js)

### Summary

This PR adds a new example in `examples/advanced/13-any-language/` that demonstrates generating Orkestra Katalogs from three different programming languages: **Python**, **Go**, and **Node.js**. The generated Katalogs are identical and can be used to deploy a simple web application (Deployment + Service + optional Ingress) on Kubernetes.

The example includes:

- `crd.yaml` – CustomResourceDefinition for a `WebApp`
- `cr.yaml` – Example custom resource (`my-webapp`)
- Three generators:
  - `generate_katalog.py` (Python, requires `pyyaml`)
  - `generate_katalog.go` (Go, uses `gopkg.in/yaml.v3`)
  - `generate_katalog.js` (Node.js, uses `js-yaml`)
- `package.json` and `package-lock.json` for Node.js dependencies
- `README.md` with step‑by‑step instructions

### Why this example matters

- **Proves that any language can emit a Katalog** – Orkestra only cares about the final YAML, not how it was produced.
- **Eliminates lock‑in** – Teams can use their primary language to generate operators.
- **Perfect for CI/CD** – Katalogs can be generated dynamically based on environment variables or external APIs.
- **Seamless switching** – The example shows that stopping the operator and restarting with a Katalog generated by a different language continues to manage the same custom resources.

### How to test

```bash
cd examples/advanced/13-any-language/

# 1. Apply the CRD
kubectl apply -f crd.yaml

# 2. Generate Katalogs (each to a separate file)
python generate_katalog.py --name my-webapp --image nginx:1.25 --port 8080 --replicas 3 --ingress myapp.example.com > python-katalog.yaml
go run generate_katalog.go -name my-webapp -image nginx:1.25 -port 8080 -replicas 3 -ingress myapp.example.com > go-katalog.yaml
npm install && node generate_katalog.js --name my-webapp --image nginx:1.25 --port 8080 --replicas 3 --ingress myapp.example.com > node-katalog.yaml

# 3. Validate all three
ork validate -f python-katalog.yaml
ork validate -f go-katalog.yaml
ork validate -f node-katalog.yaml

# 4. Run the Python operator, apply the CR, see resources created
ork run -f python-katalog.yaml
# (in another terminal) kubectl apply -f cr.yaml

# 5. Stop Python operator, run Go operator – resources are unchanged
ork run -f go-katalog.yaml

# 6. Repeat with Node.js operator
ork run -f node-katalog.yaml
```
