### PR TITLE
CRD‑Driven Operators + Seamless Dev‑Mode Bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,7 @@ metadata:
 spec:
   crds:
     website:
-      apiTypes:
-        group: demo.orkestra.io
-        version: v1alpha1
-        kind: Website
-        plural: websites
+      crdFile: website-crd.yaml
       operatorBox:               # isolated environment for this operator in the runtime
         onCreate:
           deployments:
@@ -58,10 +54,12 @@ spec:
               reconcile: true
 ```
 
+That's the whole operator.
+
 ```bash
 # Run
 ork run -f katalog.yaml
-kubectl apply -f website.yaml
+kubectl apply -f website-cr.yaml
 ```
 
 Orkestra creates the Deployment and Service, sets owner references, writes status, emits events, corrects drift, exposes metrics and a control center — without a single line of Go.
@@ -522,33 +520,119 @@ operatorBox:
 
 ## Composition
 
-Pull Katalogs from files, Helm, Git, or OCI registries:
+Composition works in three layers: **Motifs → Katalogs → Komposer**.
+
+---
+
+### Layer 1 — Motif: reusable infrastructure template
+
+A Motif is a parameterized package of child resource declarations. Write it once, import it from any Katalog.
 
 ```yaml
+# db-motif.yaml
+apiVersion: orkestra.orkspace.io/v1
+kind: Motif
+metadata:
+  name: managed-database
+  version: 0.1.0
+
+inputs:
+  - name: engine
+    default: postgres
+  - namespace: namespace
+    required: true
+  - name: storage
+    default: "10Gi"
+
+resources:
+  custom:
+    - apiVersion: storage.example.io/v1alpha1
+      kind: DatabaseCluster
+      metadata:
+        name: "{{ .metadata.name }}-db"
+        namespace: "{{ .inputs.namespace }}"
+      spec:
+        engine: "{{ .inputs.engine }}"
+        storage: "{{ .inputs.storage }}"
+
+  configMaps:
+    - name: "{{ .metadata.name }}-config"
+        namespace: "{{ .inputs.namespace }}"
+      data:
+        ENGINE: "{{ .inputs.engine }}"
+        STORAGE: "{{ .inputs.storage }}"
+```
+
+---
+
+### Layer 2 — Katalog: import the Motif
+
+A Katalog declares a CRD and imports Motifs for its child resource patterns. The motif's
+`custom:` block is expanded into the Katalog's `onReconcile` at parse time — no duplication,
+no copy-paste.
+
+```yaml
+# app-katalog.yaml
+apiVersion: orkestra.orkspace.io/v1
+kind: Katalog
+metadata:
+  name: app-operator
+
+spec:
+  crds:
+    app:
+      crdFile: ./crd-app.yaml
+      imports:
+        - motif: ./db-motif.yaml
+          with:
+            engine: postgres
+            storage: "20Gi"
+            namespace: "{{ .metadata.namespace }}"
+      operatorBox:
+        onCreate:
+          deployments:
+            - image: "{{ .spec.image }}"
+              replicas: "{{ .spec.replicas }}"
+              reconcile: true
+```
+
+---
+
+### Layer 3 — Komposer: compose Katalogs into one runtime
+
+A Komposer pulls Katalogs from files, Helm, or OCI registries and runs them in a single
+Orkestra instance. Override any field without touching the source Katalog.
+
+```yaml
+# komposer.yaml
 apiVersion: orkestra.orkspace.io/v1
 kind: Komposer
 metadata:
   name: platform
-sources:
+
+imports:
+  files:
+    - ./app-katalog.yaml
+    - ./pipeline-katalog.yaml
   registry:
     - url: ghcr.io/orkspace/orkestra-registry/postgres@v14
       oci: true
-  files:
-    - ./katalogs/website.yaml
-    - ./katalogs/pipeline.yaml
   helm:
     - repo: ghcr.io/orkspace/registry/platform
       chart: platform-example
       version: 0.1.0
-      valueFiles:
-        - values/overrides.yaml
+
 spec:
   crds:
-    postgres:
-      workers: 8
+    app:
+      workers: 8        # override — all other fields inherited from app-katalog.yaml
 ```
 
-One command starts the entire platform.
+One command runs the full platform:
+
+```bash
+ork run -f komposer.yaml
+```
 
 ---
 

--- a/cmd/cli/run_dev.go
+++ b/cmd/cli/run_dev.go
@@ -3,9 +3,16 @@
 package cli
 
 import (
+	"context"
 	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"github.com/orkspace/orkestra/pkg/doctor"
+	"github.com/orkspace/orkestra/pkg/logger"
+	"github.com/orkspace/orkestra/pkg/merger"
+	"github.com/orkspace/orkestra/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -43,6 +50,54 @@ func init() {
 			return fmt.Errorf("cluster not reachable\n")
 		}
 
+		// Apply declared crdFile paths before handing off to the runtime.
+		// In-cluster check is inside — this is a no-op in production.
+		paths, _ := cmd.Flags().GetStringSlice("file")
+		if len(paths) > 0 {
+			m := merger.New(paths...)
+			if err := m.Merge(); err == nil {
+				applyCRDFilesIfNeeded(cmd.Context(), paths[0], m)
+			}
+		}
+
 		return originalRunE(cmd, args)
+	}
+}
+
+// applyCRDFilesIfNeeded applies any crdFile declarations via kubectl before the
+// operator starts. Only runs outside the cluster (dev mode). In production,
+// CRDs must be pre-applied by the platform operator.
+func applyCRDFilesIfNeeded(ctx context.Context, katalogPath string, m *merger.Merger) {
+	if utils.IsRunningInCluster() {
+		return
+	}
+
+	katalogDir := filepath.Dir(katalogPath)
+
+	for crdName, entry := range m.All() {
+		if entry.CRDFile == "" {
+			continue
+		}
+
+		path := entry.CRDFile
+		if !filepath.IsAbs(path) && !strings.HasPrefix(path, "http") {
+			path = filepath.Join(katalogDir, path)
+		}
+
+		out, err := exec.CommandContext(ctx, "kubectl", "apply", "-f", path).CombinedOutput()
+		if err != nil {
+			// Best effort — CRD may already exist at the correct version.
+			logger.Warn().
+				Str("crd", crdName).
+				Str("path", path).
+				Str("output", strings.TrimSpace(string(out))).
+				Err(err).
+				Msg("crdFile pre-apply failed (continuing)")
+		} else {
+			logger.Info().
+				Str("crd", crdName).
+				Str("path", path).
+				Msg("crdFile applied")
+		}
 	}
 }

--- a/cmd/cli/validate.go
+++ b/cmd/cli/validate.go
@@ -128,7 +128,7 @@ func validateMotifFile(path string) error {
 func init() {
 	rootCmd.AddCommand(validateCmd)
 
-	validateCmd.Flags().StringSliceP("file", "f", nil, "Path to katalog.yaml or komposer.yaml (can be specified multiple times or as comma-separated)")
+	validateCmd.Flags().StringSliceP("file", "f", nil, "Path to katalog.yaml or komposer.yaml (repeatable or comma-separated)")
 
 	// Shadow global flags so they don't appear under `ork validate`
 	validateCmd.Flags().Bool("debug", false, "")

--- a/docs/getting-started/writing-your-first-katalog.md
+++ b/docs/getting-started/writing-your-first-katalog.md
@@ -41,8 +41,26 @@ This Katalog tells Orkestra:
 - Do not create any resources yet  
 
 !!! tip
-    Every CRD entry must define `apiTypes` and a `reconciler`.  
-    Everything else is optional and added only when needed.
+    Every CRD entry must define either `apiTypes` or `crdFile:` (which populates `apiTypes`
+    automatically from the CRD YAML), plus a `reconciler`. Everything else is optional.
+
+!!! note "crdFile shorthand (dev mode)"
+    If you are running locally with `ork run`, you can omit `apiTypes` entirely and declare
+    `crdFile:` instead. Orkestra reads `group`, `version`, `kind`, and `plural` directly
+    from the CRD YAML, and auto-applies the CRD before starting:
+
+    ```yaml
+    spec:
+      crds:
+        myapp:
+          crdFile: ./crd.yaml   # apiTypes populated from this file; CRD applied automatically
+          operatorBox:
+            default: true
+    ```
+
+    This only works with `ork run` (dev mode). For Helm-deployed Orkestra, declare
+    `apiTypes:` explicitly and install the CRD with `kubectl apply -f crd.yaml` before
+    deploying.
 
 ---
 

--- a/docs/guides/user-guide/best-practices.md
+++ b/docs/guides/user-guide/best-practices.md
@@ -108,6 +108,25 @@ Don't specify `group`, `version`, or `plural` for built‑in resources. Orkestra
     plural: pods
 ```
 
+### Use crdFile in Dev Workflows
+
+When running locally with `ork run`, declare `crdFile:` instead of an `apiTypes:` block
+for custom CRDs. Orkestra reads the API group, version, kind, and plural directly from the
+CRD YAML and auto-applies the CRD before starting — no separate `kubectl apply -f crd.yaml`
+step needed.
+
+```yaml
+# Good — self-contained for ork run
+spec:
+  crds:
+    myapp:
+      crdFile: ./crd.yaml
+      operatorBox:
+        # ...
+```
+
+For Helm-deployed Orkestra, keep `apiTypes:` explicit — `crdFile` auto-apply is dev-only.
+
 ### Name CRDs Clearly
 
 Use lowercase kebab‑case for CRD names. These appear in URLs and logs.

--- a/docs/publications/operator-of-operators.md
+++ b/docs/publications/operator-of-operators.md
@@ -1,0 +1,283 @@
+# Operator of Operators: Compositional Platform Engineering with Orkestra
+
+*Orkestra Project — May 2026*
+
+---
+
+## Abstract
+
+Orkestra operators have always been able to create Kubernetes primitives —
+Deployments, Services, StatefulSets, Secrets. The `custom:` block in
+HookTemplates extends this to Custom Resources, enabling one Orkestra operator
+to instantiate and manage resources that are themselves watched by other
+operators. Combined with Orkestra's `when:` conditions, `forEach:` expansion,
+and `anyOf:` logic, this produces a compositional platform engineering model
+where a single CRD can represent any combination of infrastructure concerns,
+with the operator deciding at runtime which sub-operators to activate.
+
+This paper describes the architecture, the proof-of-concept in the
+`AppEnvironment` operator, and what the capability unlocks.
+
+---
+
+## 1. The gap this fills
+
+Before this capability, Orkestra operators could declare what Kubernetes
+primitives to create. They could not declare what other operators to
+instantiate. This meant platform composition — "deploy a CacheCluster
+when caching is enabled, a SearchIndex when search is enabled" — required
+either:
+
+- Multiple separate CRDs with manual application of each CR
+- External orchestration (Helm, Argo, Flux) managing the CR lifecycle
+- Platform engineers writing Go code to create child CRs dynamically
+
+All three approaches break the declarative model. The platform engineer
+either writes imperative code, or delegates to a tool outside Orkestra's
+reconcile loop. The result is state that Orkestra cannot observe, drift
+that Orkestra cannot correct, and deletion that Orkestra cannot order.
+
+The `custom:` block brings child CR creation inside the reconcile loop.
+Everything Orkestra knows how to do — conditional creation, drift correction,
+ordered deletion, owner references, event emission — now applies to child
+CRs exactly as it applies to Deployments.
+
+---
+
+## 2. What custom: is
+
+`custom:` is a field in `HookTemplates` alongside `deployments:`,
+`statefulsets:`, `services:`, and every other resource type Orkestra manages.
+It accepts the same primitives:
+
+```yaml
+custom:
+  - apiVersion: platform.example.io/v1alpha1
+    kind: CacheCluster
+    when:
+      - field: spec.cache.enabled
+        equals: "true"
+    metadata:
+      name: "{{ .metadata.name }}-cache"
+      namespace: "{{ .metadata.namespace }}"
+    spec:
+      size: "{{ .spec.cache.size }}"
+      ttl: "{{ .spec.cache.ttl }}"
+    hasStatus: false
+    reconcile: true
+```
+
+This entry behaves identically to a Deployment entry in every respect:
+
+- `when:` gates creation on a condition
+- `reconcile: true` enables drift correction on subsequent reconciles
+- `{{ .metadata.name }}` uses the parent CR's name for consistent naming
+- Owner reference is set — Kubernetes garbage-collects the child CR when
+  the parent is deleted
+- The `hasStatus: false` hint prevents Orkestra from attempting status
+  writes on CRDs that do not expose the status subresource
+
+The implementation uses the dynamic client and RESTMapper to resolve any
+`apiVersion` + `kind` combination to a GroupVersionResource at runtime.
+No code generation required. No CRD-specific client. Any installed CRD
+works.
+
+---
+
+## 3. The AppEnvironment proof
+
+The `appenvironment-operator` demonstrates the full capability:
+
+```yaml
+spec:
+  crds:
+    appenvironment:
+      apiTypes:
+        kind: AppEnvironment
+      operatorBox:
+        onCreate:
+          custom:
+            - apiVersion: platform.example.io/v1alpha1
+              kind: CacheCluster
+              when:
+                - field: spec.cache.enabled
+                  equals: "true"
+              metadata:
+                name: "{{ .metadata.name }}-cache"
+              spec:
+                size: "{{ .spec.cache.size }}"
+              hasStatus: false
+
+            - apiVersion: platform.example.io/v1alpha1
+              kind: SearchIndex
+              when:
+                - field: spec.search.enabled
+                  equals: "true"
+              metadata:
+                name: "{{ .metadata.name }}-search"
+              spec:
+                indexName: "{{ .spec.search.indexName }}"
+              hasStatus: false
+
+    cachecluster:
+      apiTypes:
+        kind: CacheCluster
+      operatorBox:
+        onCreate:
+          deployments:
+            - image: "redis:7-alpine"
+              port: 6379
+
+    searchindex:
+      apiTypes:
+        kind: SearchIndex
+      operatorBox:
+        onCreate:
+          deployments:
+            - image: "opensearchproject/opensearch:2.11.0"
+              port: 9200
+```
+
+A user applies one AppEnvironment CR:
+
+```yaml
+apiVersion: platform.example.io/v1alpha1
+kind: AppEnvironment
+metadata:
+  name: prod-env
+spec:
+  tier: production
+  cache:
+    enabled: "true"
+    size: "2Gi"
+    ttl: "3600"
+  search:
+    enabled: "true"
+    indexName: "prod-index"
+    replicas: "3"
+```
+
+Orkestra reconciles the AppEnvironment CR. The `when:` conditions pass.
+Orkestra creates a `CacheCluster` CR named `prod-env-cache` and a
+`SearchIndex` CR named `prod-env-search`. The `cachecluster` and
+`searchindex` reconcilers in the same Katalog then pick up their respective
+CRs and create Redis and OpenSearch deployments.
+
+The user applied one CR. Three separate reconcile loops ran. Six
+Kubernetes resources were created. One YAML file described the intent.
+
+Change `cache.enabled` to `"false"` and update the CR. On the next
+reconcile, the `when:` condition fails. Orkestra deletes the `CacheCluster`
+CR. The `cachecluster` reconciler sees the deletion and removes the Redis
+deployment. The platform contracts to match the updated intent.
+
+---
+
+## 4. The architectural properties
+
+### Conditionality is first-class
+
+Every child CR is gated by `when:`. The parent operator decides at runtime
+whether to instantiate a sub-operator based on the parent CR's spec. This
+is not a static composition — it is a dynamic one. A single CRD can
+represent a lean development environment (no cache, no search) and a full
+production environment (both enabled) with the same operator handling both.
+
+### Drift correction applies to child CRs
+
+`reconcile: true` on a custom resource entry means Orkestra compares the
+desired spec (from the parent CR's template) against the existing child CR's
+spec on every reconcile. If they differ, Orkestra updates the child CR.
+The child operator then reconciles to match the updated spec. Drift at
+any level in the composition is corrected automatically.
+
+### Deletion is ordered
+
+The `custom:` entries participate in Orkestra's ordered deletion model.
+When the parent CR is deleted, Orkestra can be configured to delete child
+CRs in a specific order, wait for each to be fully deleted before proceeding,
+and emit events throughout. Infrastructure teardown is as structured as
+infrastructure creation.
+
+### Owner references cascade Kubernetes garbage collection
+
+Every child CR created by `custom:` has the parent CR as its owner reference.
+When the parent is deleted without going through Orkestra's ordered deletion
+(for example, a direct `kubectl delete`), Kubernetes garbage collection
+removes the child CRs. The child operators then clean up their resources.
+Nothing is orphaned.
+
+### The same primitives, all the way down
+
+`custom:` supports `when:`, `anyOf:`, `forEach:`, `reconcile:`, `sleep:`.
+These are the same primitives that every other resource type in HookTemplates
+supports. There is no special API for operator composition. The Katalog
+author writes the same patterns they already know.
+
+---
+
+## 5. What this unlocks
+
+### Platform CRDs
+
+A platform team can now write a single CRD — `AppEnvironment`,
+`MicroservicePlatform`, `DataPipeline` — that encapsulates any combination
+of infrastructure. The CRD's spec defines what the platform offers. The
+operator's `custom:` blocks define which sub-operators implement each
+offered capability. The platform user sees one CRD with a clean API.
+The platform team manages one Katalog with composable operators.
+
+### Operator hierarchies
+
+Orkestra can now express operator hierarchies that mirror organizational
+boundaries. A cluster-level `Platform` operator creates namespace-level
+`Tenant` CRs. Each `Tenant` operator creates application-level `Service`
+CRs. Each `Service` operator creates Deployments, Services, and HPAs.
+Three levels of operator, one Katalog, one reconcile loop per level,
+fully declarative.
+
+### Conditional infrastructure
+
+The `when:` condition on `custom:` entries enables infrastructure that
+responds to application state. When a `Service` CR's `spec.tier` changes
+from `development` to `production`, the operator creates a `CacheCluster`
+CR. The cache sub-operator activates. The service gets a sidecar connection.
+All triggered by a spec field change on the parent CR.
+
+### Motifs for operator composition
+
+The Motif system — Orkestra's reusable primitive layer — can now include
+Motifs that compose operators, not just Kubernetes resources. A
+`postgres-platform` Motif might import a `postgres` Motif (for the
+StatefulSet and Service) and a `backup-operator` Motif (for a CronJob
+that creates `Backup` CRs managed by a backup operator). The composition
+is declarative. The inputs are typed. The validation is static.
+
+### The Orkestra registry becomes an operator marketplace
+
+Operators in the registry are no longer just reconcilers for specific CRDs.
+They are building blocks that other operators can instantiate. A
+`monitoring` operator from the registry can be referenced in a `custom:`
+block — when a service opts into monitoring, the parent operator creates
+the monitoring CR, and the monitoring operator activates. The registry
+becomes a marketplace of composable operator behaviors.
+
+---
+
+## 6. The mental model shift
+
+Before `custom:`, Orkestra operators created infrastructure. After `custom:`,
+Orkestra operators create infrastructure and orchestrate other operators.
+
+The distinction matters because it changes the granularity at which Orkestra
+operates. An operator that creates a Deployment is managing compute. An
+operator that creates a `CacheCluster` CR is managing a concern — caching —
+and delegating the implementation of that concern to the `CacheCluster`
+operator.
+
+This delegation is the correct model for platform engineering at scale.
+Platform teams do not manage Redis clusters. They manage the concern of
+caching. The concern has an API (`CacheCluster`). The implementation is
+hidden behind the API. The operator hierarchy enforces this separation.
+
+Orkestra's `custom:` block makes this separation declarative.

--- a/docs/runtime-manual/concepts/operator-of-operators.md
+++ b/docs/runtime-manual/concepts/operator-of-operators.md
@@ -1,0 +1,70 @@
+# Concept: Operator of Operators
+
+The `custom:` block in an Orkestra operatorBox creates Custom Resources —
+not Kubernetes primitives. This means one Orkestra operator can instantiate
+resources that are themselves managed by other Orkestra operators in the
+same Katalog.
+
+## The pattern
+
+```yaml
+operatorBox:
+  onCreate:
+    custom:
+      - apiVersion: platform.io/v1alpha1
+        kind: CacheCluster
+        when:
+          - field: spec.cache.enabled
+            equals: "true"
+        metadata:
+          name: "{{ .metadata.name }}-cache"
+        spec:
+          size: "{{ .spec.cache.size }}"
+        hasStatus: false
+        reconcile: true
+```
+
+The parent operator creates a `CacheCluster` CR when caching is enabled.
+The `cachecluster` reconciler in the same Katalog watches `CacheCluster`
+CRs and creates the actual Redis deployment. One spec change on the parent
+CR activates or deactivates an entire sub-operator.
+
+## What custom: supports
+
+Every primitive available to other resource types is available to custom:
+
+- `when:` — conditional creation
+- `anyOf:` — OR conditions
+- `forEach:` — expand to multiple CRs from a list
+- `reconcile: true` — drift correction
+- `sleep:` — testing and chaos engineering
+- `hasStatus:` — hint to skip status writes for CRDs without subresource
+
+## hasStatus
+
+Most CRDs expose a status subresource. Some do not. The `hasStatus` field
+controls whether Orkestra attempts status writes:
+
+```yaml
+hasStatus: false   # never write status — avoids API errors
+hasStatus: true    # always write status
+# omit             # auto-detect via discovery
+```
+
+## Owner references
+
+Every child CR created by `custom:` is given the parent CR as its owner
+reference. When the parent is deleted, Kubernetes garbage-collects all
+child CRs. Their operators then clean up their resources.
+
+## Naming convention
+
+Use the parent CR's name as a prefix for child CR names:
+
+```yaml
+metadata:
+  name: "{{ .metadata.name }}-cache"
+```
+
+This ensures child CRs are identifiable as belonging to the parent and
+avoids naming conflicts when multiple parent CRs exist in the same namespace.

--- a/examples/advanced/11-mixed-operator-patterm/01-hello-website/katalog.yaml
+++ b/examples/advanced/11-mixed-operator-patterm/01-hello-website/katalog.yaml
@@ -13,11 +13,7 @@ metadata:
 spec:
   crds:
     website:
-      apiTypes:
-        group: demo.orkestra.io
-        version: v1alpha1
-        kind: Website
-        plural: websites
+      crdFile: ./crd.yaml
       allowedNamespaces:
         - default
 

--- a/examples/advanced/11-mixed-operator-patterm/09-hooks/katalog.yaml
+++ b/examples/advanced/11-mixed-operator-patterm/09-hooks/katalog.yaml
@@ -11,20 +11,7 @@ metadata:
 spec:
   crds:
     database:
-      apiTypes:
-        group: demo.orkestra.io
-        version: v1alpha1
-        kind: Database
-        plural: databases
-        object: Database
-        objectList: DatabaseList
-        # location enables typed mode — the informer decodes API server
-        # responses into *apiv1.Database rather than *unstructured.Unstructured.
-        # Required when hooks need type-safe struct access.
-        # After setting this, run: ork generate registry --file katalog.yaml
-        location: github.com/orkspace/orkestra-mixed-operator-pattern/09-hooks/api/v1alpha1
-        alias: demov1alpha1
-
+      crdFile: ./crd.yaml
       workers: 3
       resync: 30s
 

--- a/examples/advanced/11-mixed-operator-patterm/10-constructor/katalog.yaml
+++ b/examples/advanced/11-mixed-operator-patterm/10-constructor/katalog.yaml
@@ -12,17 +12,7 @@ metadata:
 spec:
   crds:
     pipeline:
-      apiTypes:
-        group: demo.orkestra.io
-        version: v1alpha1
-        kind: Pipeline
-        plural: pipelines
-        object: Pipeline
-        objectList: PipelineList
-        # location enables typed mode — the informer delivers *apiv1.Pipeline
-        # instead of *unstructured.Unstructured.
-        location: github.com/orkspace/orkestra-mixed-operator-pattern/10-constructor/api/v1alpha1
-
+      crdFile: ./crd.yaml
       workers: 5       # pipelines can be IO-bound — more workers tolerated
       resync: 10s      # short resync to check Job completion quickly
 

--- a/examples/advanced/12-autoscale/01-without-autoscaler/katalog.yaml
+++ b/examples/advanced/12-autoscale/01-without-autoscaler/katalog.yaml
@@ -12,12 +12,7 @@ metadata:
 spec:
   crds:
     ingestor:
-      apiTypes:
-        group: autoscale.orkestra.io
-        version: v1alpha1
-        kind: Ingestor
-        plural: ingestors
-
+      crdFile: ./crd.yaml
       workers: 2
       resync: 60s
 

--- a/examples/advanced/12-autoscale/02-based-on-own-metrics/katalog.yaml
+++ b/examples/advanced/12-autoscale/02-based-on-own-metrics/katalog.yaml
@@ -13,12 +13,7 @@ metadata:
 spec:
   crds:
     ingestor:
-      apiTypes:
-        group: autoscale.orkestra.io
-        version: v1alpha1
-        kind: Ingestor
-        plural: ingestors
-
+      crdFile: ./crd.yaml
       workers: 2
       resync: 60s
 

--- a/examples/advanced/12-autoscale/03-sibling-in-binary/katalog.yaml
+++ b/examples/advanced/12-autoscale/03-sibling-in-binary/katalog.yaml
@@ -27,12 +27,7 @@ spec:
     # Produces work for Processor and Auditor to consume.
     # Fixed concurrency — no autoscale on the producer itself.
     loader:
-      apiTypes:
-        group: autoscale.orkestra.io
-        version: v1alpha1
-        kind: Loader
-        plural: loaders
-
+      crdFile: ./crd-loader.yaml
       workers: 3
       resync: 60s
 
@@ -69,12 +64,7 @@ spec:
     # Cannot be combined with interval/cooldown/conditions/do — the profile owns
     # the entire autoscale block.
     processor:
-      apiTypes:
-        group: autoscale.orkestra.io
-        version: v1alpha1
-        kind: Processor
-        plural: processors
-
+      crdFile: ./crd-processor.yaml
       workers: 2
       resync: 30s
 
@@ -105,12 +95,7 @@ spec:
     # cross.<crd>.metrics.* field path — reads from the sibling CRD's live
     # metrics without any network call (same binary, same runtime).
     auditor:
-      apiTypes:
-        group: autoscale.orkestra.io
-        version: v1alpha1
-        kind: Auditor
-        plural: auditors
-
+      crdFile: ./crd-auditor.yaml
       workers: 1
       resync: 60s
 

--- a/examples/advanced/13-dependencies/01-in-binary/katalog.yaml
+++ b/examples/advanced/13-dependencies/01-in-binary/katalog.yaml
@@ -19,12 +19,7 @@ spec:
     # Writes its connection string into status.endpoint once the StatefulSet
     # is ready so App can read it.
     database:
-      apiTypes:
-        group: deps.orkestra.io
-        version: v1alpha1
-        kind: Database
-        plural: databases
-
+      crdFile: ./crd.yaml
       workers: 2
       resync: 30s
 
@@ -63,12 +58,7 @@ spec:
     #     database:
     #       condition: healthy
     app:
-      apiTypes:
-        group: deps.orkestra.io
-        version: v1alpha1
-        kind: App
-        plural: apps
-
+      crdFile: ./crd.yaml
       workers: 3
       resync: 30s
 

--- a/examples/advanced/16-custom-resources/01-single-child/katalog.yaml
+++ b/examples/advanced/16-custom-resources/01-single-child/katalog.yaml
@@ -16,11 +16,7 @@ spec:
     # The "parent" CRD. When a Workspace is created, its operatorBox declares
     # a SecretVault child CR via onCreate.custom.
     workspace:
-      apiTypes:
-        group: platform.example.io
-        version: v1alpha1
-        kind: Workspace
-        plural: workspaces
+      crdFile: ./crd-workspace.yaml
       workers: 2
       resync: 60s
       operatorBox:
@@ -61,11 +57,7 @@ spec:
     # not know it was created by a Workspace. The owner reference set by Orkestra
     # ensures it is deleted when the parent Workspace is deleted.
     secretvault:
-      apiTypes:
-        group: platform.example.io
-        version: v1alpha1
-        kind: SecretVault
-        plural: secretvaults
+      crdFile: ./crd-secretvault.yaml
       workers: 2
       resync: 60s
       operatorBox:

--- a/examples/advanced/16-custom-resources/02-status-propagation/katalog.yaml
+++ b/examples/advanced/16-custom-resources/02-status-propagation/katalog.yaml
@@ -14,11 +14,7 @@ spec:
 
     # ── DataPipeline ───────────────────────────────────────────────────────────
     datapipeline:
-      apiTypes:
-        group: data.example.io
-        version: v1alpha1
-        kind: DataPipeline
-        plural: datapipelines
+      crdFile: ./crd-datapipeline.yaml
       workers: 2
       resync: 30s
       operatorBox:
@@ -61,11 +57,7 @@ spec:
 
     # ── Connector ─────────────────────────────────────────────────────────────
     connector:
-      apiTypes:
-        group: data.example.io
-        version: v1alpha1
-        kind: Connector
-        plural: connectors
+      crdFile: ./crd-connector.yaml
       workers: 2
       resync: 30s
       operatorBox:

--- a/examples/advanced/16-custom-resources/03-conditional-children/katalog.yaml
+++ b/examples/advanced/16-custom-resources/03-conditional-children/katalog.yaml
@@ -15,11 +15,7 @@ spec:
 
     # ── AppEnvironment ─────────────────────────────────────────────────────────
     appenvironment:
-      apiTypes:
-        group: platform.example.io
-        version: v1alpha1
-        kind: AppEnvironment
-        plural: appenvironments
+      crdFile: ./crd-appenvironment.yaml
       workers: 2
       resync: 60s
       operatorBox:
@@ -78,11 +74,7 @@ spec:
 
     # ── CacheCluster ───────────────────────────────────────────────────────────
     cachecluster:
-      apiTypes:
-        group: platform.example.io
-        version: v1alpha1
-        kind: CacheCluster
-        plural: cacheclusters
+      crdFile: ./crd-cachecluster.yaml
       workers: 1
       resync: 60s
       operatorBox:
@@ -103,11 +95,7 @@ spec:
 
     # ── SearchIndex ────────────────────────────────────────────────────────────
     searchindex:
-      apiTypes:
-        group: platform.example.io
-        version: v1alpha1
-        kind: SearchIndex
-        plural: searchindices
+      crdFile: ./crd-searchindex.yaml
       workers: 1
       resync: 60s
       operatorBox:

--- a/examples/advanced/16-custom-resources/04-drift-correction/katalog.yaml
+++ b/examples/advanced/16-custom-resources/04-drift-correction/katalog.yaml
@@ -15,11 +15,7 @@ spec:
 
     # ── Database ───────────────────────────────────────────────────────────────
     database:
-      apiTypes:
-        group: storage.example.io
-        version: v1alpha1
-        kind: Database
-        plural: databases
+      crdFile: ./crd-database.yaml
       workers: 2
       resync: 30s
       operatorBox:
@@ -59,11 +55,7 @@ spec:
 
     # ── BackupPolicy ───────────────────────────────────────────────────────────
     backuppolicy:
-      apiTypes:
-        group: storage.example.io
-        version: v1alpha1
-        kind: BackupPolicy
-        plural: backuppolicies
+      crdFile: ./crd-backuppolicy.yaml
       workers: 1
       resync: 60s
       operatorBox:

--- a/examples/advanced/16-custom-resources/05-forEach-sharding/katalog.yaml
+++ b/examples/advanced/16-custom-resources/05-forEach-sharding/katalog.yaml
@@ -15,11 +15,7 @@ spec:
 
     # ── ShardedStore ───────────────────────────────────────────────────────────
     shardedstore:
-      apiTypes:
-        group: storage.example.io
-        version: v1alpha1
-        kind: ShardedStore
-        plural: shardedstores
+      crdFile: ./crd-shardedstore.yaml
       workers: 2
       resync: 60s
       operatorBox:
@@ -59,11 +55,7 @@ spec:
 
     # ── Shard ──────────────────────────────────────────────────────────────────
     shard:
-      apiTypes:
-        group: storage.example.io
-        version: v1alpha1
-        kind: Shard
-        plural: shards
+      crdFile: ./crd-shard.yaml
       workers: 3
       resync: 60s
       operatorBox:

--- a/examples/advanced/16-custom-resources/06-full-platform-composition/katalog.yaml
+++ b/examples/advanced/16-custom-resources/06-full-platform-composition/katalog.yaml
@@ -20,11 +20,7 @@ spec:
     #
     # Small preset: lean development platform.
     platform:
-      apiTypes:
-        group: infra.example.io
-        version: v1alpha1
-        kind: Platform
-        plural: platforms
+      crdFile: ./crd-platform.yaml
       workers: 2
       resync: 60s
       # Import the motif. The 'with' block provides sizing-specific values.
@@ -56,11 +52,7 @@ spec:
 
     # ── MessageQueue ───────────────────────────────────────────────────────────
     messagequeue:
-      apiTypes:
-        group: infra.example.io
-        version: v1alpha1
-        kind: MessageQueue
-        plural: messagequeues
+      crdFile: ./crd-messagequeue.yaml
       workers: 3
       resync: 60s
       operatorBox:
@@ -82,11 +74,7 @@ spec:
 
     # ── ObjectStore ────────────────────────────────────────────────────────────
     objectstore:
-      apiTypes:
-        group: infra.example.io
-        version: v1alpha1
-        kind: ObjectStore
-        plural: objectstores
+      crdFile: ./crd-objectstore.yaml
       workers: 1
       resync: 60s
       operatorBox:
@@ -113,11 +101,7 @@ spec:
 
     # ── SearchCluster ──────────────────────────────────────────────────────────
     searchcluster:
-      apiTypes:
-        group: infra.example.io
-        version: v1alpha1
-        kind: SearchCluster
-        plural: searchclusters
+      crdFile: ./crd-searchcluster.yaml
       workers: 1
       resync: 60s
       operatorBox:

--- a/examples/advanced/16-custom-resources/07-multi-crd-pipeline/katalog.yaml
+++ b/examples/advanced/16-custom-resources/07-multi-crd-pipeline/katalog.yaml
@@ -11,11 +11,7 @@ metadata:
 spec:
   crds:
     pipeline:
-      apiTypes:
-        group: cicd.orkestra.io
-        version: v1alpha1
-        kind: Pipeline
-        plural: pipelines
+      crdFile: ./crd-pipeline.yaml
       imports:
         - motif: ./pipeline-motif.yaml
           with:
@@ -25,11 +21,7 @@ spec:
 
     # ── Loader ────────────────────────────────────────────────────────────────
     loader:
-      apiTypes:
-        group: autoscale.orkestra.io
-        version: v1alpha1
-        kind: Loader
-        plural: loaders
+      crdFile: ./crd-loader.yaml
       workers: 3
       resync: 60s
       operatorBox:
@@ -48,11 +40,7 @@ spec:
 
     # ── Processor ────────────────────────────────────────────────────────────
     processor:
-      apiTypes:
-        group: autoscale.orkestra.io
-        version: v1alpha1
-        kind: Processor
-        plural: processors
+      crdFile: ./crd-processor.yaml
       workers: 2
       resync: 30s
       operatorBox:
@@ -71,11 +59,7 @@ spec:
 
     # ── Auditor ────────────────────────────────────────────────────────────
     auditor:
-      apiTypes:
-        group: autoscale.orkestra.io
-        version: v1alpha1
-        kind: Auditor
-        plural: auditors
+      crdFile: ./crd-auditor.yaml
       workers: 1
       resync: 60s
       operatorBox:

--- a/examples/advanced/17-apitype-override/README.md
+++ b/examples/advanced/17-apitype-override/README.md
@@ -1,0 +1,130 @@
+# 17 — API Type Override
+
+A vendor ships a Katalog. Your company has its own API group. This example shows
+how to import the vendor Katalog with a Komposer and override only the `apiTypes`
+block — your operator runs identical logic under your own CRD identity.
+
+**What you learn:** `apiTypes` override in a Komposer, white-label operator pattern,
+how inherited fields (reconciler, status, onCreate) are untouched by the override.
+
+**Builds on:** [06 — Basic Komposer](../../intermediate/06-komposer-basic/README.md)
+
+---
+
+## The problem
+
+A vendor ships:
+```yaml
+# vendor-katalog.yaml
+spec:
+  crds:
+    db-cluster:
+      apiTypes:
+        group: vendor.example.io   # vendor's group
+        kind: DatabaseCluster
+```
+
+You want to run the same operator but watch `platform.acme.io/DatabaseCluster` —
+your company's API surface. You cannot modify the vendor file.
+
+---
+
+## The solution
+
+```yaml
+# komposer.yaml
+imports:
+  files:
+    - ./vendor-katalog.yaml
+
+spec:
+  crds:
+    db-cluster:
+      apiTypes:
+        group: platform.acme.io    # your group — only this changes
+        version: v1alpha1
+        kind: DatabaseCluster
+        plural: databaseclusters
+      # workers, resync, operatorBox all inherited from vendor-katalog.yaml
+```
+
+The Komposer replaces `apiTypes` for `db-cluster`. Everything else — workers,
+resync interval, status fields, onCreate resources — is inherited from the vendor
+Katalog unchanged.
+
+---
+
+## Steps
+
+### 1. Install your CRD
+
+```bash
+kubectl apply -f crd-mine.yaml
+```
+
+> The vendor CRD (`crd-vendor.yaml`) is included for reference. You do not install
+> it — your Komposer points the operator at your CRD instead.
+
+### 2. Validate
+
+```bash
+ork validate --file komposer.yaml
+```
+
+Expected:
+```
+✓ db-cluster
+    kind: DatabaseCluster
+    group: platform.acme.io / version: v1alpha1 / plural: databaseclusters
+    mode: dynamic / workers: 2 / resync: 45s
+```
+
+The group is `platform.acme.io` — not `vendor.example.io`. The workers and
+resync values come from the vendor Katalog.
+
+### 3. Start the operator
+
+```bash
+ork run --file komposer.yaml
+```
+
+### 4. Apply a CR
+
+```bash
+kubectl apply -f cr.yaml
+```
+
+`cr.yaml` uses `apiVersion: platform.acme.io/v1alpha1` — your API group.
+
+### 5. Verify
+
+```bash
+kubectl get databaseclusters
+kubectl get statefulsets | grep prod-db
+kubectl get services   | grep prod-db
+```
+
+The operator created a StatefulSet and Service for `prod-db` under your API group.
+The vendor's group (`vendor.example.io`) is never involved at runtime.
+
+---
+
+## What the override covers
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `apiTypes.group` | Komposer (overrides) | Your company's API group |
+| `apiTypes.kind` | Komposer (overrides) | Same kind name |
+| `workers` | Vendor Katalog (inherited) | Can be overridden |
+| `resync` | Vendor Katalog (inherited) | Can be overridden |
+| `operatorBox` | Vendor Katalog (inherited) | Full reconciler logic reused |
+
+The Komposer override wins field-by-field. You only declare what changes.
+
+---
+
+## Cleanup
+
+```bash
+chmod +x cleanup.sh && ./cleanup.sh
+```

--- a/examples/advanced/17-apitype-override/cleanup.sh
+++ b/examples/advanced/17-apitype-override/cleanup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "Cleaning up 17-apitype-override..."
+
+kubectl delete -f cr.yaml          --ignore-not-found
+kubectl delete -f crd-mine.yaml    --ignore-not-found
+kubectl delete -f crd-vendor.yaml  --ignore-not-found
+
+echo "✓ Done. Stop 'ork run' with Ctrl+C if still running."

--- a/examples/advanced/17-apitype-override/cr.yaml
+++ b/examples/advanced/17-apitype-override/cr.yaml
@@ -1,0 +1,9 @@
+apiVersion: platform.acme.io/v1alpha1
+kind: DatabaseCluster
+metadata:
+  name: prod-db
+  namespace: default
+spec:
+  engine: postgres
+  image: postgres:15-alpine
+  nodes: 2

--- a/examples/advanced/17-apitype-override/crd-mine.yaml
+++ b/examples/advanced/17-apitype-override/crd-mine.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: databaseclusters.platform.acme.io
+spec:
+  group: platform.acme.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Engine
+          type: string
+          jsonPath: .spec.engine
+        - name: Nodes
+          type: integer
+          jsonPath: .spec.nodes
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required: [engine]
+              properties:
+                engine:
+                  type: string
+                  default: postgres
+                  enum: [postgres, mysql]
+                image:
+                  type: string
+                  default: postgres:15-alpine
+                nodes:
+                  type: integer
+                  default: 1
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+  names:
+    kind: DatabaseCluster
+    plural: databaseclusters
+    singular: databasecluster
+  scope: Namespaced

--- a/examples/advanced/17-apitype-override/crd-vendor.yaml
+++ b/examples/advanced/17-apitype-override/crd-vendor.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: databaseclusters.vendor.example.io
+spec:
+  group: vendor.example.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Engine
+          type: string
+          jsonPath: .spec.engine
+        - name: Nodes
+          type: integer
+          jsonPath: .spec.nodes
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required: [engine]
+              properties:
+                engine:
+                  type: string
+                  default: postgres
+                  enum: [postgres, mysql]
+                image:
+                  type: string
+                  default: postgres:15-alpine
+                nodes:
+                  type: integer
+                  default: 1
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+  names:
+    kind: DatabaseCluster
+    plural: databaseclusters
+    singular: databasecluster
+  scope: Namespaced

--- a/examples/advanced/17-apitype-override/komposer.yaml
+++ b/examples/advanced/17-apitype-override/komposer.yaml
@@ -1,0 +1,24 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: Komposer
+metadata:
+  name: acme-db-komposer
+  author: acme-platform
+  version: 0.1.0
+  description: >
+    Imports the vendor DatabaseCluster Katalog and overrides apiTypes
+    to run under the platform.acme.io API group instead of vendor.example.io.
+    The operator logic (reconciler, status, onCreate) is inherited unchanged.
+
+imports:
+  files:
+    - ./vendor-katalog.yaml
+
+spec:
+  crds:
+    db-cluster:
+      apiTypes:
+        group: platform.acme.io        # your company's API group
+        version: v1alpha1
+        kind: DatabaseCluster
+        plural: databaseclusters
+      # workers, resync, operatorBox all inherited from vendor-katalog.yaml

--- a/examples/advanced/17-apitype-override/vendor-katalog.yaml
+++ b/examples/advanced/17-apitype-override/vendor-katalog.yaml
@@ -1,0 +1,45 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: Katalog
+metadata:
+  name: vendor-cluster-katalog
+  description: >
+    Vendor-shipped Katalog for the DatabaseCluster CRD.
+    Operators import this file — they never modify it directly.
+    Use a Komposer to override apiTypes and point at your own CRD.
+
+spec:
+  crds:
+    db-cluster:
+      apiTypes:
+        group: vendor.example.io
+        version: v1alpha1
+        kind: DatabaseCluster
+        plural: databaseclusters
+
+      workers: 2
+      resync: 45s
+
+      operatorBox:
+        status:
+          fields:
+            - path: phase
+              value: "Running"
+            - path: engine
+              value: "{{ .spec.engine }}"
+            - path: nodes
+              value: "{{ .spec.nodes }}"
+
+        onCreate:
+          statefulSets:
+            - replicas: "{{ .spec.nodes }}"
+              image: "{{ .spec.image }}"
+              port: 5432
+              reconcile: true
+          services:
+            - port: "5432"
+              targetPort: "5432"
+          configMaps:
+            - name: "{{ .metadata.name }}-config"
+              data:
+                ENGINE: "{{ .spec.engine }}"
+                NODES: "{{ .spec.nodes }}"

--- a/examples/advanced/18-crd-file-komposer/README.md
+++ b/examples/advanced/18-crd-file-komposer/README.md
@@ -1,0 +1,108 @@
+# 18 — CRD File + API Type Override in Komposer
+
+Combine both override types in a single Komposer: replace the vendor's API group
+with yours (`apiTypes`) and declare the path to your CRD file (`crdFile`). The
+result is a fully self-contained Komposer — hand it off and `ork run` handles
+the rest.
+
+**What you learn:** `apiTypes` + `crdFile` together in a Komposer override,
+the self-contained operator pattern, and how dev-mode auto-apply interacts
+with Komposer imports.
+
+**Builds on:** [17 — API Type Override](../17-apitype-override/README.md) and
+[07 — CRD File](../../intermediate/07-crd-file/README.md)
+
+---
+
+## The pattern
+
+```
+vendor-katalog.yaml            →  logic (reconciler, status, onCreate)
+komposer.yaml (override)       →  apiTypes: platform.acme.io    ← your group
+                                  crdFile:  ./crd-mine.yaml     ← your CRD
+```
+
+The vendor Katalog provides all the operator logic. The Komposer declares:
+1. **Which CRD to watch** — your group, not the vendor's
+2. **Where the CRD file lives** — applied automatically by `ork run` in dev mode
+
+No manual `kubectl apply -f crd-mine.yaml` step. No modifications to the vendor
+file.
+
+---
+
+## Steps
+
+### 1. Validate
+
+```bash
+ork validate --file komposer.yaml
+```
+
+Expected:
+```
+✓ managed-service
+    kind: ManagedService
+    group: platform.acme.io / version: v1alpha1 / plural: managedservices
+    crdFile: ./crd-mine.yaml
+    mode: dynamic / workers: 2 / resync: 30s
+```
+
+### 2. Start the operator
+
+```bash
+ork run --file komposer.yaml
+```
+
+On startup you will see:
+```
+INF crdFile applied crd=managed-service path=.../crd-mine.yaml
+```
+
+`crd-mine.yaml` is installed automatically. The operator begins watching
+`platform.acme.io/ManagedService` immediately.
+
+### 3. Apply a CR
+
+```bash
+kubectl apply -f cr.yaml
+```
+
+`cr.yaml` uses `apiVersion: platform.acme.io/v1alpha1` — your API surface,
+not the vendor's.
+
+### 4. Verify
+
+```bash
+kubectl get managedservices
+kubectl get deployments | grep my-service
+kubectl get services   | grep my-service
+```
+
+Expected (after a moment):
+```
+NAME         IMAGE                PHASE
+my-service   nginx:stable-alpine  Running
+```
+
+---
+
+## How it differs from 17-apitype-override
+
+| Aspect | 17 — apitype-override | 18 — crd-file-komposer |
+|--------|-----------------------|------------------------|
+| CRD install | Manual: `kubectl apply -f crd-mine.yaml` | Automatic: `ork run` applies it |
+| `apiTypes` override | Yes | Yes |
+| `crdFile` override | No | Yes |
+| Startup step count | 5 (install → validate → run → CR → verify) | 4 (validate → run → CR → verify) |
+
+Use **18** when you want the Komposer to be the single artifact to hand off.
+Use **17** when your CI pipeline handles CRD installation separately.
+
+---
+
+## Cleanup
+
+```bash
+chmod +x cleanup.sh && ./cleanup.sh
+```

--- a/examples/advanced/18-crd-file-komposer/cleanup.sh
+++ b/examples/advanced/18-crd-file-komposer/cleanup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "Cleaning up 18-crd-file-komposer..."
+
+kubectl delete -f cr.yaml       --ignore-not-found
+kubectl delete -f crd-mine.yaml --ignore-not-found
+
+echo "✓ Done. Stop 'ork run' with Ctrl+C if still running."

--- a/examples/advanced/18-crd-file-komposer/cr.yaml
+++ b/examples/advanced/18-crd-file-komposer/cr.yaml
@@ -1,0 +1,9 @@
+apiVersion: platform.acme.io/v1alpha1
+kind: ManagedService
+metadata:
+  name: my-service
+  namespace: default
+spec:
+  image: nginx:stable-alpine
+  replicas: 2
+  port: 8080

--- a/examples/advanced/18-crd-file-komposer/crd-mine.yaml
+++ b/examples/advanced/18-crd-file-komposer/crd-mine.yaml
@@ -1,0 +1,49 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: managedservices.platform.acme.io
+spec:
+  group: platform.acme.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Image
+          type: string
+          jsonPath: .spec.image
+        - name: Port
+          type: integer
+          jsonPath: .spec.port
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required: [image]
+              properties:
+                image:
+                  type: string
+                replicas:
+                  type: integer
+                  default: 1
+                port:
+                  type: integer
+                  default: 8080
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+  names:
+    kind: ManagedService
+    plural: managedservices
+    singular: managedservice
+  scope: Namespaced

--- a/examples/advanced/18-crd-file-komposer/komposer.yaml
+++ b/examples/advanced/18-crd-file-komposer/komposer.yaml
@@ -1,0 +1,25 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: Komposer
+metadata:
+  name: acme-service-komposer
+  author: acme-platform
+  version: 0.1.0
+  description: >
+    Imports the vendor ManagedService Katalog and overrides both apiTypes
+    and crdFile. The operator runs under platform.acme.io and automatically
+    installs crd-mine.yaml on ork run — no manual kubectl apply step needed.
+
+imports:
+  files:
+    - ./vendor-katalog.yaml
+
+spec:
+  crds:
+    managed-service:
+      apiTypes:
+        group: platform.acme.io        # your API group
+        version: v1alpha1
+        kind: ManagedService
+        plural: managedservices
+      crdFile: ./crd-mine.yaml         # auto-applied by ork run in dev mode
+      # workers, resync, operatorBox all inherited from vendor-katalog.yaml

--- a/examples/advanced/18-crd-file-komposer/vendor-katalog.yaml
+++ b/examples/advanced/18-crd-file-komposer/vendor-katalog.yaml
@@ -1,0 +1,38 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: Katalog
+metadata:
+  name: vendor-service-katalog
+  description: >
+    Vendor-shipped Katalog for the ManagedService CRD.
+    Does not declare a crdFile — vendor assumes the CRD is pre-installed.
+    Import this with a Komposer to add your own API group and crdFile.
+
+spec:
+  crds:
+    managed-service:
+      apiTypes:
+        group: vendor.example.io
+        version: v1alpha1
+        kind: ManagedService
+        plural: managedservices
+
+      workers: 2
+      resync: 30s
+
+      operatorBox:
+        status:
+          fields:
+            - path: phase
+              value: "Running"
+            - path: endpoint
+              value: "{{ .metadata.name }}.svc.cluster.local:{{ .spec.port }}"
+
+        onCreate:
+          deployments:
+            - image: "{{ .spec.image }}"
+              replicas: "{{ .spec.replicas }}"
+              port: "{{ .spec.port }}"
+              reconcile: true
+          services:
+            - port: "{{ .spec.port }}"
+              targetPort: "{{ .spec.port }}"

--- a/examples/beginner/01-hello-website/katalog.yaml
+++ b/examples/beginner/01-hello-website/katalog.yaml
@@ -13,11 +13,7 @@ metadata:
 spec:
   crds:
     website:
-      apiTypes:
-        group: demo.orkestra.io
-        version: v1alpha1
-        kind: Website
-        plural: websites
+      crdFile: ./crd.yaml
       allowedNamespaces:
         - default
 

--- a/examples/beginner/02-website-with-service/katalog.yaml
+++ b/examples/beginner/02-website-with-service/katalog.yaml
@@ -11,11 +11,7 @@ metadata:
 spec:
   crds:
     website:
-      apiTypes:
-        group: demo.orkestra.io
-        version: v1alpha1
-        kind: Website
-        plural: websites
+      crdFile: ./crd.yaml
       resync: 5s
 
       operatorBox:

--- a/examples/beginner/03-secret-copy/katalog.yaml
+++ b/examples/beginner/03-secret-copy/katalog.yaml
@@ -16,11 +16,7 @@ metadata:
 spec:
   crds:
     secret-distribution:
-      apiTypes:
-        group: demo.orkestra.io
-        version: v1alpha1
-        kind: SecretDistribution
-        plural: secretdistributions
+      crdFile: ./crd.yaml
       namespaced: false             # Default: (true)
 
       operatorBox:

--- a/examples/beginner/03b-bonus-configmap-copy/katalog.yaml
+++ b/examples/beginner/03b-bonus-configmap-copy/katalog.yaml
@@ -12,11 +12,7 @@ metadata:
 spec:
   crds:
     configmap-distribution:
-      apiTypes:
-        group: demo.orkestra.io
-        version: v1alpha1
-        kind: ConfigMapDistribution
-        plural: configmapdistributions
+      crdFile: ./crd.yaml
       namespaced: false             # Default: (true)
 
       operatorBox:

--- a/examples/intermediate/04-multi-resource/katalog.yaml
+++ b/examples/intermediate/04-multi-resource/katalog.yaml
@@ -11,12 +11,7 @@ metadata:
 spec:
   crds:
     application:
-      apiTypes:
-        group: demo.orkestra.io
-        version: v1alpha1
-        kind: Application
-        plural: applications
-
+      crdFile: ./crd.yaml
       workers: 3
       resync: 15s
 

--- a/examples/intermediate/05-when-conditions/katalog.yaml
+++ b/examples/intermediate/05-when-conditions/katalog.yaml
@@ -12,12 +12,7 @@ metadata:
 spec:
   crds:
     platform:
-      apiTypes:
-        group: demo.orkestra.io
-        version: v1alpha1
-        kind: Platform
-        plural: platforms
-
+      crdFile: ./crd.yaml
       operatorBox:
         default: true
 

--- a/examples/intermediate/07-crd-file/README.md
+++ b/examples/intermediate/07-crd-file/README.md
@@ -1,0 +1,133 @@
+# 07 — CRD File
+
+Declare the path to your CRD YAML inside the Katalog. When you run
+`ork run` outside the cluster, Orkestra automatically applies the CRD
+files before starting reconcile loops — no manual `kubectl apply` step needed.
+
+**What you learn:** `crdFile` field in `spec.crds`, automatic CRD pre-application
+in dev mode, managing multiple CRDs each with their own file.
+
+**Builds on:** [06 — Basic Komposer](../06-komposer-basic/README.md)
+
+---
+
+## What is new
+
+**`crdFile`** — each CRD entry in the Katalog can declare the path to its
+CRD YAML:
+
+```yaml
+spec:
+  crds:
+    app:
+      apiTypes:
+        group: crdfile.orkestra.io
+        version: v1alpha1
+        kind: App
+        plural: apps
+      crdFile: ./crd-app.yaml
+```
+
+When `ork run` starts outside the cluster, it reads all `crdFile` paths and
+runs `kubectl apply -f <path>` for each one before initialising any reconciler.
+Your CRDs are guaranteed to exist before the operator begins watching for CRs.
+
+This example has two CRDs — `App` and `Database` — each with its own file.
+
+---
+
+## Steps
+
+### 1. Validate
+
+```bash
+ork validate --file katalog.yaml
+```
+
+Expected:
+```
+✓ app
+    kind: App
+    group: crdfile.orkestra.io / version: v1alpha1 / plural: apps
+    crdFile: ./crd-app.yaml
+    mode: dynamic / workers: 2 / resync: 30s
+
+✓ database
+    kind: Database
+    group: crdfile.orkestra.io / version: v1alpha1 / plural: databases
+    crdFile: ./crd-database.yaml
+    mode: dynamic / workers: 1 / resync: 60s
+```
+
+### 2. Start the operator
+
+```bash
+ork run --file katalog.yaml
+```
+
+Watch the startup logs. You will see two lines like:
+
+```
+INF crdFile applied crd=app path=.../crd-app.yaml
+INF crdFile applied crd=database path=.../crd-database.yaml
+```
+
+Both CRDs are installed automatically. No separate `kubectl apply -f crd-*.yaml`
+step is needed.
+
+### 3. Apply the CRs
+
+In a second terminal:
+
+```bash
+kubectl apply -f cr-app.yaml
+kubectl apply -f cr-database.yaml
+```
+
+### 4. Verify
+
+```bash
+kubectl get apps
+kubectl get databases
+```
+
+Expected (after a moment):
+```
+NAME      IMAGE                PHASE
+my-app    nginx:stable-alpine  Running
+
+NAME          ENGINE    STORAGE   PHASE
+my-database   postgres  5Gi       Running
+```
+
+### 5. Inspect the running state
+
+```bash
+curl localhost:8080/katalog | jq '.crds[] | {name: .name, workers: .workers, resync: .resync}'
+```
+
+Both CRDs are running in the same Orkestra instance.
+
+---
+
+## Without crdFile
+
+Without this feature, the typical flow is:
+
+```bash
+kubectl apply -f crd-app.yaml
+kubectl apply -f crd-database.yaml
+ork run --file katalog.yaml
+kubectl apply -f cr-app.yaml
+```
+
+With `crdFile`, the operator owns its CRD lifecycle in dev mode. The Katalog
+is self-contained — you hand it off and it just works.
+
+---
+
+## Cleanup
+
+```bash
+chmod +x cleanup.sh && ./cleanup.sh
+```

--- a/examples/intermediate/07-crd-file/cleanup.sh
+++ b/examples/intermediate/07-crd-file/cleanup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "Cleaning up 07-crd-file..."
+
+kubectl delete -f cr-app.yaml      --ignore-not-found
+kubectl delete -f cr-database.yaml --ignore-not-found
+kubectl delete -f crd-app.yaml     --ignore-not-found
+kubectl delete -f crd-database.yaml --ignore-not-found
+
+echo "✓ Done. Stop 'ork run' with Ctrl+C if still running."

--- a/examples/intermediate/07-crd-file/cr-app.yaml
+++ b/examples/intermediate/07-crd-file/cr-app.yaml
@@ -1,0 +1,8 @@
+apiVersion: crdfile.orkestra.io/v1alpha1
+kind: App
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  image: nginx:stable-alpine
+  replicas: 1

--- a/examples/intermediate/07-crd-file/cr-database.yaml
+++ b/examples/intermediate/07-crd-file/cr-database.yaml
@@ -1,0 +1,8 @@
+apiVersion: crdfile.orkestra.io/v1alpha1
+kind: Database
+metadata:
+  name: my-database
+  namespace: default
+spec:
+  engine: postgres
+  storageSize: "5Gi"

--- a/examples/intermediate/07-crd-file/crd-app.yaml
+++ b/examples/intermediate/07-crd-file/crd-app.yaml
@@ -1,0 +1,43 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: apps.crdfile.orkestra.io
+spec:
+  group: crdfile.orkestra.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Image
+          type: string
+          jsonPath: .spec.image
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required: [image]
+              properties:
+                image:
+                  type: string
+                replicas:
+                  type: integer
+                  default: 1
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+  names:
+    kind: App
+    plural: apps
+    singular: app
+  scope: Namespaced

--- a/examples/intermediate/07-crd-file/crd-database.yaml
+++ b/examples/intermediate/07-crd-file/crd-database.yaml
@@ -1,0 +1,47 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: databases.crdfile.orkestra.io
+spec:
+  group: crdfile.orkestra.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Engine
+          type: string
+          jsonPath: .spec.engine
+        - name: Storage
+          type: string
+          jsonPath: .spec.storageSize
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                engine:
+                  type: string
+                  default: postgres
+                  enum: [postgres, mysql, sqlite]
+                storageSize:
+                  type: string
+                  default: "1Gi"
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+  names:
+    kind: Database
+    plural: databases
+    singular: database
+  scope: Namespaced

--- a/examples/intermediate/07-crd-file/katalog.yaml
+++ b/examples/intermediate/07-crd-file/katalog.yaml
@@ -1,0 +1,56 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: Katalog
+metadata:
+  name: crd-file-example
+  description: >
+    Two CRDs, each declaring the path to their CRD YAML via crdFile.
+    When you run ork run --file katalog.yaml outside the cluster,
+    Orkestra automatically applies both CRD files before starting
+    the reconcile loops — no manual kubectl apply step needed.
+
+spec:
+  crds:
+    app:
+      crdFile: ./crd-app.yaml     # applied automatically by ork run (dev mode)
+
+      workers: 2
+      resync: 30s
+
+      operatorBox:
+        status:
+          fields:
+            - path: phase
+              value: "Running"
+            - path: image
+              value: "{{ .spec.image }}"
+
+        onCreate:
+          deployments:
+            - image: "{{ .spec.image }}"
+              replicas: "{{ .spec.replicas }}"
+              port: 8080
+              reconcile: true
+          services:
+            - port: "80"
+              targetPort: "8080"
+
+    database:
+      crdFile: ./crd-database.yaml
+
+      workers: 1
+      resync: 60s
+
+      operatorBox:
+        status:
+          fields:
+            - path: phase
+              value: "Running"
+            - path: engine
+              value: "{{ .spec.engine }}"
+
+        onCreate:
+          configMaps:
+            - name: "{{ .metadata.name }}-db-config"
+              data:
+                ENGINE: "{{ .spec.engine }}"
+                STORAGE: "{{ .spec.storageSize }}"

--- a/examples/use-cases/rollback/01-basic-rollback/katalog.yaml
+++ b/examples/use-cases/rollback/01-basic-rollback/katalog.yaml
@@ -12,11 +12,7 @@ metadata:
 spec:
   crds:
     webapp:
-      apiTypes:
-        group: rollback.orkestra.io
-        version: v1alpha1
-        kind: WebApp
-        plural: webapps
+      crdFile: ./crd.yaml
       workers: 2
       resync: 15s
 

--- a/examples/use-cases/rollback/02-rollback-with-trigger/katalog.yaml
+++ b/examples/use-cases/rollback/02-rollback-with-trigger/katalog.yaml
@@ -13,11 +13,7 @@ metadata:
 spec:
   crds:
     apiserver:
-      apiTypes:
-        group: rollback.orkestra.io
-        version: v1alpha1
-        kind: ApiServer
-        plural: apiservers
+      crdFile: ./crd.yaml
       workers: 2
       resync: 15s
 

--- a/pkg/katalog/README.md
+++ b/pkg/katalog/README.md
@@ -35,14 +35,17 @@ NewKatalog(merger, konfig)
 Each `CRDEntry` goes through several enrichment phases before it is considered ready:
 
 1. **Parse** — decoded from YAML via the merger.
-2. **Enrich** — `EnrichCRDEntry` fills in computed fields (API path, plural, GVK).
-3. **Validate** — uniqueness, dependency graph (existence + cycle), reconciler mode.
-4. **Defaults** — workers, resync interval, namespace handling, finalizers, description.
-5. **Runtime objects** — dynamic mode → `*unstructured.Unstructured` factory; typed mode → `ObjectRegistry` lookup.
-6. **Reconcilers** — hooks from `HookRegistry`, constructors from `ReconcilerRegistry`.
-7. **Status flags** — `IgnoreStatusPatch` and `IgnoreObservedGeneration` set from `builtins.go`.
+2. **crdFile population** — if `crdFile:` is declared, `populateAPITypesFromCRDFile` reads the CRD YAML and fills `APITypes` (group, version, kind, plural) from it. `crdFile` is the source of truth and overwrites any inline `apiTypes:` block. Typed-mode fields (Object, List, Alias, Location) are preserved from the inline declaration if present.
+3. **Enrich** — `EnrichCRDEntry` fills in computed fields (API path, plural, GVK). For built-in Kubernetes kinds (Deployment, ConfigMap, etc.), group/version/plural are looked up from `builtins.go`.
+4. **Validate** — uniqueness, dependency graph (existence + cycle), reconciler mode.
+5. **Defaults** — workers, resync interval, namespace handling, finalizers, description.
+6. **Runtime objects** — dynamic mode → `*unstructured.Unstructured` factory; typed mode → `ObjectRegistry` lookup.
+7. **Reconcilers** — hooks from `HookRegistry`, constructors from `ReconcilerRegistry`.
+8. **Status flags** — `IgnoreStatusPatch` and `IgnoreObservedGeneration` set from `builtins.go`.
 
 After this pipeline, `k.enabledCRDs` contains fully-prepared entries. All runtime code reads from this map — it is never mutated after boot.
+
+Step 2 (crdFile population) runs inside `KomposeRuntimeKatalog`, before `ValidateConfig`. By the time any validation runs, `APITypes` is fully populated regardless of whether the user declared `apiTypes:` or `crdFile:` or both.
 
 ## Motif support
 
@@ -65,3 +68,4 @@ Motif YAML is loaded by `pkg/motif/loader.go` using `utils.StrictUnmarshal` (sam
 | Understand security defaults | [docs/04-security.md](docs/04-security.md) |
 | Understand built-in type handling | [docs/05-builtins.md](docs/05-builtins.md) |
 | Understand Motif validation and import expansion | [docs/06-motif-validation.md](docs/06-motif-validation.md) |
+| Understand crdFile — auto-populating APITypes from a CRD YAML | [docs/07-crd-file.md](docs/07-crd-file.md) |

--- a/pkg/katalog/crdfile.go
+++ b/pkg/katalog/crdfile.go
@@ -1,0 +1,129 @@
+package katalog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	orktypes "github.com/orkspace/orkestra/pkg/types"
+	"gopkg.in/yaml.v3"
+)
+
+// populateAPITypesFromCRDFile reads the CRD YAML declared in entry.CRDFile and
+// overwrites entry.APITypes with the values parsed from the file.
+//
+// crdFile is the source of truth — any apiTypes already declared on the entry
+// are replaced. This is called in the enrichment loop in KomposeRuntimeKatalog,
+// before EnrichCRDEntry, so the entry is fully specified by the time
+// isFullySpecified runs.
+//
+// Remote URLs (http/https) are left untouched — kubectl handles those at runtime.
+func populateAPITypesFromCRDFile(entry *orktypes.CRDEntry, katalogDir string) error {
+	path := entry.CRDFile
+
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		return nil
+	}
+
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(katalogDir, path)
+	}
+
+	apiTypes, err := readAPITypesFromCRDFile(path)
+	if err != nil {
+		return fmt.Errorf("reading crdFile %q: %w", entry.CRDFile, err)
+	}
+
+	// Preserve typed-mode fields (Object, List, Alias, Location) — those come
+	// from the user's apiTypes declaration and are not present in the CRD YAML.
+	apiTypes.Object = entry.APITypes.Object
+	apiTypes.List = entry.APITypes.List
+	apiTypes.Alias = entry.APITypes.Alias
+	apiTypes.Location = entry.APITypes.Location
+	apiTypes.APIPath = entry.APITypes.APIPath
+
+	entry.APITypes = *apiTypes
+	return nil
+}
+
+// crdFileHeader is the minimal structure needed to extract apiTypes from a CRD YAML.
+type crdFileHeader struct {
+	Kind string `yaml:"kind"`
+	Spec struct {
+		Group string `yaml:"group"`
+		Names struct {
+			Kind   string `yaml:"kind"`
+			Plural string `yaml:"plural"`
+		} `yaml:"names"`
+		Versions []struct {
+			Name    string `yaml:"name"`
+			Served  bool   `yaml:"served"`
+			Storage bool   `yaml:"storage"`
+		} `yaml:"versions"`
+	} `yaml:"spec"`
+}
+
+// readAPITypesFromCRDFile reads a CRD YAML file and extracts APITypes.
+func readAPITypesFromCRDFile(path string) (*orktypes.APITypes, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read file: %w", err)
+	}
+
+	var doc crdFileHeader
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("invalid YAML: %w", err)
+	}
+
+	if doc.Kind != "CustomResourceDefinition" {
+		return nil, fmt.Errorf("expected kind: CustomResourceDefinition, got %q", doc.Kind)
+	}
+	if doc.Spec.Group == "" {
+		return nil, fmt.Errorf("spec.group is missing")
+	}
+	if doc.Spec.Names.Kind == "" {
+		return nil, fmt.Errorf("spec.names.kind is missing")
+	}
+	if doc.Spec.Names.Plural == "" {
+		return nil, fmt.Errorf("spec.names.plural is missing")
+	}
+	if len(doc.Spec.Versions) == 0 {
+		return nil, fmt.Errorf("spec.versions is empty")
+	}
+
+	version := selectCRDVersion(doc.Spec.Versions)
+	if version == "" {
+		return nil, fmt.Errorf("no served or storage version found")
+	}
+
+	return &orktypes.APITypes{
+		Group:   doc.Spec.Group,
+		Version: version,
+		Kind:    doc.Spec.Names.Kind,
+		Plural:  doc.Spec.Names.Plural,
+	}, nil
+}
+
+// selectCRDVersion picks the version name from the CRD's version list.
+// Priority: storage: true → served: true → first in list.
+func selectCRDVersion(versions []struct {
+	Name    string `yaml:"name"`
+	Served  bool   `yaml:"served"`
+	Storage bool   `yaml:"storage"`
+}) string {
+	for _, v := range versions {
+		if v.Storage {
+			return v.Name
+		}
+	}
+	for _, v := range versions {
+		if v.Served {
+			return v.Name
+		}
+	}
+	if len(versions) > 0 {
+		return versions[0].Name
+	}
+	return ""
+}

--- a/pkg/katalog/debug.go
+++ b/pkg/katalog/debug.go
@@ -1,0 +1,26 @@
+package katalog
+
+import (
+	"github.com/orkspace/orkestra/pkg/logger"
+)
+
+// Debug katalog information from merger
+func (k *Katalog) DebugKatalogInformation() {
+	// [DEBUG] Contents of k.Security
+	logger.Debug().Interface("katalog security", k.Security).Msg("katalog security")
+
+	// [DEBUG] Contents of k.Notiication
+	logger.Debug().Interface("katalog notification", k.Notification).Msg("katalog notification")
+
+	// [DEBUG] Contents of k.Providers
+	logger.Debug().Interface("katalog providers", k.Providers).Msg("katalog providers")
+
+	// [DEBUG] Contents of k.Spec
+	logger.Debug().Interface("katalog spec", k.Spec).Msg("katalog spec")
+
+	// [DEBUG] Contents of k.enabledCRDs
+	logger.Debug().Interface("katalog enabledCRDs", k.enabledCRDs).Msg("katalog enabledCRDs")
+
+	// [DEBUG] Contents of k.metadata
+	logger.Debug().Interface("katalog metadata", k.metadata).Msg("katalog metadata")
+}

--- a/pkg/katalog/docs/07-crd-file.md
+++ b/pkg/katalog/docs/07-crd-file.md
@@ -1,0 +1,73 @@
+# 07 — crdFile: Auto-populating APITypes from a CRD YAML
+
+## What it does
+
+When a Katalog CRD entry declares `crdFile:`, Orkestra reads the referenced CRD YAML
+and extracts `group`, `version`, `kind`, and `plural` from it automatically. The
+`apiTypes:` block becomes optional for custom CRDs — the CRD file itself is the source
+of truth.
+
+```yaml
+spec:
+  crds:
+    website:
+      crdFile: ./crd.yaml   # apiTypes populated automatically from this file
+      workers: 2
+      operatorBox:
+        # ...
+```
+
+## Where it fits in the lifecycle
+
+crdFile population runs in `KomposeRuntimeKatalog`, **before** `EnrichCRDEntry` is
+called. By the time any validation step runs, `APITypes` is fully populated.
+
+```
+merger.Merge()
+  ↓
+KomposeRuntimeKatalog
+  ├─ populateAPITypesFromCRDFile (crdfile.go) ← reads CRD YAML, fills APITypes
+  └─ EnrichCRDEntry (enrichment.go)           ← sees fully-specified APITypes, skips built-in lookup
+  ↓
+ValidateConfig
+  ├─ setGroupVersionKind                      ← APITypes already set, just copies to GVK fields
+  └─ ...
+```
+
+## Source of truth rules
+
+- If only `crdFile:` is declared → APITypes come entirely from the CRD YAML.
+- If both `apiTypes:` and `crdFile:` are declared → `crdFile` wins on `group`, `version`,
+  `kind`, `plural`. Typed-mode fields (`object`, `objectList`, `alias`, `location`) come
+  from the inline `apiTypes:` declaration and are preserved.
+- Remote URLs (`http://`, `https://`) are passed through unchanged — kubectl handles them
+  at runtime.
+
+## Version selection
+
+When a CRD declares multiple versions, `populateAPITypesFromCRDFile` picks:
+
+1. The version with `storage: true` (canonical API version)
+2. The first version with `served: true` (fallback)
+3. The first version in the list (last resort)
+
+## Dev-mode only
+
+`crdFile` auto-applies the CRD at `ork run` startup via `applyCRDFilesIfNeeded` in
+`cmd/cli/run_dev.go`. This function is behind `//go:build !runtime` and only runs when
+`!utils.IsRunningInCluster()` — it never executes inside a Helm-deployed Orkestra.
+
+For Helm-based deployments, the CRD must be pre-installed (`kubectl apply -f crd.yaml`)
+before deploying the Orkestra chart. The `crdFile` field is still valid in the Katalog
+(APITypes are still populated from it) — only the auto-apply step is skipped.
+
+## Implementation
+
+| File | Role |
+|------|------|
+| `pkg/katalog/crdfile.go` | `populateAPITypesFromCRDFile`, `readAPITypesFromCRDFile`, `selectCRDVersion` |
+| `pkg/katalog/parser.go` | calls `populateAPITypesFromCRDFile` in the enrichment loop in `KomposeRuntimeKatalog` |
+| `cmd/cli/run_dev.go` | `applyCRDFilesIfNeeded` — applies CRD files before starting reconcilers (dev only) |
+| `pkg/merger/merger.go` | `FirstEntryDir()` — returns the directory of the first entry point for relative path resolution |
+
+→ Back to: [README.md](../README.md)

--- a/pkg/katalog/parser.go
+++ b/pkg/katalog/parser.go
@@ -2,8 +2,9 @@
 package katalog
 
 import (
+	"fmt"
+
 	"github.com/orkspace/orkestra/pkg/konfig"
-	"github.com/orkspace/orkestra/pkg/logger"
 	"github.com/orkspace/orkestra/pkg/merger"
 	orktypes "github.com/orkspace/orkestra/pkg/types"
 )
@@ -24,16 +25,22 @@ func (k *Katalog) KomposeRuntimeKatalog(kfg *konfig.Konfig, m *merger.Merger, pa
 	k.APIVersion = m.APIMetadata().APIVersion
 	k.Kind = m.APIMetadata().Kind
 	k.konfig = kfg
+	k.katalogDir = m.FirstEntryDir()
 
 	// Debug
 	// comment after use
 	// k.DebugKatalogInformation()
 
-	// Enrich enabled CRDs
-	// Switching from slice to map — must copy back since map values are not addressable
 	for name, entry := range k.enabledCRDs {
-		// logger.Debug().Str("name", name).
-		// 	Msgf("enriching %s", name)
+		// Populate APITypes from crdFile before enrichment so isFullySpecified sees
+		// the correct values. crdFile is the source of truth — overwrites any apiTypes.
+		if entry.CRDFile != "" {
+			if err := populateAPITypesFromCRDFile(&entry, k.katalogDir); err != nil {
+				return nil, fmt.Errorf("CRD %q: %w", name, err)
+			}
+		}
+
+		// Enrich enabled CRDs
 		outcome, err := EnrichCRDEntry(&entry)
 		if err != nil {
 			return nil, err
@@ -206,25 +213,4 @@ func (k *Katalog) ValidateConfig(kfg *konfig.Konfig) (*Katalog, error) {
 	}
 
 	return k, nil
-}
-
-// Debug katalog information from merger
-func (k *Katalog) DebugKatalogInformation() {
-	// [DEBUG] Contents of k.Security
-	logger.Debug().Interface("katalog security", k.Security).Msg("katalog security")
-
-	// [DEBUG] Contents of k.Notiication
-	logger.Debug().Interface("katalog notification", k.Notification).Msg("katalog notification")
-
-	// [DEBUG] Contents of k.Providers
-	logger.Debug().Interface("katalog providers", k.Providers).Msg("katalog providers")
-
-	// [DEBUG] Contents of k.Spec
-	logger.Debug().Interface("katalog spec", k.Spec).Msg("katalog spec")
-
-	// [DEBUG] Contents of k.enabledCRDs
-	logger.Debug().Interface("katalog enabledCRDs", k.enabledCRDs).Msg("katalog enabledCRDs")
-
-	// [DEBUG] Contents of k.metadata
-	logger.Debug().Interface("katalog metadata", k.metadata).Msg("katalog metadata")
 }

--- a/pkg/katalog/type.go
+++ b/pkg/katalog/type.go
@@ -33,6 +33,7 @@ type Katalog struct {
 	// Internal — enabledCRDs is enriched and validated; Spec.CRDs holds all (including disabled)
 	metadata           orktypes.KatalogMeta         `yaml:"-" json:"-"`
 	enabledCRDs        map[string]orktypes.CRDEntry `yaml:"-" json:"-"`
+	katalogDir         string                       `yaml:"-" json:"-"`
 	conversionRegistry *InMemoryConversionRegistry
 	admissionRegistry  *InMemoryAdmissionRegistry
 

--- a/pkg/katalog/validate.go
+++ b/pkg/katalog/validate.go
@@ -160,7 +160,10 @@ func (k *Katalog) setGroupVersionKind() error {
 		}
 
 		if crd.GroupVersionKind.Empty() {
-			return fmt.Errorf("CRD '%s': missing required fields: apiTypes.group, apiTypes.version, apiTypes.kind", name)
+			if crd.CRDFile != "" {
+				return fmt.Errorf("CRD '%s': could not determine group/version/kind from crdFile %q", name, crd.CRDFile)
+			}
+			return fmt.Errorf("CRD '%s': missing required fields: apiTypes.group, apiTypes.version, apiTypes.kind (or declare crdFile: to read these from the CRD YAML)", name)
 		}
 
 		if crd.GroupVersion.Empty() {

--- a/pkg/merger/merger.go
+++ b/pkg/merger/merger.go
@@ -14,6 +14,7 @@ package merger
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/orkspace/orkestra/pkg/konfig"
 	"github.com/orkspace/orkestra/pkg/logger"
@@ -137,6 +138,9 @@ func mergeCRDEntry(base, override orktypes.CRDEntry) orktypes.CRDEntry {
 	if override.APITypes.Kind != "" {
 		result.APITypes = override.APITypes
 	}
+	if override.CRDFile != "" {
+		result.CRDFile = override.CRDFile
+	}
 
 	// ── Enabled ───────────────────────────────────────────────────────────
 	// Only override if explicitly set to false — zero value (true) means
@@ -164,11 +168,6 @@ func mergeCRDEntry(base, override orktypes.CRDEntry) orktypes.CRDEntry {
 	if override.Namespace != "" {
 		result.Namespace = override.Namespace
 	}
-
-	// ── Critical ──────────────────────────────────────────────────────────
-	// if override.IsCritical() {
-	// 	result.Critical = override.Critical
-	// }
 
 	// ── Dependencies ──────────────────────────────────────────────────────
 	// Override replaces entirely if declared — partial dependency override
@@ -347,6 +346,15 @@ func (m *Merger) ToProjectInfo() *orktypes.ProjectInfo {
 func (m *Merger) APIMetadata() apiMetadata {
 	m.mustBeMerged()
 	return m.apiMetadata
+}
+
+// FirstEntryDir returns the directory of the first entry point path.
+// Used by the Katalog parser to resolve relative crdFile paths.
+func (m *Merger) FirstEntryDir() string {
+	if len(m.entryPoints) == 0 {
+		return ""
+	}
+	return filepath.Dir(m.entryPoints[0])
 }
 
 func (m *Merger) SetRegistryURL(url string) {

--- a/pkg/types/methods.go
+++ b/pkg/types/methods.go
@@ -299,6 +299,12 @@ func (c *CRDEntry) HasRollbackRules() bool {
 	return c.OperatorBox.Rollback != nil || c.OperatorBox.RollBackOnError
 }
 
+// HasCRDFile reports whether this CRDEntry declares a CRD file
+// to be auto-applied before the operator starts.
+func (c *CRDEntry) HasCRDFile() bool {
+	return c != nil && c.CRDFile != ""
+}
+
 // NotificationEnabled reports whether this CRD declares the notification block
 // Enabled by default
 func (c *CRDEntry) IsNotificationEnabled() bool {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -2397,6 +2397,17 @@ type CRDEntry struct {
 	// See APITypes for full field documentation.
 	APITypes APITypes `yaml:"apiTypes" json:"apiTypes" validate:"required"`
 
+	// CRDFile is the path to the CRD YAML file to apply before operator start.
+	// Supports relative (resolved from katalog file location), absolute, or
+	// remote (https://…) paths.
+	//
+	// Only applied when running outside the cluster (dev mode via ork run).
+	// In production, CRDs must be pre-applied by the platform operator.
+	//
+	// During ork validate, the file is read and its group/kind are checked
+	// against apiTypes to catch mismatches before deployment.
+	CRDFile string `yaml:"crdFile,omitempty" json:"crdFile,omitempty"`
+
 	// ── Runtime objects ───────────────────────────────────────────────────────
 	// Set by addRuntimeObjects() during Katalog validation. Never set from YAML.
 	//


### PR DESCRIPTION
This PR introduces a major simplification to the Orkestra development workflow by making **CRDs first‑class, auto‑applied, and schema‑driven**. The result is a dramatically cleaner “happy path” for operator authors, especially in `ork run` in dev mode.

---

## Summary

This change adds support for `crdFile:` in `spec.crds` and uses the CRD itself as the **single source of truth** for API types. When a CRD file is provided, Orkestra:

- auto‑applies the CRD before starting the runtime  
- infers `group`, `version`, `kind`, and `plural` directly from the CRD  
- eliminates the need for explicit `apiTypes` definitions  
- enables CRD override in Komposer without duplication  
- updates all examples to use `crd.yaml` instead of manual API type declarations  

In dev mode, Orkestra now fully bootstraps itself:

- spins up a kind cluster if none exists  
- applies all CRDs referenced via `crdFile:`  
- starts the Orkestra runtime  
- launches into a clean, green Control Center  

This is now the default, frictionless operator authoring experience.

---

## What’s Included

### 1. `crdFile:` support in Katalog `spec.crds`
A CRD entry can now declare:

```yaml
spec:
  crds:
    website:
      crdFile: website-crd.yaml
```

When present, Orkestra:

- applies the CRD (best effort)
- parses the CRD to infer API types
- uses the inferred API for watcher setup and reconciliation

### 2. CRD auto‑apply in `ork run`
Before starting the runtime:

- collect all CRD files
- apply them server‑side
- wait for CRDs to be established

This removes the last manual step in dev workflows.

### 3. kind cluster auto‑creation
If no cluster is available, `ork run --dev` now:

- creates a kind cluster
- applies CRDs
- starts Orkestra

### 4. Updated examples
All examples that previously showed:

```yaml
apiTypes:
  group: ...
  version: ...
  kind: ...
  plural: ...
```

have been updated to reference `crd.yaml` instead.

This reflects the new, simplified happy path.

### 5. Komposer CRD override remains supported
If a Komposer overrides a CRD:

```yaml
spec:
  crds:
    website:
      crdFile: ./custom-crd.yaml
```

Orkestra uses the override CRD as the API contract.