### PR TITLE
Gateway Auto‑Detection + Setup Support + Helm Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,7 @@ test-fixture-note:
 	@bash scripts/setup-kind.sh $(FIXTURE_NOTE_CLUSTER)
 	@kubectl apply -f pkg/note/fixture/crd.yaml
 	@ork generate bundle --file pkg/note/fixture/katalog.yaml | kubectl apply -f -
-	@helm install orkestra $(HELM_CHART) --namespace default --wait --timeout 120s
+	@helm install orkestra $(HELM_CHART) --namespace orkestra-system --wait --timeout 120s
 	@kubectl apply -f pkg/note/fixture/cr.yaml
 	@kubectl wait reconcilerprobe/my-probe --for=jsonpath='{.status.phase}'=Ready \
 	    --timeout=120s 2>/dev/null || kubectl wait noteprobe/my-probe \
@@ -312,7 +312,7 @@ test-fixture-reconciler:
 	@bash scripts/setup-kind.sh $(FIXTURE_RECONCILER_CLUSTER)
 	@kubectl apply -f pkg/reconciler/fixture/crd.yaml
 	@ork generate bundle --file pkg/reconciler/fixture/katalog.yaml | kubectl apply -f -
-	@helm install orkestra $(HELM_CHART) --namespace default --wait --timeout 120s
+	@helm install orkestra $(HELM_CHART) --namespace orkestra-system --wait --timeout 120s
 	@kubectl apply -f pkg/reconciler/fixture/cr.yaml
 	@kubectl wait reconcilerprobe/probe --for=jsonpath='{.status.tier}'=premium \
 	    --timeout=120s || kubectl get reconcilerprobe probe -o yaml

--- a/charts/orkestra/templates/_helpers.tpl
+++ b/charts/orkestra/templates/_helpers.tpl
@@ -91,6 +91,22 @@ Returns the name of the ConfigMap containing the Katalog definition.
 
 {{/*
 ─────────────────────────────────────────────────────────────────────────────
+GATEWAY HELPER FUNCTION
+─────────────────────────────────────────────────────────────────────────────
+{{/*
+Gateway image — respects tag override, falls back to appVersion.
+Returns the full container image URL for the Orkestra gateway.
+*/}}
+{{- define "orkestra.gatewayImage" -}}
+{{- if .Values.gateway.image.tag }}
+{{- printf "%s:%s" .Values.gateway.image.repository .Values.gateway.image.tag }}
+{{- else }}
+{{- printf "%s:%s" .Values.gateway.image.repository .Chart.AppVersion }}
+{{- end }}
+{{- end }}
+
+{{/*
+─────────────────────────────────────────────────────────────────────────────
 CONTROL CENTER HELPER FUNCTIONS
 ─────────────────────────────────────────────────────────────────────────────
 */}}

--- a/charts/orkestra/templates/gateway-deployment.yaml
+++ b/charts/orkestra/templates/gateway-deployment.yaml
@@ -44,7 +44,7 @@ spec:
 
       containers:
         - name: gateway
-          image: {{ include "orkestra.runtimeImage" . }}
+          image: {{ include "orkestra.gatewayImage" . }}
           imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.gateway.securityContext | nindent 12 }}

--- a/cmd/cli/deploy.go
+++ b/cmd/cli/deploy.go
@@ -45,7 +45,6 @@ to the cluster, and patch the CR to trigger a rolling deploy.
 		clean, _ := cmd.Flags().GetBool("clean")
 		orkestraVersion, _ := cmd.Flags().GetString("orkestra-version")
 		values, _ := cmd.Flags().GetString("values")
-		upgradeOrkestra, _ := cmd.Flags().GetBool("upgrade-orkestra")
 		dev, _ := cmd.Flags().GetBool("dev")
 		enableMetrics, _ := cmd.Flags().GetBool("enable-metrics")
 		expose, _ := cmd.Flags().GetBool("expose")
@@ -106,7 +105,6 @@ to the cluster, and patch the CR to trigger a rolling deploy.
 				clean:           clean,
 				values:          values,
 				orkestraVersion: orkestraVersion,
-				upgradeOrkestra: upgradeOrkestra,
 				expose:          expose,
 				tunnelProvider:  tunnelProvider,
 				tunnelToken:     tunnelToken,
@@ -313,20 +311,9 @@ to the cluster, and patch the CR to trigger a rolling deploy.
 			repoAdd.Stderr = os.Stderr
 			_ = repoAdd.Run()
 
-			if upgradeOrkestra {
-				updateRepo := exec.Command("helm", "repo", "update", doctor.Orkestra)
-				updateRepo.Stdout = os.Stdout
-				updateRepo.Stderr = os.Stderr
-				if err := updateRepo.Run(); err != nil {
-					return fmt.Errorf("updating Orkestra repo: %w", err)
-				}
-			}
-
-			if !doctor.OrkestraInstalled() || upgradeOrkestra {
+			if !doctor.OrkestraInstalled() {
 				fmt.Println("  ⠸ Installing Orkestra...")
-				if err := doctor.InstallOrUpgradeOrkestra(
-					orkestraVersion, helmValues, upgradeOrkestra,
-				); err != nil {
+				if err := doctor.InstallOrUpgradeOrkestra(orkestraVersion, helmValues, ""); err != nil {
 					return err
 				}
 				fmt.Printf("  %s Orkestra installed", utils.SuccessMark())
@@ -410,7 +397,6 @@ type deployContext struct {
 	clean           bool
 	values          string
 	orkestraVersion string
-	upgradeOrkestra bool
 	expose          bool
 	tunnelProvider  string
 	tunnelToken     string
@@ -621,9 +607,9 @@ func deployMultiApp(dc deployContext) error {
 		repoAdd.Stderr = os.Stderr
 		_ = repoAdd.Run()
 
-		if !doctor.OrkestraInstalled() || dc.upgradeOrkestra {
+		if !doctor.OrkestraInstalled() {
 			fmt.Println("  ⠸ Installing Orkestra...")
-			if err := doctor.InstallOrUpgradeOrkestra(dc.orkestraVersion, helmValues, dc.upgradeOrkestra); err != nil {
+			if err := doctor.InstallOrUpgradeOrkestra(dc.orkestraVersion, helmValues, ""); err != nil {
 				return err
 			}
 			fmt.Printf("  %s Orkestra installed", utils.SuccessMark())

--- a/cmd/cli/init.go
+++ b/cmd/cli/init.go
@@ -64,7 +64,7 @@ func initCanonical(name string) error {
 	fmt.Printf("Initialising %s...\n\n", utils.Bold(label))
 
 	steps := []initStep{}
-	if name != "." {
+	if !isCurrentDirectory(name) {
 		steps = append(steps, initStep{"Creating project folder", func() error { return os.MkdirAll(name, 0755) }})
 	}
 	steps = append(steps, initStep{"Writing katalog.yaml", func() error { return extractCanonical(name) }})
@@ -74,7 +74,7 @@ func initCanonical(name string) error {
 	}
 
 	fmt.Printf("\n%s\n\n", utils.Green("✓ Project ready: "+label))
-	if name != "." {
+	if !isCurrentDirectory(name) {
 		fmt.Printf("  cd %s\n", name)
 	}
 	fmt.Printf("  ork run\n\n")
@@ -87,7 +87,7 @@ func initCanonical(name string) error {
 // nameLabel returns the display name for a project path.
 // When initialising in the current directory, it uses the directory's base name.
 func nameLabel(name string) string {
-	if name != "." {
+	if !isCurrentDirectory(name) {
 		return name
 	}
 	cwd, err := os.Getwd()
@@ -99,15 +99,24 @@ func nameLabel(name string) string {
 
 func initProject(name, pack string, refresh bool) error {
 
+	p, ok := GetPack(pack)
+	if !ok {
+		return fmt.Errorf("unknown pack: %s", pack)
+	}
+	first := p.firstExample()
+
 	printBanner()
+	label := nameLabel(name)
+	ver := version.Version // ldflags
+	if name == "." {
+		name = label
+	}
+
 	fmt.Printf("Initialising %s using '%s' example pack...\n\n",
 		utils.Bold(name), pack)
 
-	label := nameLabel(name)
-	ver := version.Version // ldflags
-
 	steps := []initStep{}
-	if name != "." {
+	if !isCurrentDirectory(name) {
 		steps = append(steps, initStep{"Creating project folder", func() error { return os.MkdirAll(name, 0755) }})
 	}
 
@@ -127,20 +136,22 @@ func initProject(name, pack string, refresh bool) error {
 	}
 
 	fmt.Printf("\n%s\n\n", utils.Green("✓ Project ready: "+label))
-	fmt.Printf("\n%s\n\n", utils.Green("✓ Project ready: "+label))
-	if name != "." {
-		fmt.Printf("  cd %s\n", name)
-	}
-	fmt.Printf("  ls %s/\n\n", pack)
-	fmt.Println("To run an example:")
-	if name != "." {
-		fmt.Printf("  cd %s/%s/01-hello-website\n", name, pack)
+
+	fmt.Println("To run the first example:")
+	if !isCurrentDirectory(name) {
+		fmt.Printf("  cd %s/%s/%s\n", name, pack, first)
 	} else {
-		fmt.Printf("  cd %s/01-hello-website\n", pack)
+		fmt.Printf("  cd %s/%s\n", pack, first)
 	}
-	fmt.Printf("  ork run\n\n")
+
+	if p.isBeginnerPack() {
+		fmt.Printf("  ork run\n\n")
+	} else {
+		fmt.Printf("  Follow the steps in the README\n\n")
+	}
+
 	fmt.Println("Control Center:")
-	fmt.Printf("  ork control    # opens localhost:8081\n\n")
+	fmt.Printf("  ork control    # open localhost:8081 (username:password → orkestra)\n\n")
 
 	return nil
 }

--- a/cmd/cli/init_helper.go
+++ b/cmd/cli/init_helper.go
@@ -327,3 +327,8 @@ func runSteps(steps []initStep) error {
 func printBanner() {
 	fmt.Printf("\n%s\n\n", utils.Green(utils.OrkestraLogoCLI))
 }
+
+// isCurrentDirectory reports whether the project name is "."
+func isCurrentDirectory(name string) bool {
+	return name == "."
+}

--- a/cmd/cli/init_packs.go
+++ b/cmd/cli/init_packs.go
@@ -60,3 +60,42 @@ func ListPacks() []Pack {
 	}
 	return out
 }
+
+// Helpers
+func (p Pack) isBeginnerPack() bool     { return p.Name == "beginner" }
+func (p Pack) isCanonicalPack() bool    { return p.Name == "." }
+func (p Pack) isIntermediatePack() bool { return p.Name == "intermediate" }
+func (p Pack) isAdvancedPack() bool     { return p.Name == "advanced" }
+func (p Pack) isSecurityPack() bool     { return p.Name == "security" }
+func (p Pack) isUseCasesPack() bool     { return p.Name == "use-cases" }
+func (p Pack) isRollbackPack() bool     { return p.Name == "rollback" }
+func (p Pack) isDeveloperPack() bool    { return p.Name == "developer" }
+
+func (p Pack) firstExample() string {
+	switch {
+	case p.isBeginnerPack(), p.isCanonicalPack():
+		return "01-hello-website"
+	case p.isIntermediatePack():
+		return "04-multi-resource"
+	case p.isAdvancedPack():
+		return "07-validation-mutation"
+	case p.isSecurityPack():
+		return "admission"
+	case p.isUseCasesPack():
+		return "full-stack-app"
+	case p.isRollbackPack():
+		return "rollback"
+	case p.isDeveloperPack():
+		return "01-one-project"
+	default:
+		return ""
+	}
+}
+
+func (p Pack) String() string {
+	ex := p.firstExample()
+	if ex == "" {
+		return p.Name + " — " + p.Description
+	}
+	return p.Name + " — " + p.Description + " (start with: examples/" + p.Path + "/" + ex + ")"
+}

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -48,7 +48,7 @@ func init() {
 
 	// Global flags — always present in both runtime and dev builds
 	rootCmd.PersistentFlags().Bool("debug", false, "Enable debug logging")
-	rootCmd.PersistentFlags().StringSliceP("file", "f", nil, "Path(s) or URL(s) to crd-katalog.yaml (repeatable)")
+	rootCmd.PersistentFlags().StringSliceP("file", "f", nil, "Path(s) or URL(s) to katalog.yaml (repeatable)")
 	// Dev-only flags (--kubeconfig, --verbose) and required-flag marking for
 	// dev commands are registered in root_dev.go (//go:build !runtime).
 }

--- a/cmd/cli/run.go
+++ b/cmd/cli/run.go
@@ -27,22 +27,18 @@ import (
 // If -f is not provided, Orkestra reads katalog.yaml (or komposer.yaml) from
 // the current directory — the same convention as Docker and Compose.
 // Pass -f explicitly only when using a non-standard filename or multiple files.
-
 var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Start the Orkestra Runtime",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Resolve katalog paths
 		paths, _ := cmd.Flags().GetStringSlice("file")
-		if len(paths) == 0 {
-			paths = defaultFilePaths()
-		}
-		if len(paths) == 0 {
-			paths = kfg.Katalog().Paths()
-		}
-		if len(paths) == 0 {
-			return fmt.Errorf(errNoKatalog)
+		paths, err := resolveKatalogPaths(paths, kfg)
+		if err != nil {
+			return err
 		}
 
+		// Merge katalogs
 		m := merger.New(paths...)
 		if err := m.Merge(); err != nil {
 			return fmt.Errorf("merging katalogs: %w", err)
@@ -56,6 +52,8 @@ var runCmd = &cobra.Command{
 
 		// This is where the actual operator starts.
 		// The --dev logic will be injected via a wrapper in run_dev.go.
+
+		// Run the runtime
 		internal.KonductRuntime(kfg, m, ctx)
 		return nil
 	},

--- a/cmd/cli/run_dev.go
+++ b/cmd/cli/run_dev.go
@@ -3,17 +3,12 @@
 package cli
 
 import (
-	"context"
 	"fmt"
-	"os/exec"
-	"path/filepath"
-	"strings"
 
 	"github.com/orkspace/orkestra/cmd/internal"
 	"github.com/orkspace/orkestra/pkg/doctor"
 	"github.com/orkspace/orkestra/pkg/logger"
 	"github.com/orkspace/orkestra/pkg/merger"
-	"github.com/orkspace/orkestra/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -42,9 +37,28 @@ var runCmd = &cobra.Command{
 		} else if !doctor.ClusterReachable() {
 			fmt.Println("\n  Cannot reach Kubernetes cluster.")
 			fmt.Println("  Check your kubeconfig, or run with --dev to deploy to a local kind cluster.")
-			fmt.Println("  This will install any missing dependencies:")
-			fmt.Println("    • kubectl")
-			fmt.Println("    • helm")
+			// Confirm missing dependencies
+			var (
+				missing []string
+				helm    = doctor.HelmAvailable()
+				kubectl = doctor.KubectlAvailable()
+			)
+			if !helm {
+				missing = append(missing, "kubectl")
+			}
+			if !kubectl {
+				missing = append(missing, "helm")
+			}
+			if len(missing) > 0 {
+				text := "these missing dependencies"
+				if len(missing) == 1 {
+					text = "this missing dependency"
+				}
+				fmt.Printf("  This will install %s:\n", text)
+				for _, m := range missing {
+					fmt.Printf("    • %s\n", m)
+				}
+			}
 			fmt.Println()
 			return fmt.Errorf("cluster not reachable\n")
 		}
@@ -76,6 +90,7 @@ var runCmd = &cobra.Command{
 			applyCRDFilesIfNeeded(cmd.Context(), paths[0], m)
 			waitForCRDsEstablished(cmd.Context(), m)
 			applyCRFilesIfNeeded(cmd.Context(), paths[0], m)
+			applySetupIfNeeded(cmd.Context(), paths[0], m)
 		}
 
 		internal.KonductRuntime(kfg, m, ctx)
@@ -87,116 +102,4 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 	runCmd.Flags().StringSliceP("file", "f", nil, "Path(s) to katalog.yaml (repeatable)")
 	runCmd.Flags().Bool("dev", false, "Create a local Kind cluster if none is reachable (development only)")
-}
-
-// applyCRFilesIfNeeded applies crFiles declarations via kubectl in order before
-// the runtime starts. Only runs outside the cluster (dev mode).
-func applyCRFilesIfNeeded(ctx context.Context, katalogPath string, m *merger.Merger) {
-	if utils.IsRunningInCluster() {
-		return
-	}
-
-	katalogDir := filepath.Dir(katalogPath)
-
-	for crdName, entry := range m.All() {
-		for _, crFile := range entry.CRFiles {
-			path := crFile
-			if !filepath.IsAbs(path) && !strings.HasPrefix(path, "http") {
-				path = filepath.Join(katalogDir, path)
-			}
-
-			out, err := exec.CommandContext(ctx, "kubectl", "apply", "-f", path).CombinedOutput()
-			if err != nil {
-				logger.Warn().
-					Str("crd", crdName).
-					Str("path", path).
-					Str("output", strings.TrimSpace(string(out))).
-					Err(err).
-					Msg("crFile pre-apply failed (continuing)")
-			} else {
-				logger.Info().
-					Str("crd", crdName).
-					Str("path", path).
-					Msg("crFile applied")
-			}
-		}
-	}
-}
-
-// waitForCRDsEstablished waits for any CRDs that have crFiles to be Established
-// in the cluster before CRs are applied. Only blocks for CRDs that need it.
-func waitForCRDsEstablished(ctx context.Context, m *merger.Merger) {
-	if utils.IsRunningInCluster() {
-		return
-	}
-
-	for crdName, entry := range m.All() {
-		if len(entry.CRFiles) == 0 {
-			continue
-		}
-
-		plural := entry.APITypes.Plural
-		group := entry.APITypes.Group
-		if plural == "" || group == "" {
-			continue
-		}
-
-		crdFullName := plural + "." + group
-
-		out, err := exec.CommandContext(ctx, "kubectl", "wait",
-			"--for=condition=Established",
-			"--timeout=30s",
-			"crd/"+crdFullName,
-		).CombinedOutput()
-		if err != nil {
-			logger.Warn().
-				Str("crd", crdName).
-				Str("name", crdFullName).
-				Str("output", strings.TrimSpace(string(out))).
-				Err(err).
-				Msg("CRD not established in time — applying CRs anyway")
-		} else {
-			logger.Info().
-				Str("crd", crdName).
-				Str("name", crdFullName).
-				Msg("CRD established")
-		}
-	}
-}
-
-// applyCRDFilesIfNeeded applies any crdFile declarations via kubectl before the
-// operator starts. Only runs outside the cluster (dev mode). In production,
-// CRDs must be pre-applied by the platform operator.
-func applyCRDFilesIfNeeded(ctx context.Context, katalogPath string, m *merger.Merger) {
-	if utils.IsRunningInCluster() {
-		return
-	}
-
-	katalogDir := filepath.Dir(katalogPath)
-
-	for crdName, entry := range m.All() {
-		if entry.CRDFile == "" {
-			continue
-		}
-
-		path := entry.CRDFile
-		if !filepath.IsAbs(path) && !strings.HasPrefix(path, "http") {
-			path = filepath.Join(katalogDir, path)
-		}
-
-		out, err := exec.CommandContext(ctx, "kubectl", "apply", "-f", path).CombinedOutput()
-		if err != nil {
-			logger.Warn().
-				Str("crd", crdName).
-				Str("path", path).
-				Str("output", strings.TrimSpace(string(out))).
-				Err(err).
-				Msg("crdFile pre-apply failed (continuing)")
-		} else {
-			logger.Info().
-				Str("crd", crdName).
-				Str("path", path).
-				Msg("crdFile applied")
-		}
-	}
 }

--- a/cmd/cli/run_dev.go
+++ b/cmd/cli/run_dev.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/orkspace/orkestra/cmd/internal"
-	"github.com/orkspace/orkestra/pkg/doctor"
 	"github.com/orkspace/orkestra/pkg/logger"
 	"github.com/orkspace/orkestra/pkg/merger"
 	"github.com/spf13/cobra"
@@ -22,58 +21,21 @@ var runCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		dev, _ := cmd.Flags().GetBool("dev")
 
+		// Dev mode cluster creation
 		if dev {
-			if err := doctor.EnsureDependencies(); err != nil {
-				return fmt.Errorf("installing dependencies: %w", err)
+			if err := ensureClusterReady(dev); err != nil {
+				return err
 			}
-
-			if !doctor.ClusterReachable() {
-				fmt.Println("\n  Cannot reach Kubernetes cluster.")
-				fmt.Printf("  Creating local Kind cluster '%s'...\n", doctor.KindClusterName)
-				if err := doctor.EnsureKindCluster(doctor.KindClusterName); err != nil {
-					return fmt.Errorf("setting up kind cluster: %w", err)
-				}
-			}
-		} else if !doctor.ClusterReachable() {
-			fmt.Println("\n  Cannot reach Kubernetes cluster.")
-			fmt.Println("  Check your kubeconfig, or run with --dev to deploy to a local kind cluster.")
-			// Confirm missing dependencies
-			var (
-				missing []string
-				helm    = doctor.HelmAvailable()
-				kubectl = doctor.KubectlAvailable()
-			)
-			if !helm {
-				missing = append(missing, "kubectl")
-			}
-			if !kubectl {
-				missing = append(missing, "helm")
-			}
-			if len(missing) > 0 {
-				text := "these missing dependencies"
-				if len(missing) == 1 {
-					text = "this missing dependency"
-				}
-				fmt.Printf("  This will install %s:\n", text)
-				for _, m := range missing {
-					fmt.Printf("    • %s\n", m)
-				}
-			}
-			fmt.Println()
-			return fmt.Errorf("cluster not reachable\n")
 		}
 
+		// Resolve katalog paths
 		paths, _ := cmd.Flags().GetStringSlice("file")
-		if len(paths) == 0 {
-			paths = defaultFilePaths()
-		}
-		if len(paths) == 0 {
-			paths = kfg.Katalog().Paths()
-		}
-		if len(paths) == 0 {
-			return fmt.Errorf(errNoKatalog)
+		paths, err := resolveKatalogPaths(paths, kfg.Katalog().Paths())
+		if err != nil {
+			return err
 		}
 
+		// Merge katalogs
 		m := merger.New(paths...)
 		if err := m.Merge(); err != nil {
 			return fmt.Errorf("merging katalogs: %w", err)
@@ -85,14 +47,12 @@ var runCmd = &cobra.Command{
 			Int("enabled", m.EnabledCount()).
 			Msg("katalogs merged")
 
-		// Apply declared crdFile and crFiles paths before handing off to the runtime.
+		// Apply declared crdFile, crFiles and setup paths before handing off to the runtime.
 		if len(paths) > 0 {
-			applyCRDFilesIfNeeded(cmd.Context(), paths[0], m)
-			waitForCRDsEstablished(cmd.Context(), m)
-			applyCRFilesIfNeeded(cmd.Context(), paths[0], m)
-			applySetupIfNeeded(cmd.Context(), paths[0], m)
+			applyPreRuntimeResources(cmd.Context(), paths[0], m)
 		}
 
+		// Run the runtime
 		internal.KonductRuntime(kfg, m, ctx)
 		return nil
 	},
@@ -100,6 +60,5 @@ var runCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(runCmd)
-	runCmd.Flags().StringSliceP("file", "f", nil, "Path(s) to katalog.yaml (repeatable)")
 	runCmd.Flags().Bool("dev", false, "Create a local Kind cluster if none is reachable (development only)")
 }

--- a/cmd/cli/run_dev_apply.go
+++ b/cmd/cli/run_dev_apply.go
@@ -1,0 +1,167 @@
+//go:build !runtime && !gateway
+
+package cli
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/orkspace/orkestra/pkg/logger"
+	"github.com/orkspace/orkestra/pkg/merger"
+	"github.com/orkspace/orkestra/pkg/utils"
+)
+
+// applyCRFilesIfNeeded applies crFiles declarations via kubectl in order before
+// the runtime starts. Only runs outside the cluster (dev mode).
+func applyCRFilesIfNeeded(ctx context.Context, katalogPath string, m *merger.Merger) {
+	if utils.IsRunningInCluster() {
+		return
+	}
+
+	katalogDir := filepath.Dir(katalogPath)
+
+	for crdName, entry := range m.All() {
+		if !entry.HasCRFiles() {
+			continue
+		}
+		for _, crFile := range entry.CRFiles {
+			path := crFile
+			if !filepath.IsAbs(path) && !strings.HasPrefix(path, "http") {
+				path = filepath.Join(katalogDir, path)
+			}
+
+			out, err := exec.CommandContext(ctx, "kubectl", "apply", "-f", path).CombinedOutput()
+			if err != nil {
+				logger.Warn().
+					Str("crd", crdName).
+					Str("path", path).
+					Str("output", strings.TrimSpace(string(out))).
+					Err(err).
+					Msg("crFile pre-apply failed (continuing)")
+			} else {
+				logger.Info().
+					Str("crd", crdName).
+					Str("path", path).
+					Msg("crFile applied")
+			}
+		}
+	}
+}
+
+// waitForCRDsEstablished waits for any CRDs that have crFiles to be Established
+// in the cluster before CRs are applied. Only blocks for CRDs that need it.
+func waitForCRDsEstablished(ctx context.Context, m *merger.Merger) {
+	if utils.IsRunningInCluster() {
+		return
+	}
+
+	for crdName, entry := range m.All() {
+		if len(entry.CRFiles) == 0 {
+			continue
+		}
+
+		plural := entry.APITypes.Plural
+		group := entry.APITypes.Group
+		if plural == "" || group == "" {
+			continue
+		}
+
+		crdFullName := plural + "." + group
+
+		out, err := exec.CommandContext(ctx, "kubectl", "wait",
+			"--for=condition=Established",
+			"--timeout=30s",
+			"crd/"+crdFullName,
+		).CombinedOutput()
+		if err != nil {
+			logger.Warn().
+				Str("crd", crdName).
+				Str("name", crdFullName).
+				Str("output", strings.TrimSpace(string(out))).
+				Err(err).
+				Msg("CRD not established in time — applying CRs anyway")
+		} else {
+			logger.Info().
+				Str("crd", crdName).
+				Str("name", crdFullName).
+				Msg("CRD established")
+		}
+	}
+}
+
+// applyCRDFilesIfNeeded applies any crdFile declarations via kubectl before the
+// operator starts. Only runs outside the cluster (dev mode). In production,
+// CRDs must be pre-applied by the platform operator.
+func applyCRDFilesIfNeeded(ctx context.Context, katalogPath string, m *merger.Merger) {
+	if utils.IsRunningInCluster() {
+		return
+	}
+
+	katalogDir := filepath.Dir(katalogPath)
+
+	for crdName, entry := range m.All() {
+		if !entry.HasCRDFile() {
+			continue
+		}
+
+		path := entry.CRDFile
+		if !filepath.IsAbs(path) && !strings.HasPrefix(path, "http") {
+			path = filepath.Join(katalogDir, path)
+		}
+
+		out, err := exec.CommandContext(ctx, "kubectl", "apply", "-f", path).CombinedOutput()
+		if err != nil {
+			logger.Warn().
+				Str("crd", crdName).
+				Str("path", path).
+				Str("output", strings.TrimSpace(string(out))).
+				Err(err).
+				Msg("crdFile pre-apply failed (continuing)")
+		} else {
+			logger.Info().
+				Str("crd", crdName).
+				Str("path", path).
+				Msg("crdFile applied")
+		}
+	}
+}
+
+// applySetupIfNeeded applies setup YAML files via kubectl in order before
+// Orkestra starts. Only runs outside the cluster (dev mode).
+func applySetupIfNeeded(ctx context.Context, katalogPath string, m *merger.Merger) {
+	if utils.IsRunningInCluster() {
+		return
+	}
+
+	katalogDir := filepath.Dir(katalogPath)
+
+	for crdName, entry := range m.All() {
+		if !entry.HasSetup() {
+			continue
+		}
+
+		for _, setupFile := range entry.Setup {
+			path := setupFile
+			if !filepath.IsAbs(path) && !strings.HasPrefix(path, "http") {
+				path = filepath.Join(katalogDir, path)
+			}
+
+			out, err := exec.CommandContext(ctx, "kubectl", "apply", "-f", path).CombinedOutput()
+			if err != nil {
+				logger.Warn().
+					Str("crd", crdName).
+					Str("path", path).
+					Str("output", strings.TrimSpace(string(out))).
+					Err(err).
+					Msg("setup pre-apply failed (continuing)")
+			} else {
+				logger.Info().
+					Str("crd", crdName).
+					Str("path", path).
+					Msg("setup applied")
+			}
+		}
+	}
+}

--- a/cmd/cli/run_dev_apply.go
+++ b/cmd/cli/run_dev_apply.go
@@ -4,14 +4,95 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"github.com/orkspace/orkestra/pkg/doctor"
 	"github.com/orkspace/orkestra/pkg/logger"
 	"github.com/orkspace/orkestra/pkg/merger"
 	"github.com/orkspace/orkestra/pkg/utils"
 )
+
+// applyPreRuntimeResources applies all pre-runtime resources declared in the
+// merged CRD entries. This includes:
+//
+//  1. CRD files      (crdFile)
+//  2. Waiting for CRDs to establish
+//  3. CR files       (crFiles) — dev mode only
+//  4. Setup files    (setup)
+//
+// All resources are applied in the correct order before the operator runtime
+// starts. Relative paths are resolved against the katalog directory. This
+// function is a no-op when running inside the cluster.
+func applyPreRuntimeResources(ctx context.Context, katalogPath string, m *merger.Merger) {
+	if utils.IsRunningInCluster() {
+		return
+	}
+
+	applyCRDFilesIfNeeded(ctx, katalogPath, m)
+	waitForCRDsEstablished(ctx, m)
+	applyCRFilesIfNeeded(ctx, katalogPath, m)
+	applySetupIfNeeded(ctx, katalogPath, m)
+}
+
+// ensureClusterReady ensures that a Kubernetes cluster is reachable before
+// starting the operator. In dev mode, this installs missing dependencies and
+// creates a local Kind cluster if needed. Outside dev mode, this reports
+// missing dependencies and unreachable cluster state to the user.
+func ensureClusterReady(dev bool) error {
+	if dev {
+		if err := doctor.EnsureDependencies(); err != nil {
+			return fmt.Errorf("installing dependencies: %w", err)
+		}
+
+		if !doctor.ClusterReachable() {
+			fmt.Println("\n  Cannot reach Kubernetes cluster.")
+			fmt.Printf("  Creating local Kind cluster '%s'...\n", doctor.KindClusterName)
+
+			if err := doctor.EnsureKindCluster(doctor.KindClusterName); err != nil {
+				return fmt.Errorf("setting up kind cluster: %w", err)
+			}
+		}
+
+		return nil
+	}
+
+	// non-dev mode
+	if doctor.ClusterReachable() {
+		return nil
+	}
+
+	fmt.Println("\n  Cannot reach Kubernetes cluster.")
+	fmt.Println("  Check your kubeconfig, or run with --dev to deploy to a local kind cluster.")
+
+	var missing []string
+	helm := doctor.HelmAvailable()
+	kubectl := doctor.KubectlAvailable()
+
+	if !kubectl {
+		missing = append(missing, "kubectl")
+	}
+	if !helm {
+		missing = append(missing, "helm")
+	}
+
+	if len(missing) > 0 {
+		text := "these missing dependencies"
+		if len(missing) == 1 {
+			text = "this missing dependency"
+		}
+
+		fmt.Printf("  This will install %s:\n", text)
+		for _, m := range missing {
+			fmt.Printf("    • %s\n", m)
+		}
+		fmt.Println()
+	}
+
+	return fmt.Errorf("cluster not reachable")
+}
 
 // applyCRFilesIfNeeded applies crFiles declarations via kubectl in order before
 // the runtime starts. Only runs outside the cluster (dev mode).

--- a/cmd/cli/run_helpers.go
+++ b/cmd/cli/run_helpers.go
@@ -1,0 +1,31 @@
+//go:build !runtime && !gateway
+
+package cli
+
+import "fmt"
+
+// resolveKatalogPaths resolves the katalog file paths in the following order:
+//
+//  1. Explicit CLI paths (highest priority)
+//  2. Default file paths in the working directory (katalog.yaml, komposer.yaml, etc.)
+//  3. Paths defined in the Konfig (kfg.Katalog().Paths())
+//
+// Returns an error if no katalog file can be resolved.
+func resolveKatalogPaths(cliPaths, cfgPaths []string) ([]string, error) {
+	// 1. CLI-provided paths
+	if len(cliPaths) > 0 {
+		return cliPaths, nil
+	}
+
+	// 2. Default file paths
+	if defaults := defaultFilePaths(); len(defaults) > 0 {
+		return defaults, nil
+	}
+
+	// 3. Config-defined paths
+	if len(cfgPaths) > 0 {
+		return cfgPaths, nil
+	}
+
+	return nil, fmt.Errorf(errNoKatalog)
+}

--- a/documentation/getting-started/index.md
+++ b/documentation/getting-started/index.md
@@ -88,7 +88,7 @@ A Deployment named `hello-website-deployment` appears. Orkestra set owner refere
 
 **Step 5 — Open the Control Center**
 
-In a third terminal:
+In a second terminal:
 
 ```bash
 ork control

--- a/documentation/reference/schema/crd-entry.md
+++ b/documentation/reference/schema/crd-entry.md
@@ -8,7 +8,9 @@ spec:
     database:                  # ← this is the name
       enabled: true
       description: string
-      crdFile: ./crd.yaml
+      crdFile: ./my-crd.yaml
+      crFiles: [./my-cr.yaml]
+      setup: [./my-setup.yaml]
 
       apiTypes:                # → apitypes.md
         ...
@@ -77,6 +79,8 @@ spec:
 | `description` | string | — | Shown in the `/katalog` endpoint. |
 | `mode` | string | auto | `typed` or `dynamic`. Auto-detected from `apiTypes.location`. |
 | `crdFile` | string | — | Path or HTTPS URL to the CRD YAML. Used for CRD-driven API inference in dev mode. |
+| ``crFiles`` | list(string) | — | Ordered list of CR YAML files to apply **after** the CRD is registered but **before** the runtime starts. Dev mode only. Supports relative paths and HTTPS URLs. |
+| ``setup`` | list(string) | — | Ordered list of YAML files to apply **before** the operator starts. Use for external dependencies such as namespaces, Secrets, or additional CRDs. Applied with ``kubectl ``apply ``-f`` in declaration order. |
 
 ## Scope
 

--- a/examples/beginner/01-hello-website/README.md
+++ b/examples/beginner/01-hello-website/README.md
@@ -48,7 +48,7 @@ Expected output:
 ## Step 2 — Start the operator
 
 ```bash
-ork run
+ork run       # add --dev if you don't have a cluster; Orkestra will create a kind cluster
 ```
 
 Orkestra reads `crdFile: ./crd.yaml`, applies the CRD and `cr.yaml` to the cluster, and starts the operator. You will see the health server start and the informer sync:
@@ -72,11 +72,10 @@ Deployment and Service being created.
 
 ## Step 4 — Open the Control Center
 
-In a third terminal:
+In a second terminal:
 
 ```bash
 ork control
-# username:password → orkestra
 # username:password → orkestra
 ```
 

--- a/examples/beginner/02-with-serviceaccount/README.md
+++ b/examples/beginner/02-with-serviceaccount/README.md
@@ -46,7 +46,7 @@ Expected output:
 ## Step 2 — Start the operator
 
 ```bash
-ork run
+ork run       # add --dev if you don't have a cluster; Orkestra will create a kind cluster
 ```
 
 Orkestra applies the CRD, waits for it to be established, applies `cr.yaml`,

--- a/examples/beginner/03-secret-copy/README.md
+++ b/examples/beginner/03-secret-copy/README.md
@@ -32,39 +32,33 @@ namespace stays in sync automatically.
 
 ## Steps
 
-### 1. Create namespaces and the source Secret
+### 1. Start the operator
 
 ```bash
-kubectl apply -f setup.yaml
+ork run       # add --dev if you don't have a cluster; Orkestra will create a kind cluster
 ```
 
-Verify:
+Orkestra reads `crdFile: ./crd.yaml`, applies the CRD, , setup file `./setup.yaml` and  `cr.yaml` to the cluster, and starts the operator.
+
+### 2. Verify CR and source Secret (optional)
 
 ```bash
+kubectl get sd -n default
 kubectl get secret database-credentials -n platform
 ```
 
-### 2. Start the operator
-
-```bash
-ork run
-```
-
-Orkestra reads `crdFile: ./crd.yaml`, applies the CRD and `cr.yaml` to the cluster, and starts the operator.
-
 ### 3. Open the Control Center
 
-In a third terminal:
+In a second terminal:
 
 ```bash
 ork control
 # username:password → orkestra
-# username:password → orkestra
 ```
 
-Open [http://localhost:8081](http://localhost:8081) to see the live operator.
+Open [http://localhost:8081](http://localhost:8081) to see the live operator, and the resources created.
 
-### 5. Verify copies exist
+### 4. Verify copies exist
 
 ```bash
 kubectl get secret database-credentials -n team-alpha
@@ -73,7 +67,7 @@ kubectl get secret database-credentials -n team-beta
 
 Both should exist and have the same data as the source.
 
-### 6. Verify owner references
+### 5. Verify owner references
 
 ```bash
 kubectl get secret database-credentials -n team-alpha -o yaml | grep -A8 ownerReferences
@@ -82,14 +76,24 @@ kubectl get secret database-credentials -n team-alpha -o yaml | grep -A8 ownerRe
 The owner is the `SecretDistribution` CR — deletion of the CR triggers
 garbage collection of all copies.
 
-### 7. Test sync (source change propagation)
+### 6. Test sync (source change propagation)
 
-Update the source Secret:
+#### Confirm the current password
+
+```bash
+kubectl get secret database-credentials -n team-alpha \
+  -o jsonpath='{.data.password}' | base64 -d && echo
+# supersecret
+```
+
+#### Update the source Secret:
 
 ```bash
 kubectl patch secret database-credentials -n platform \
   --type=merge -p '{"stringData":{"password":"newpassword"}}'
 ```
+
+#### Verify the new password
 
 Wait one resync interval (15s), then check a copy:
 
@@ -99,7 +103,7 @@ kubectl get secret database-credentials -n team-alpha \
 # newpassword
 ```
 
-### 8. Test cleanup
+### 7. Test cleanup
 
 Delete the CR and watch copies disappear:
 

--- a/examples/beginner/03-secret-copy/crd.yaml
+++ b/examples/beginner/03-secret-copy/crd.yaml
@@ -36,4 +36,6 @@ spec:
     kind: SecretDistribution
     plural: secretdistributions
     singular: secretdistribution
+    shortNames:
+      - sd
   scope: Cluster  # This is so it can distribute to all namespaces

--- a/examples/beginner/03-secret-copy/katalog.yaml
+++ b/examples/beginner/03-secret-copy/katalog.yaml
@@ -19,11 +19,11 @@ spec:
       crdFile: ./crd.yaml
       crFiles:
         - ./cr.yaml
+      setup:
+        - ./setup.yaml
       namespaced: false             # Default: (true)
 
       operatorBox:
-        default: true
-
         status:
           fields:
             - path: phase

--- a/examples/beginner/03b-bonus-configmap-copy/README.md
+++ b/examples/beginner/03b-bonus-configmap-copy/README.md
@@ -27,39 +27,33 @@ Orkestra reads the source ConfigMap and creates copies in each target namespace,
 
 ## Steps
 
-### 1. Create namespaces and the source ConfigMap
+### 1. Verify CR and source ConfigMap (optional)
 
 ```bash
-kubectl apply -f setup.yaml
-```
-
-Verify:
-
-```bash
+kubectl get cd -n default
 kubectl get configmap app-config -n platform
 ```
 
 ### 2. Start the operator
 
 ```bash
-ork run
+ork run       # add --dev if you don't have a cluster; Orkestra will create a kind cluster
 ```
 
-Orkestra reads `crdFile: ./crd.yaml`, applies the CRD and `cr.yaml` to the cluster, and starts the operator.
+Orkestra reads `crdFile: ./crd.yaml`, applies the CRD, , setup file `./setup.yaml` and  `cr.yaml` to the cluster, and starts the operator.
 
 ### 3. Open the Control Center
 
-In a third terminal:
+In a second terminal:
 
 ```bash
 ork control
 # username:password → orkestra
-# username:password → orkestra
 ```
 
-Open [http://localhost:8081](http://localhost:8081) to see the live operator.
+Open [http://localhost:8081](http://localhost:8081) to see the live operator, and the resources created.
 
-### 5. Verify copies exist
+### 4. Verify copies exist
 
 ```bash
 kubectl get configmap app-config -n team-alpha
@@ -68,7 +62,7 @@ kubectl get configmap app-config -n team-beta
 
 Both should exist and contain the same data as the source.
 
-### 6. Verify owner references
+### 5. Verify owner references
 
 ```bash
 kubectl get configmap app-config -n team-alpha -o yaml | grep -A8 ownerReferences
@@ -76,15 +70,24 @@ kubectl get configmap app-config -n team-alpha -o yaml | grep -A8 ownerReference
 
 The owner is the `ConfigMapDistribution` CR — deletion of the CR triggers garbage collection of all copies.
 
-### 7. Test sync (source change propagation)
+### 6. Test sync (source change propagation)
 
 Update the source ConfigMap from loglevel 'info' to 'debug':
+
+#### Confirm the current log level
+```bash
+kubectl get configmap app-config -n team-alpha -o jsonpath='{.data.logLevel}' && echo
+# info
+```
+
+#### Update the source ConfigMap
 
 ```bash
 kubectl patch configmap app-config -n platform \
   --type=merge -p '{"data":{"logLevel":"debug"}}'
 ```
 
+#### Verify the new log level
 Wait one resync interval (15s), then check a copy:
 
 ```bash
@@ -92,7 +95,7 @@ kubectl get configmap app-config -n team-alpha -o jsonpath='{.data.logLevel}' &&
 # debug
 ```
 
-### 8. Test cleanup
+### 7. Test cleanup
 
 Delete the CR and watch copies disappear:
 

--- a/examples/beginner/03b-bonus-configmap-copy/crd.yaml
+++ b/examples/beginner/03b-bonus-configmap-copy/crd.yaml
@@ -36,4 +36,6 @@ spec:
     kind: ConfigMapDistribution
     plural: configmapdistributions
     singular: configmapdistribution
+    shortNames:
+      - cd
   scope: Cluster  # This is so it can distribute to all namespaces

--- a/examples/beginner/03b-bonus-configmap-copy/katalog.yaml
+++ b/examples/beginner/03b-bonus-configmap-copy/katalog.yaml
@@ -15,11 +15,11 @@ spec:
       crdFile: ./crd.yaml
       crFiles:
         - ./cr.yaml
+      setup:
+        - ./setup.yaml
       namespaced: false             # Default: (true)
 
       operatorBox:
-        default: true
-
         status:
           fields:
             - path: phase

--- a/pkg/doctor/helm.go
+++ b/pkg/doctor/helm.go
@@ -32,40 +32,48 @@ func BuildControlCenterValues(host string) (string, error) {
 	return tmp.Name(), nil
 }
 
-func InstallOrUpgradeOrkestra(version string, valueFiles []string, upgrade bool) error {
+// InstallOrUpgradeOrkestra installs or upgrades the Orkestra Helm chart in an
+// idempotent way. This function:
+//
+//  1. Ensures the Orkestra Helm repo exists and updates its index
+//  2. Builds a complete `helm upgrade --install` command
+//  3. Applies optional version constraints
+//  4. Applies any number of values files (`-f file.yaml`)
+//  5. Applies any additional Helm arguments (e.g. --set, --set-string, --atomic)
+//
+// The caller may pass arbitrary Helm flags through `args`, allowing full control
+// over the installation behaviour while keeping Orkestra defaults intact.
+func InstallOrUpgradeOrkestra(version string, valueFiles []string, args ...string) error {
 	// Always add and update repo — add is idempotent, update ensures fresh index.
-	repoAdd := exec.Command("helm", "repo", "add", Orkestra, OrkestraChartRepo)
-	repoAdd.Stdout = os.Stdout
-	repoAdd.Stderr = os.Stderr
-	_ = repoAdd.Run() // ignore "already exists"
+	_ = exec.Command("helm", "repo", "add", Orkestra, OrkestraChartRepo).Run()
+	_ = exec.Command("helm", "repo", "update", Orkestra).Run()
 
-	update := exec.Command("helm", "repo", "update", Orkestra)
-	update.Stdout = os.Stdout
-	update.Stderr = os.Stderr
-	_ = update.Run() // non-fatal if offline or repo not yet populated
-
-	// Build Helm args — always use upgrade --install (idempotent)
-	args := []string{"upgrade", "--install"}
-
-	args = append(args,
+	// Base Helm args — always upgrade --install (idempotent)
+	helmArgs := []string{
+		"upgrade", "--install",
 		Orkestra,
 		fmt.Sprintf("%s/%s", Orkestra, OrkestraChartName),
 		"--namespace", OrkestraNamespace,
 		"--create-namespace",
-	)
-
-	if version != "" {
-		args = append(args, "--version", version)
 	}
 
+	// Optional version
+	if version != "" {
+		helmArgs = append(helmArgs, "--version", version)
+	}
+
+	// Values files
 	for _, f := range valueFiles {
 		if f != "" {
-			args = append(args, "-f", f)
+			helmArgs = append(helmArgs, "-f", f)
 		}
 	}
 
+	// Additional Helm args (e.g. --set foo=bar)
+	helmArgs = append(helmArgs, args...)
+
 	// Run Helm
-	cmd := exec.Command("helm", args...)
+	cmd := exec.Command("helm", helmArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/pkg/e2e/runner.go
+++ b/pkg/e2e/runner.go
@@ -211,9 +211,21 @@ func (r *Runner) Run(ctx context.Context) (*Result, error) {
 	appliedSetupPaths = setupPaths
 
 	// ── 6. Install Orkestra ──────────────────────────────────────────────
+	args := []string{}
+	text := "..."
+
+	gatewayEnabled, err := resolveGatewayEnabled(r.katalogFile)
+	if err != nil {
+		return nil, err
+	}
+	if gatewayEnabled {
+		args = append(args, "--set", "gateway.enabled=true")
+		text = " with gateway..."
+	}
+
 	if !doctor.OrkestraInstalled() {
-		fmt.Printf("→ Installing Orkestra...\n")
-		if err := doctor.InstallOrUpgradeOrkestra("", nil, false); err != nil {
+		fmt.Printf("→ Installing Orkestra%s\n", text)
+		if err := doctor.InstallOrUpgradeOrkestra("", nil, args...); err != nil {
 			return nil, fmt.Errorf("helm install: %w", err)
 		}
 		installedOrkestra = true
@@ -327,6 +339,25 @@ func (r *Runner) Run(ctx context.Context) (*Result, error) {
 		return result, fmt.Errorf("%d of %d expectations failed", result.Total()-result.Passed(), result.Total())
 	}
 	return result, nil
+}
+
+// resolveGatewayEnabled inspects the katalog file and returns true if the
+// gateway block is present. This allows Helm installation to automatically
+// enable the gateway chart when required by the katalog.
+func resolveGatewayEnabled(katalogFile string) (bool, error) {
+	var raw struct {
+		Gateway *orktypes.GatewayConfig `yaml:"gateway,omitempty"`
+	}
+
+	data, err := os.ReadFile(katalogFile)
+	if err != nil {
+		return false, err
+	}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return false, err
+	}
+
+	return raw.Gateway != nil, nil
 }
 
 // ensureCluster sets up the cluster according to the spec.

--- a/pkg/registry/CONTRACT.md
+++ b/pkg/registry/CONTRACT.md
@@ -1,0 +1,31 @@
+# pkg/registry — stability contract
+
+This package is the single implementation of OCI registry logic for the Orkestra toolchain. Both the CLI (`ork registry push/pull/info`) and the Marketplace (`store/memory/oci_client.go`) depend on it. Changes here affect both consumers.
+
+## What is stable
+
+- `Resolve(ociURL string) (Ref, error)` — parses any `oci://` URL into a typed reference. The URL format is `oci://<registry>/<repository>:<tag>`.
+- `NewClient() (*Client, error)` — creates an ORAS client. Picks up Docker credential helpers and `~/.docker/config.json` automatically.
+- `Client.Info(ctx, ref) (*ArtifactInfo, error)` — fetches manifest annotations without downloading layers. Returns `ArtifactInfo.Meta` which holds name, version, description, author, tags, and E2E result.
+- `Client.Pull(ctx, ref, force) (cacheDir string, error)` — pulls all layers to a local cache directory and returns its path. Files can be read from disk after this call.
+- `ArtifactMeta` fields: `Name`, `Version`, `Description`, `Author`, `Tags`, `E2E` (`*E2EResult` with `Status string`).
+
+## E2E trust model
+
+`E2EResult.Status` is written by `ork registry push`, not by the publisher manually. The push command detects `e2e.yaml` in the pattern, runs the tests, and bakes the outcome (`passed`, `skipped`, or `failed`) into the OCI annotation before the push completes. The Marketplace reads this annotation and surfaces it as a verified signal — it is not self-reported.
+
+## What is not stable yet
+
+- The exact set of fields in `ArtifactMeta`. New fields may be added; no fields will be removed without a deprecation notice in this file.
+- The cache directory layout returned by `Pull`. Treat it as opaque — read files from it but do not rely on its path structure.
+- `ArtifactInfo` fields beyond `Meta` (e.g. digest, size). These are implementation details.
+
+## Versioning rules
+
+The Marketplace pins to a specific `github.com/orkspace/orkestra` version in its `go.mod`. Changes to any stable surface above require:
+
+1. A minor or patch version bump in `orkestra`.
+2. A corresponding `go get github.com/orkspace/orkestra@<new-version>` + `go mod tidy` in the Marketplace.
+3. If `ArtifactMeta` gains new fields used by the Marketplace, update `store/memory/oci_client.go` to map them.
+
+If you are changing this package and the Marketplace depends on what you are changing, update both in the same release cycle.

--- a/pkg/types/methods.go
+++ b/pkg/types/methods.go
@@ -310,6 +310,18 @@ func (c *CRDEntry) HasCRDFile() bool {
 	return c != nil && c.CRDFile != ""
 }
 
+// HasCRFiles reports whether this CRDEntry declares CR YAML files
+// to be applied before the runtime starts.
+func (c *CRDEntry) HasCRFiles() bool {
+	return c != nil && len(c.CRFiles) > 0
+}
+
+// HasSetup reports whether this CRDEntry declares setup YAML files
+// to be applied before Orkestra starts.
+func (c *CRDEntry) HasSetup() bool {
+	return c != nil && len(c.Setup) > 0
+}
+
 // NotificationEnabled reports whether this CRD declares the notification block
 // Enabled by default
 func (c *CRDEntry) IsNotificationEnabled() bool {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -2428,6 +2428,11 @@ type CRDEntry struct {
 	// Same path resolution as CRDFile. Dev mode only.
 	CRFiles []string `yaml:"crFiles,omitempty" json:"crFiles,omitempty"`
 
+	// Setup lists YAML files to apply before Orkestra starts.
+	// Use this for external dependencies: namespaces, secrets, additional CRDs.
+	// Applied in order with kubectl apply -f, after spec.crd.
+	Setup []string `yaml:"setup,omitempty" json:"setup,omitempty"`
+
 	// ── Runtime objects ───────────────────────────────────────────────────────
 	// Set by addRuntimeObjects() during Katalog validation. Never set from YAML.
 	//


### PR DESCRIPTION
## **Summary**

This PR introduces automatic gateway‑configuration detection during E2E and local development, adds first‑class support for `setup:` files in `CRDEntry`, fixes gateway image resolution in the Helm chart, and improves helper messaging and documentation. Together, these changes make Orkestra’s pre‑runtime behavior more predictable, self‑contained, and aligned with the katalog‑as‑source‑of‑truth model.

---

## **Key Changes**

### **1. Gateway auto‑detection (E2E + runtime)**
- Added logic to inspect the katalog for a `gateway:` block.
- If present, Orkestra automatically injects:
  - **`--set gateway.enabled=true`** into the Helm install/upgrade.
- Ensures E2E tests requiring the gateway now pass without manual flags.
- Makes gateway activation declarative and katalog‑driven.

### **2. Added `setup:` support to `CRDEntry`**
- New field:  
  ```yaml
  setup:
    - ./setup.yaml
  ```
- Automatically applied before runtime, after CRDs and before CRs.
- Mirrors E2E behavior and removes the need for manual `kubectl apply -f setup.yaml` in examples.
- Fully integrated into the unified `applyPreRuntimeResources()` pipeline.

### **3. Helm chart fixes**
- Corrected gateway image reference.
- Ensures gateway pods pull the correct image in both dev and cluster installs.

### **4. Helper and UX improvements**
- Improved helper messages for clarity during installation and cluster setup.
- Added documentation for:
  - `setup:`  
  - `crFiles:`  
  - gateway auto‑detection  
- Updated example READMEs to reflect the new one‑step `ork run` workflow.

---

## **Implementation Notes**

- Introduced `resolveGatewayEnabled()` to centralize gateway detection.
- Updated `InstallOrUpgradeOrkestra()` to correctly merge base Helm args with user‑provided args (e.g., `--set`).
- Added `applySetupIfNeeded()` and unified all pre‑runtime apply steps under `applyPreRuntimeResources()`.
- Ensured katalog resolution is now handled by `resolveKatalogPaths()`.

---

## **Testing**

- Verified E2E suite passes with gateway‑dependent katalogs.
- Validated:
  - CRD application  
  - setup file application  
  - CR file application  
  - gateway auto‑enable  
  - Helm install/upgrade flow  
- Confirmed correct behavior in both `--dev` and non‑dev modes.

---

## **Why This Matters**

This PR removes the last bits of manual orchestration from the developer workflow.  
Katalogs now fully describe their dependencies, and Orkestra handles the rest.

This makes:

- E2E tests deterministic  
- Examples one‑command runnable  
- Gateway usage declarative  
- Pre‑runtime behavior consistent across environments  