### PR TITLE
Fix/multi replica crd health reporting

### DIFF
--- a/charts/orkestra/values.yaml
+++ b/charts/orkestra/values.yaml
@@ -318,7 +318,14 @@ controlCenter:
   ingress:
     enabled: false                  # Disabled by default – enable and set hosts
     className: ""
-    annotations: {}
+    annotations:
+      # Sticky sessions ensure each browser is consistently routed to the same
+      # CC pod. The CC cache is in-memory per-pod, so without affinity a user
+      # may see different state on each request when replicaCount > 1.
+      nginx.ingress.kubernetes.io/affinity: "cookie"
+      nginx.ingress.kubernetes.io/session-cookie-name: "cc-session"
+      nginx.ingress.kubernetes.io/session-cookie-max-age: "86400"
+      nginx.ingress.kubernetes.io/session-cookie-samesite: "Strict"
     hosts: []
     # hosts:
     #   - host: control-center.mycompany.com

--- a/cmd/controlcenter/cc/client.go
+++ b/cmd/controlcenter/cc/client.go
@@ -22,6 +22,14 @@ func NewClient(baseURL string, _ time.Duration, _ string) *Client {
 		baseURL: baseURL,
 		httpClient: &http.Client{
 			Timeout: 10 * time.Second,
+			// Disable keep-alives so each background fetch opens a new TCP
+			// connection. Without this, the Service load-balancer routes the
+			// first connection to a pod and all subsequent requests reuse it —
+			// pinning the CC permanently to whichever pod (leader or follower)
+			// it happened to reach first.
+			Transport: &http.Transport{
+				DisableKeepAlives: true,
+			},
 		},
 	}
 }
@@ -40,15 +48,50 @@ func (c *Client) FetchKatalog() (*KatalogResponse, error) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 // FetchCRDDetail fetches health + info for a single CRD and merges them.
+// The health call is retried up to 3 times until it comes from the leader pod
+// (isKonductor: true). Without this, a multi-replica runtime Service can
+// route the request to a follower whose CRD health is always "pending".
 func (c *Client) FetchCRDDetail(name string) (*CRDDetail, error) {
-	health, err := getJSON[CRDHealth](c, "/katalog/"+name+"/health")
-	if err != nil {
-		return nil, fmt.Errorf("fetching health: %w", err)
+	var health *CRDHealth
+	for i := 0; i < 3; i++ {
+		h, err := getJSON[CRDHealth](c, "/katalog/"+name+"/health")
+		if err != nil {
+			return nil, fmt.Errorf("fetching health: %w", err)
+		}
+		if h.IsKonductor {
+			health = h
+			break
+		}
+	}
+	if health == nil {
+		// All attempts hit a follower — use the last response rather than
+		// returning an error. The data may be stale but is better than nothing.
+		h, err := getJSON[CRDHealth](c, "/katalog/"+name+"/health")
+		if err != nil {
+			return nil, fmt.Errorf("fetching health: %w", err)
+		}
+		health = h
 	}
 
-	info, err := getJSON[CRDInfo](c, "/katalog/"+name)
-	if err != nil {
-		return nil, fmt.Errorf("fetching info: %w", err)
+	// Same retry pattern for info — worker counts (workersActive, workerDetails)
+	// are zero on follower pods since they never start reconcilers.
+	var info *CRDInfo
+	for i := 0; i < 3; i++ {
+		inf, err := getJSON[CRDInfo](c, "/katalog/"+name)
+		if err != nil {
+			return nil, fmt.Errorf("fetching info: %w", err)
+		}
+		if inf.IsKonductor {
+			info = inf
+			break
+		}
+	}
+	if info == nil {
+		inf, err := getJSON[CRDInfo](c, "/katalog/"+name)
+		if err != nil {
+			return nil, fmt.Errorf("fetching info: %w", err)
+		}
+		info = inf
 	}
 
 	nsProtection := info.NamespaceProtection

--- a/cmd/controlcenter/cc/controlcenter.go
+++ b/cmd/controlcenter/cc/controlcenter.go
@@ -149,19 +149,23 @@ func (cc *ControlCenter) fetchAllKatalogs() {
 			} else {
 				inst.GatewayEndpoint = kat.GatewayEndpoint
 				if kat.IsKonductor {
-					// This pod holds the leader lease — its CRD data is authoritative.
+					// Leader pod — data is authoritative, always update.
 					inst.Katalog = kat
 					inst.Status = "online"
 					inst.Healthy = true
 					inst.LastError = ""
-				} else {
-					// Standby pod responded. Keep the last known-good snapshot so the
-					// display does not flip between healthy and pending on each tick.
-					if inst.Katalog == nil {
-						inst.Status = "starting"
-						inst.Healthy = false
-					}
+				} else if inst.Katalog == nil {
+					// Follower pod but we have nothing yet — accept it so the
+					// katalog appears immediately rather than waiting for a lucky
+					// tick that hits the leader. It may show CRDs as pending until
+					// the next leader response overwrites it.
+					inst.Katalog = kat
+					inst.Status = "starting"
+					inst.Healthy = false
+					inst.LastError = ""
 				}
+				// Follower + already have good data → keep last known-good snapshot,
+				// discard this response so the display does not flip.
 				log.Printf("INFO: fetched katalog %q from %s (%d CRDs, gateway=%q)",
 					kat.Name, u, len(kat.CRDs), kat.GatewayEndpoint)
 			}

--- a/cmd/controlcenter/cc/types.go
+++ b/cmd/controlcenter/cc/types.go
@@ -215,6 +215,7 @@ type CRDSummary struct {
 type CRDHealth struct {
 	Name                     string                      `json:"name"`
 	State                    string                      `json:"state"`
+	IsKonductor              bool                        `json:"isKonductor"`
 	Healthy                  bool                        `json:"healthy"`
 	Started                  bool                        `json:"started"`
 	Pending                  bool                        `json:"pending"`
@@ -276,6 +277,7 @@ type CRDInfo struct {
 	Namespaced               bool                      `json:"namespaced"`
 	Namespace                string                    `json:"namespace"`
 	DependsOn                []string                  `json:"dependsOn"`
+	IsKonductor              bool                      `json:"isKonductor"`
 	Workers                  int                       `json:"workers"`
 	WorkersActive            int32                     `json:"workersActive"`
 	WorkersIdle              int32                     `json:"workersIdle"`

--- a/cmd/controlcenter/docs/03-data-flow.md
+++ b/cmd/controlcenter/docs/03-data-flow.md
@@ -46,9 +46,15 @@ KatalogResponse
 
 ### Cache-update rule
 
-`inst.Katalog` is only replaced when `KatalogResponse.IsKonductor == true`. When it is `false` (the response came from a standby pod), the last known-good snapshot is kept and the tick is a no-op for display state.
+Three cases on each fetch:
 
-This matters when `replicaCount > 1`: the Kubernetes Service can round-robin to any pod. Only the leader pod sets `IsKonductor: true` (via `DependencyKordinator.Kordinate()`); follower pods never run the reconcilers so their CRD health stays "pending". Without this guard, the display would flip between healthy and pending on every other fetch tick.
+| Response | `inst.Katalog` state | Action |
+|----------|----------------------|--------|
+| `isKonductor: true` | any | Replace — leader data is authoritative |
+| `isKonductor: false` | nil | Accept — no data yet, something beats nothing; CRDs may show as pending until a leader response arrives |
+| `isKonductor: false` | non-nil | Discard — keep last known-good snapshot; prevents flipping between healthy and pending |
+
+This matters when `replicaCount > 1`: the Kubernetes Service round-robins to any pod. Only the leader sets `isKonductor: true` (via `DependencyKordinator.Kordinate()`); follower pods never run reconcilers so their CRD health stays "pending". The second case ensures all katalogs appear immediately on startup; the third case ensures the display does not flip once stable.
 
 The `CRDSummary` slice is what drives the Katalog panel and the index. It does not include deep detail — for that, the user navigates to a CRD page, which triggers a fresh `FetchCRDDetail` call at request time.
 

--- a/cmd/internal/runtime_konstructor.go
+++ b/cmd/internal/runtime_konstructor.go
@@ -428,6 +428,8 @@ func konstructRuntime(kfg *konfig.Konfig, m *merger.Merger, ctx context.Context)
 	//	 /katalog/raw				 		→ the user's katalog config
 	//	 /katalog/enriched				 	→ the runtime katalog config
 	//   /katalog                    		→ all CRDs, dependency graph, health summary
+	orkHealth := kordinator.NewOrkestraHealth()
+
 	deletionProtectedCRDs := kat.DeletionProtectedCRDNames()
 	for _, crd := range kat.Enabled() {
 		gvk := crd.GVKString()
@@ -447,7 +449,7 @@ func konstructRuntime(kfg *konfig.Konfig, m *merger.Merger, ctx context.Context)
 		if crd.IsHealthEnabled() {
 			hs.Register(
 				"/katalog/"+crdName+"/health",
-				kordinator.BuildCRDHealthHandler(crd, kfg, inf, crdHealth),
+				kordinator.BuildCRDHealthHandler(crd, kfg, inf, crdHealth, orkHealth),
 			)
 		}
 
@@ -456,6 +458,7 @@ func konstructRuntime(kfg *konfig.Konfig, m *merger.Merger, ctx context.Context)
 				"/katalog/"+crdName,
 				kordinator.BuildCRDInfoHandler(
 					crd, kfg, inf, crdHealth,
+					orkHealth,
 					nil, // conversion stats — live in gateway process
 					nil, // admission stats — live in gateway process
 					nil, // protection stats — live in gateway process
@@ -496,7 +499,6 @@ func konstructRuntime(kfg *konfig.Konfig, m *merger.Merger, ctx context.Context)
 			Msg("registered CRD routes")
 	}
 
-	orkHealth := kordinator.NewOrkestraHealth()
 	hs.Register("/katalog/raw", kordinator.BuildRawKatalogHandler(m))
 	hs.Register("/katalog/enriched", kordinator.BuildEnrichedKatalogHandler(kat))
 	hs.Register("/katalog", kordinator.BuildKatalogHandler(kat, kfg, ktrlRegistry, crdHealthMap, orkHealth))

--- a/deployments/public/Makefile
+++ b/deployments/public/Makefile
@@ -24,7 +24,7 @@ all: cluster-01 cluster-02 cluster-03 cluster-04 cluster-05 cluster-06
 
 cluster-01:
 	@echo "→ cluster-01: hello-website ($(NS_01))"
-	cd cluster-01 && ork generate bundle -n $(NS_01) | kubectl apply -f -
+	cd cluster-01 && ork generate bundle --for runtime,cc -n $(NS_01) | kubectl apply -f -
 	kubectl apply -f cluster-01/crd.yaml
 	helm upgrade --install orkestra $(CHART) \
 		--namespace $(NS_01) \
@@ -34,7 +34,7 @@ cluster-01:
 
 cluster-02:
 	@echo "→ cluster-02: website-with-serviceaccount ($(NS_02))"
-	cd cluster-02 && ork generate bundle -n $(NS_02) | kubectl apply -f -
+	cd cluster-02 && ork generate bundle --for runtime -n $(NS_02) | kubectl apply -f -
 	kubectl apply -f cluster-02/crd.yaml
 	helm upgrade --install orkestra $(CHART) \
 		--namespace $(NS_02) \
@@ -45,7 +45,7 @@ cluster-02:
 
 cluster-03:
 	@echo "→ cluster-03: secret-distribution ($(NS_03))"
-	cd cluster-03 && ork generate bundle -n $(NS_03) | kubectl apply -f -
+	cd cluster-03 && ork generate bundle --for runtime -n $(NS_03) | kubectl apply -f -
 	kubectl apply -f cluster-03/crd.yaml
 	kubectl apply -f cluster-03/setup.yaml
 	helm upgrade --install orkestra $(CHART) \
@@ -56,7 +56,7 @@ cluster-03:
 
 cluster-04:
 	@echo "→ cluster-04: app-platform ($(NS_04))"
-	cd cluster-04 && ork generate bundle -n $(NS_04) | kubectl apply -f -
+	cd cluster-04 && ork generate bundle --for runtime -n $(NS_04) | kubectl apply -f -
 	kubectl apply -f cluster-04/crd.yaml
 	helm upgrade --install orkestra $(CHART) \
 		--namespace $(NS_04) \
@@ -67,7 +67,7 @@ cluster-04:
 
 cluster-05:
 	@echo "→ cluster-05: data-platform ($(NS_05))"
-	cd cluster-05 && ork generate bundle -n $(NS_05) | kubectl apply -f -
+	cd cluster-05 && ork generate bundle --for runtime -n $(NS_05) | kubectl apply -f -
 	kubectl apply -f cluster-05/crd.yaml
 	helm upgrade --install orkestra $(CHART) \
 		--namespace $(NS_05) \
@@ -78,7 +78,7 @@ cluster-05:
 
 cluster-06:
 	@echo "→ cluster-06: network-suite ($(NS_06))"
-	cd cluster-06 && ork generate bundle -n $(NS_06) | kubectl apply -f -
+	cd cluster-06 && ork generate bundle --for runtime -n $(NS_06) | kubectl apply -f -
 	kubectl apply -f cluster-06/crd.yaml
 	helm upgrade --install orkestra $(CHART) \
 		--namespace $(NS_06) \
@@ -201,39 +201,39 @@ clean-01:
 	kubectl delete -f cluster-01/cr.yaml --ignore-not-found
 	kubectl delete -f cluster-01/crd.yaml --ignore-not-found
 	kubectl delete namespace demo-01     --ignore-not-found
-	cd cluster-01 && ork generate bundle -n $(NS_01) | kubectl delete -f - --ignore-not-found
+	cd cluster-01 && ork generate bundle --for runtime,cc -n $(NS_01) | kubectl delete -f - --ignore-not-found
 
 clean-02:
 	helm uninstall orkestra -n $(NS_02) --ignore-not-found
 	kubectl delete -f cluster-02/cr.yaml --ignore-not-found
 	kubectl delete -f cluster-02/crd.yaml --ignore-not-found
 	kubectl delete namespace demo-02     --ignore-not-found
-	cd cluster-02 && ork generate bundle -n $(NS_02) | kubectl delete -f - --ignore-not-found
+	cd cluster-02 && ork generate bundle --for runtime -n $(NS_02) | kubectl delete -f - --ignore-not-found
 
 clean-03:
 	helm uninstall orkestra -n $(NS_03) --ignore-not-found
 	kubectl delete -f cluster-03/cr.yaml    --ignore-not-found
 	kubectl delete -f cluster-03/setup.yaml --ignore-not-found
 	kubectl delete -f cluster-03/crd.yaml   --ignore-not-found
-	cd cluster-03 && ork generate bundle -n $(NS_03) | kubectl delete -f - --ignore-not-found
+	cd cluster-03 && ork generate bundle --for runtime -n $(NS_03) | kubectl delete -f - --ignore-not-found
 
 clean-04:
 	helm uninstall orkestra -n $(NS_04) --ignore-not-found
 	kubectl delete -f cluster-04/cr.yaml  --ignore-not-found
 	kubectl delete -f cluster-04/crd.yaml --ignore-not-found
 	kubectl delete namespace demo-04      --ignore-not-found
-	cd cluster-04 && ork generate bundle -n $(NS_04) | kubectl delete -f - --ignore-not-found
+	cd cluster-04 && ork generate bundle --for runtime -n $(NS_04) | kubectl delete -f - --ignore-not-found
 
 clean-05:
 	helm uninstall orkestra -n $(NS_05) --ignore-not-found
 	kubectl delete -f cluster-05/cr.yaml  --ignore-not-found
 	kubectl delete -f cluster-05/crd.yaml --ignore-not-found
 	kubectl delete namespace demo-05      --ignore-not-found
-	cd cluster-05 && ork generate bundle -n $(NS_05) | kubectl delete -f - --ignore-not-found
+	cd cluster-05 && ork generate bundle --for runtime -n $(NS_05) | kubectl delete -f - --ignore-not-found
 
 clean-06:
 	helm uninstall orkestra -n $(NS_06) --ignore-not-found
 	kubectl delete -f cluster-06/cr.yaml  --ignore-not-found
 	kubectl delete -f cluster-06/crd.yaml --ignore-not-found
 	kubectl delete namespace demo-06      --ignore-not-found
-	cd cluster-06 && ork generate bundle -n $(NS_06) | kubectl delete -f - --ignore-not-found
+	cd cluster-06 && ork generate bundle --for runtime -n $(NS_06) | kubectl delete -f - --ignore-not-found

--- a/deployments/public/values.yaml
+++ b/deployments/public/values.yaml
@@ -8,7 +8,7 @@
 runtime:
   image:
     repository: ghcr.io/orkspace/orkestra
-    tag: "7be90ccb-1780069192"
+    tag: "0.6.1"
   resources:
     requests:
       cpu: 50m
@@ -20,13 +20,13 @@ runtime:
 gateway:
   image:
     repository: ghcr.io/orkspace/orkestra-gateway
-    tag: "dev-1780065008"
+    tag: "0.6.1"
 
 controlCenter:
   replicaCount: 2
   image:
     repository: ghcr.io/orkspace/orkestra-cc
-    tag: "7be90ccb-1780069603"
+    tag: "0.6.1"
   config:
     orkestraURLs:
       - http://orkestra-runtime.orkestra-system-01.svc.cluster.local:8080

--- a/deployments/public/values.yaml
+++ b/deployments/public/values.yaml
@@ -8,7 +8,7 @@
 runtime:
   image:
     repository: ghcr.io/orkspace/orkestra
-    tag: "dev-1780044525"
+    tag: "7be90ccb-1780069192"
   resources:
     requests:
       cpu: 50m
@@ -20,13 +20,13 @@ runtime:
 gateway:
   image:
     repository: ghcr.io/orkspace/orkestra-gateway
-    tag: "dev-1780044525"
+    tag: "dev-1780065008"
 
 controlCenter:
   replicaCount: 2
   image:
     repository: ghcr.io/orkspace/orkestra-cc
-    tag: "dev-1780044525"
+    tag: "7be90ccb-1780069603"
   config:
     orkestraURLs:
       - http://orkestra-runtime.orkestra-system-01.svc.cluster.local:8080

--- a/pkg/kordinator/crd_health_handers.go
+++ b/pkg/kordinator/crd_health_handers.go
@@ -24,6 +24,7 @@ type CRDHealthResponse struct {
 	Name                     string                      `json:"name"`
 	State                    string                      `json:"state"` // "not started", "pending", "started", "healthy", "degraded"
 	Status                   int                         `json:"status"`
+	IsKonductor              bool                        `json:"isKonductor"`
 	Healthy                  bool                        `json:"healthy"`
 	Started                  bool                        `json:"started"`
 	Pending                  bool                        `json:"pending"`
@@ -64,6 +65,7 @@ func BuildCRDHealthHandler(
 	kfg *konfig.Konfig,
 	inf cache.SharedIndexInformer,
 	h *CRDHealth,
+	o *OrkestraHealth,
 ) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		state, status := h.StateAndStatus()
@@ -73,6 +75,7 @@ func BuildCRDHealthHandler(
 			Name:                     crd.Name,
 			State:                    state,
 			Status:                   status,
+			IsKonductor:              o.IsKonductor(),
 			Healthy:                  h.IsHealthy(),
 			Started:                  h.Started(),
 			Pending:                  h.Pending(),
@@ -114,6 +117,7 @@ type CRDInfoResponse struct {
 	Namespaced             bool                             `json:"namespaced"`
 	Namespace              string                           `json:"namespace"`
 	DependsOn              []string                         `json:"dependsOn,omitempty"`
+	IsKonductor            bool                             `json:"isKonductor"`
 	Workers                int                              `json:"workers"`
 	WorkersActive          int32                            `json:"workersActive"`
 	WorkersIdle            int32                            `json:"workersIdle"`
@@ -259,6 +263,7 @@ func BuildCRDInfoHandler(
 	kfg *konfig.Konfig,
 	inf cache.SharedIndexInformer,
 	h *CRDHealth,
+	o *OrkestraHealth,
 	convStats *health.ConversionStats,
 	admStats *health.AdmissionStats,
 	protStats *health.DeletionProtectionStats,
@@ -328,6 +333,7 @@ func BuildCRDInfoHandler(
 			Namespaced:          crd.IsNamespaced(),
 			Namespace:           crd.Namespace,
 			DependsOn:           crd.DependsOn.Names(),
+			IsKonductor:         o.IsKonductor(),
 			Workers:             workers,
 			WorkersActive:       workersActive,
 			WorkersIdle:         workersIdle,

--- a/pkg/kordinator/docs/README.md
+++ b/pkg/kordinator/docs/README.md
@@ -12,3 +12,14 @@
 | [04-self-healing.md](04-self-healing.md) | The retry loop and its four phases — missing CRDs, runtime deletion, reappearance, deferred activation |
 | [05-workers.md](05-workers.md) | The worker loop, `processItemForGVK`, queue drain, and shutdown semantics |
 | [06-handlers.md](06-handlers.md) | The three runtime introspection HTTP handlers that power the Control Center |
+
+## Multi-replica health reporting
+
+Running the runtime with `replicaCount > 1` introduces a split-brain health state problem — only the leader reconciles, but all pods serve traffic. The `health-reporting/` subfolder documents the full solution end-to-end.
+
+| File | Covers |
+|---|---|
+| [health-reporting/01-overview.md](health-reporting/01-overview.md) | The problem, the `isKonductor` signal, how it flows |
+| [health-reporting/02-runtime.md](health-reporting/02-runtime.md) | `OrkestraHealth.isKonductor`, `Kordinate()` lifecycle, real JSON responses from leader and follower |
+| [health-reporting/03-control-center.md](health-reporting/03-control-center.md) | Connection pooling root cause, cache-update guard, CRD detail retry logic |
+| [health-reporting/04-diagnosis.md](health-reporting/04-diagnosis.md) | Diagnosing flapping health, port-forward inspection commands, common failure patterns |

--- a/pkg/kordinator/docs/health-reporting/01-overview.md
+++ b/pkg/kordinator/docs/health-reporting/01-overview.md
@@ -1,0 +1,57 @@
+# CRD Health Reporting — Overview
+
+Orkestra exposes live health state for every managed CRD through HTTP endpoints on the runtime process. The Control Center fetches this state on a periodic background loop and renders it in the UI.
+
+This works correctly with `replicaCount: 1`. With `replicaCount > 1` and leader election enabled, only one pod (the konductor) runs the reconcilers. Follower pods serve requests but their in-memory `CRDHealth` never advances — they always return `state: pending, healthy: false`.
+
+This document series covers how the health signal is tracked, surfaced, and correctly consumed under multi-replica deployments.
+
+---
+
+## The problem
+
+```
+Runtime Service (2 pods)
+  ├── Pod A  — konductor (leader)    → state: healthy, totalReconciles: 101
+  └── Pod B  — follower              → state: pending, totalReconciles: 0
+
+Control Center
+  └── background fetch → Service → round-robins to A or B
+        → display flips between healthy and pending on every other tick
+```
+
+With HTTP keep-alive (Go's default), the CC's HTTP client reuses the first TCP connection to a given Service. Whichever pod it connected to first is where ALL subsequent requests go — permanently. Two runtimes whose first connection landed on a follower pod are stuck showing "pending" for the lifetime of the CC pod.
+
+---
+
+## The solution: `isKonductor`
+
+The konductor pod sets an atomic flag on `OrkestraHealth` at the start of `Kordinate()`. Every runtime HTTP response includes this flag. The CC uses it to decide whether the response came from an authoritative source.
+
+```
+Kordinate() called on winning pod
+  → orkHealth.SetIsKonductor(true)
+  → reconcilers start
+  → CRDHealth advances: pending → started → healthy
+
+Pod loses leadership
+  → orkHealth.SetIsKonductor(false)
+  → Kordinate() returns
+```
+
+The flag is present on every endpoint that returns health-sensitive data:
+
+| Endpoint | Field | Used for |
+|----------|-------|----------|
+| `GET /katalog` | `"isKonductor"` | Background fetch cache guard |
+| `GET /katalog/{crd}/health` | `"isKonductor"` | Per-CRD detail page retry |
+
+---
+
+## Pages in this series
+
+| Page | Covers |
+|------|--------|
+| [02-runtime.md](02-runtime.md) | How `isKonductor` is set and surfaced on the runtime |
+| [03-control-center.md](03-control-center.md) | How the CC consumes it — cache guard and retry logic |
+| [04-diagnosis.md](04-diagnosis.md) | Diagnosing multi-replica health issues |

--- a/pkg/kordinator/docs/health-reporting/02-runtime.md
+++ b/pkg/kordinator/docs/health-reporting/02-runtime.md
@@ -1,0 +1,206 @@
+# CRD Health Reporting — Runtime
+
+## `OrkestraHealth` and `isKonductor`
+
+`OrkestraHealth` is the operator-level health aggregate. It is a single shared instance created in `konstructRuntime` and passed to every handler that serves health-sensitive data. It is separate from the per-CRD `CRDHealth` objects.
+
+```go
+type OrkestraHealth struct {
+    name        string
+    orkReady    atomic.Bool  // runtime process is up and serving
+    katReady    atomic.Bool  // all CRDs in the Katalog are online
+    allOnline   atomic.Bool  // set when topo-order startup completes
+    isKonductor atomic.Bool  // this pod holds the leader election lease
+    mu          sync.RWMutex
+}
+```
+
+`isKonductor` is set at the start of `Kordinate()` — the function that is only called on the pod that wins the leader election:
+
+```go
+func (k *DependencyKordinator) Kordinate(ctx context.Context) {
+    k.orkHealth.SetOrkReady()
+    k.orkHealth.SetIsKonductor(true)   // ← only the leader reaches this
+
+    // ... starts all CRD workers in dependency order ...
+
+    <-ctx.Done()   // blocks until leadership is lost
+
+    k.orkHealth.SetIsKonductor(false)  // ← clears on leadership loss
+    k.orkHealth.SetOrkDegraded()
+}
+```
+
+Follower pods start the runtime, bind the HTTP server, and serve requests — but never call `Kordinate()`. Their `isKonductor` stays `false` for their entire lifetime.
+
+---
+
+## `GET /katalog`
+
+The top-level katalog endpoint. Used by the CC background fetch loop.
+
+**Leader pod:**
+```json
+{
+  "name": "data-platform",
+  "total": 10,
+  "totalEnabled": 10,
+  "OrkReady": true,
+  "isKonductor": true,
+  "healthy": true,
+  "status": 200,
+  "statusCounts": {
+    "healthy": 10,
+    "degraded": 0,
+    "started": 0,
+    "pending": 0
+  }
+}
+```
+
+**Follower pod:**
+```json
+{
+  "name": "data-platform",
+  "total": 10,
+  "totalEnabled": 10,
+  "OrkReady": true,
+  "isKonductor": false,
+  "healthy": false,
+  "status": 200,
+  "statusCounts": {
+    "healthy": 0,
+    "degraded": 0,
+    "started": 0,
+    "pending": 10
+  }
+}
+```
+
+`OrkReady: true` on both pods — the runtime process is running on both. `isKonductor` is the distinguishing signal.
+
+---
+
+## `GET /katalog/{crd}/health`
+
+Per-CRD health endpoint. Used by the CC CRD detail page for state, error counters, and reconcile timestamps.
+
+`isKonductor` here comes from the same `OrkestraHealth` instance as `/katalog`. It is NOT the per-CRD `h.orkHealth` field — that is a separate uninitialised instance attached to `CRDHealth` for other purposes. Both handlers take the global `o *OrkestraHealth` explicitly:
+
+```go
+func BuildCRDHealthHandler(
+    crd orktypes.CRDEntry,
+    kfg *konfig.Konfig,
+    inf cache.SharedIndexInformer,
+    h   *CRDHealth,
+    o   *OrkestraHealth,   // ← global instance from konstructRuntime
+) http.HandlerFunc
+```
+
+**Leader pod (`isKonductor: true`):**
+```json
+{
+  "name": "website",
+  "state": "healthy",
+  "status": 200,
+  "isKonductor": true,
+  "healthy": true,
+  "started": true,
+  "pending": false,
+  "startedAt": "2026-05-29T14:53:01Z",
+  "uptime": "12m14s",
+  "queueDepth": 0,
+  "errorRate": 0,
+  "consecutiveFails": 0,
+  "totalReconciles": 101,
+  "resourceCount": 1,
+  "lastError": "",
+  "lastReconcile": "2026-05-29T15:05:14Z",
+  "hasUnhealthyDependencies": false
+}
+```
+
+**Follower pod (`isKonductor: false`):**
+```json
+{
+  "name": "website",
+  "state": "pending",
+  "status": 200,
+  "isKonductor": false,
+  "healthy": false,
+  "started": false,
+  "pending": true,
+  "startedAt": "not started",
+  "uptime": "not started",
+  "queueDepth": 0,
+  "errorRate": 0,
+  "consecutiveFails": 0,
+  "totalReconciles": 0,
+  "resourceCount": 1,
+  "lastError": "",
+  "lastReconcile": "not started",
+  "hasUnhealthyDependencies": false
+}
+```
+
+---
+
+## `GET /katalog/{crd}`
+
+Per-CRD info endpoint. Used by the CC CRD detail page for worker pool state, queue depth, resync, RBAC, and providers.
+
+Worker fields are only meaningful on the leader — the follower never starts reconcilers so its worker counts are all zero and `workerDetails` is empty.
+
+```go
+func BuildCRDInfoHandler(
+    crd orktypes.CRDEntry,
+    kfg *konfig.Konfig,
+    inf cache.SharedIndexInformer,
+    h   *CRDHealth,
+    o   *OrkestraHealth,   // ← global instance from konstructRuntime
+    ...
+) http.HandlerFunc
+```
+
+**Leader pod (`isKonductor: true`):**
+```json
+{
+  "name": "website",
+  "isKonductor": true,
+  "workers": 3,
+  "workersActive": 3,
+  "workersIdle": 3,
+  "workersProcessing": 0,
+  "workerDetails": {
+    "demo.orkestra.io/v1alpha1-Kind=Website-worker-0": "idle",
+    "demo.orkestra.io/v1alpha1-Kind=Website-worker-1": "idle",
+    "demo.orkestra.io/v1alpha1-Kind=Website-worker-2": "idle"
+  },
+  "resync": "15s",
+  "queueDepth": 0,
+  "maxQueueDepth": 100
+}
+```
+
+**Follower pod (`isKonductor: false`):**
+```json
+{
+  "name": "website",
+  "isKonductor": false,
+  "workers": 3,
+  "workersActive": 0,
+  "workersIdle": 0,
+  "workersProcessing": 0,
+  "resync": "15s",
+  "queueDepth": 0,
+  "maxQueueDepth": 100
+}
+```
+
+`workers: 3` is the configured value (from the Katalog) — present on both pods. `workersActive`, `workersIdle`, `workerDetails` are live runtime state — only meaningful on the leader.
+
+`resourceCount` is identical on both pods — it comes from the informer cache, which is synced from the Kubernetes API independently of leadership.
+
+---
+
+→ Next: [03-control-center.md](03-control-center.md)

--- a/pkg/kordinator/docs/health-reporting/03-control-center.md
+++ b/pkg/kordinator/docs/health-reporting/03-control-center.md
@@ -1,0 +1,135 @@
+# CRD Health Reporting — Control Center
+
+The CC fetches health data from the runtime over HTTP. Two paths exist: the background fetch loop (periodic, cached) and the CRD detail page (on-demand, per request). Both need to handle multi-replica runtimes without showing stale follower data.
+
+---
+
+## The connection pooling problem
+
+Go's `http.Client` reuses TCP connections by default (HTTP keep-alive). With a Kubernetes Service in front of a multi-replica runtime:
+
+```
+CC http.Client
+  └── first request to orkestra-runtime.svc:8080
+        → kube-proxy picks a backend pod (e.g. the follower)
+        → TCP connection established
+        → all subsequent requests reuse this connection
+        → CC is pinned to the follower forever
+```
+
+The Service's load balancing only applies to new connections. With a pooled client, the CC never naturally migrates to the leader.
+
+**Fix:** `DisableKeepAlives: true` forces a new TCP connection on every fetch:
+
+```go
+func NewClient(baseURL string, _ time.Duration, _ string) *Client {
+    return &Client{
+        baseURL: baseURL,
+        httpClient: &http.Client{
+            Timeout: 10 * time.Second,
+            Transport: &http.Transport{
+                DisableKeepAlives: true,
+            },
+        },
+    }
+}
+```
+
+With a new connection per tick, kube-proxy distributes across pods, and every fetch has a fair chance of hitting the leader.
+
+---
+
+## Background fetch — `fetchAllKatalogs`
+
+Runs every `RefreshInterval` seconds. Calls `GET /katalog` on each runtime URL and updates `inst.Katalog`.
+
+### Cache-update rule
+
+`inst.Katalog` is only replaced when `KatalogResponse.IsKonductor == true`:
+
+```
+Response from leader (isKonductor: true)
+  → replace inst.Katalog with authoritative data
+  → inst.Status = "online", inst.Healthy = true
+
+Response from follower (isKonductor: false), inst.Katalog == nil
+  → accept it — better than nothing; shows CRDs as pending
+  → inst.Status = "starting", inst.Healthy = false
+
+Response from follower (isKonductor: false), inst.Katalog already set
+  → discard — keep last known-good snapshot
+  → display does not change
+```
+
+**Why the nil case matters:** With multiple runtime Services, the first fetch for each one opens a new connection. If it lands on the follower, `inst.Katalog` would stay nil forever without the nil case — the katalog would never appear in the UI until a lucky tick hits the leader. Accepting the first response (even stale) makes every katalog visible immediately; the leader's data overwrites it on the next hit.
+
+### Convergence
+
+After startup, with 2 pods and true random load balancing per connection:
+
+```
+Tick 1:  hits follower → inst.Katalog = pending (nil case)
+Tick 2:  hits leader   → inst.Katalog = healthy ✓
+Tick 3:  hits follower → discard, keep healthy ✓
+Tick 4:  hits leader   → update healthy ✓
+```
+
+All runtimes converge to showing healthy within 1–2 ticks (~10–20 seconds).
+
+---
+
+## CRD detail page — `FetchCRDDetail`
+
+Called on-demand when a user opens a CRD page. Makes two live requests:
+- `GET /katalog/{crd}/health` — state, errors, reconcile counters
+- `GET /katalog/{crd}` — GVK, workers config, RBAC, providers
+
+With `DisableKeepAlives`, each call opens a fresh connection and can land on any pod. The health fields flap if the health request hits the follower — configuration fields (GVK, workers) are static and don't flap.
+
+### Retry until leader
+
+`FetchCRDDetail` retries the health call up to 3 times until it gets `isKonductor: true`:
+
+```go
+var health *CRDHealth
+for i := 0; i < 3; i++ {
+    h, err := getJSON[CRDHealth](c, "/katalog/"+name+"/health")
+    if err != nil {
+        return nil, fmt.Errorf("fetching health: %w", err)
+    }
+    if h.IsKonductor {
+        health = h
+        break
+    }
+}
+if health == nil {
+    // All 3 attempts hit a follower — use last response rather than error
+    health, _ = getJSON[CRDHealth](c, "/katalog/"+name+"/health")
+}
+```
+
+The info call (`GET /katalog/{crd}`) is retried with the same logic. Worker fields (`workersActive`, `workersIdle`, `workerDetails`) are live runtime state — zero on follower pods. Showing zero workers alongside 101 reconciles would be misleading. Static fields (GVK, resync, namespace) are identical on both pods.
+
+```go
+var info *CRDInfo
+for i := 0; i < 3; i++ {
+    inf, err := getJSON[CRDInfo](c, "/katalog/"+name)
+    if err != nil {
+        return nil, fmt.Errorf("fetching info: %w", err)
+    }
+    if inf.IsKonductor {
+        info = inf
+        break
+    }
+}
+if info == nil {
+    info, _ = getJSON[CRDInfo](c, "/katalog/"+name)
+}
+```
+
+With 2 pods and 50/50 routing, the probability of hitting the leader at least once in 3 tries is 87.5%. The fallback renders with stale data rather than an error.
+
+---
+
+→ Next: [04-diagnosis.md](04-diagnosis.md)  
+→ Previous: [02-runtime.md](02-runtime.md)

--- a/pkg/kordinator/docs/health-reporting/04-diagnosis.md
+++ b/pkg/kordinator/docs/health-reporting/04-diagnosis.md
@@ -1,0 +1,128 @@
+# CRD Health Reporting — Diagnosis
+
+## Identifying the leader pod
+
+Port-forward directly to each runtime pod and check `isKonductor` on both `/katalog` and `/katalog/{crd}/health`:
+
+```bash
+# Forward to each pod individually
+kubectl port-forward -n orkestra-system-01 pod/<pod-a> 8010:8080 &
+kubectl port-forward -n orkestra-system-01 pod/<pod-b> 8011:8080 &
+
+# Check which pod is the leader
+curl -sSL localhost:8010/katalog | jq .isKonductor   # true  = leader
+curl -sSL localhost:8011/katalog | jq .isKonductor   # false = follower
+```
+
+The leader will have non-zero `totalReconciles` and a real `lastReconcile` timestamp:
+
+```bash
+curl -sSL localhost:8010/katalog/website/health | jq '{isKonductor,state,totalReconciles,lastReconcile}'
+# Leader:
+{
+  "isKonductor": true,
+  "state": "healthy",
+  "totalReconciles": 101,
+  "lastReconcile": "2026-05-29T15:05:14Z"
+}
+
+curl -sSL localhost:8011/katalog/website/health | jq '{isKonductor,state,totalReconciles,lastReconcile}'
+# Follower:
+{
+  "isKonductor": false,
+  "state": "pending",
+  "totalReconciles": 0,
+  "lastReconcile": "not started"
+}
+```
+
+---
+
+## Confirming the CC is getting authoritative data
+
+Check the CC logs for each runtime fetch. Every tick logs the katalog name and CRD count:
+
+```
+INFO: fetched katalog "data-platform" from http://orkestra-runtime.orkestra-system-05.svc.cluster.local:8080 (10 CRDs, gateway="")
+```
+
+If you see all runtimes fetched consistently every tick but some still show pending in the UI, the CC is hitting the follower and the `isKonductor` guard is discarding the update. The state will resolve within 1–2 ticks once the guard accepts a leader response.
+
+---
+
+## Common failure patterns
+
+### All runtimes show pending indefinitely
+
+**Cause:** The runtime binary is old — it does not emit `isKonductor` in its response. The field defaults to `false` in JSON. The CC guard discards every update after the first follower response, freezing state as pending.
+
+**Fix:** Rebuild and redeploy the runtime. Both runtime and CC must be on builds that include `isKonductor`.
+
+**Check:**
+```bash
+curl -sSL <runtime-svc>/katalog | jq 'has("isKonductor")'
+# true  → new build
+# false → old build (isKonductor will be absent, Go unmarshals as false)
+```
+
+---
+
+### Some runtimes healthy, others stuck on pending
+
+**Cause (pre-fix):** Connection pooling in the CC HTTP client. The first TCP connection to each runtime Service lands on a random pod. If it lands on the follower, all subsequent requests reuse that connection and always return follower data.
+
+**Fix:** `DisableKeepAlives: true` on the CC HTTP client (see [03-control-center.md](03-control-center.md)).
+
+**Confirm:**
+```bash
+# From inside the CC pod, verify the runtime responds with isKonductor
+kubectl exec -n orkestra-system-01 deploy/orkestra-cc -- \
+  wget -qO- http://orkestra-runtime.orkestra-system-05.svc.cluster.local:8080/katalog \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print('isKonductor:', d['isKonductor'])"
+```
+
+Run this a few times — with `DisableKeepAlives`, each run opens a new connection. You should see `isKonductor: true` approximately half the time (leader) and `false` the other half (follower).
+
+---
+
+### CRD detail page flaps but katalog index is stable
+
+**Cause:** The background fetch (index) is cached and guarded. The CRD detail page makes live on-demand calls that can land on the follower.
+
+**Fix:** Retry logic on `FetchCRDDetail` (see [03-control-center.md](03-control-center.md)).
+
+**Confirm:** Open the CRD detail page and watch the `state` badge — if it alternates between `healthy` and `pending` on each page load, the retry is not working or the runtime binary is old.
+
+---
+
+### `isKonductor: false` on both pods
+
+**Cause:** Leader election is not running, OR the runtime binary predates the `SetIsKonductor` call in `Kordinate()`.
+
+Check the Lease object:
+```bash
+kubectl get lease orkestra-konductor -n orkestra-system-01 -o yaml
+```
+
+The `holderIdentity` field shows the current leader's pod hostname. If the Lease doesn't exist, leader election hasn't started.
+
+Check that `LEADER_ELECTION=true` is set on the runtime pods:
+```bash
+kubectl exec -n orkestra-system-01 deploy/orkestra-runtime -- env | grep LEADER_ELECTION
+```
+
+---
+
+## Quick reference — expected responses by pod type
+
+| Field | Leader | Follower |
+|-------|--------|----------|
+| `isKonductor` | `true` | `false` |
+| `OrkReady` | `true` | `true` |
+| `healthy` | `true` (after warmup) | `false` |
+| `state` | `healthy` | `pending` |
+| `totalReconciles` | > 0 | `0` |
+| `lastReconcile` | RFC3339 timestamp | `"not started"` |
+| `resourceCount` | > 0 (informer cache) | > 0 (informer cache) |
+
+`resourceCount` is the same on both pods — it comes from the informer cache, which is synced from the Kubernetes API independently of leadership.


### PR DESCRIPTION
# fix: prevent CRD health flapping under multi-replica deployments

## Problem

When the runtime runs with `replicaCount > 1` and leader election enabled, only one pod (the konductor) runs the reconcilers. Follower pods serve HTTP requests but their in-memory `CRDHealth` never advances — they always return `state: pending, healthy: false, totalReconciles: 0`.

The Control Center's background fetch loop calls `GET /katalog` on each runtime via the Kubernetes Service. The Service round-robins across pods. Some ticks land on the leader (healthy CRDs), some on the follower (pending CRDs). The display alternates between healthy and pending on every other tick.

Additionally, Go's `http.Client` reuses TCP connections by default. The Service's load balancing only applies to **new** connections. The CC's first connection to each runtime Service gets pinned to whichever pod kube-proxy picked — permanently. Two of the six runtime Services happened to pin to the follower, showing those operators as pending forever regardless of actual state.

The same problem affects the CRD detail page: `workersActive`, `workersIdle`, and `workerDetails` are all zero on follower pods because workers are never started. A user opening the detail page for a healthy CRD would see zero workers alongside a healthy state — or a pending state if they were unlucky on the health call.

Confirmed by port-forwarding to each pod individually:
```json
// Pod A — konductor (8010)
{ "isKonductor": true, "state": "healthy", "totalReconciles": 101 }

// Pod B — follower (8011)  
{ "isKonductor": false, "state": "pending", "totalReconciles": 0 }
```

## Solution

### 1 — `isKonductor` signal on all runtime health endpoints

Added `isKonductor atomic.Bool` to `OrkestraHealth`. Set to `true` at the start of `Kordinate()` (only called on the winning pod), cleared to `false` on leadership loss.

Propagated to all three data-serving endpoints via the global `OrkestraHealth` instance from `konstructRuntime`:

| Endpoint | Field added | Guards |
|----------|-------------|--------|
| `GET /katalog` | `"isKonductor"` | Background fetch cache |
| `GET /katalog/{crd}/health` | `"isKonductor"` | CRD state, error counts, reconcile timestamps |
| `GET /katalog/{crd}` | `"isKonductor"` | Worker pool state, queue depth |

The per-CRD `h.orkHealth` field was NOT used — it is a separate uninitialised instance attached to each `CRDHealth` for unrelated purposes. Both `BuildCRDHealthHandler` and `BuildCRDInfoHandler` now take `o *OrkestraHealth` explicitly.

`orkHealth` construction was moved before the CRD route registration loop so it is in scope for both handlers.

### 2 — `DisableKeepAlives` on CC HTTP client

Forces a new TCP connection on every background fetch. With keep-alive (the default), the CC is permanently pinned to whichever pod its first connection reached. With new connections per tick, kube-proxy distributes load and every fetch has a fair chance of hitting the leader.

### 3 — Cache-update guard in `fetchAllKatalogs`

Three-case rule on each fetch result:

| Response | `inst.Katalog` state | Action |
|----------|----------------------|--------|
| `isKonductor: true` | any | Replace — authoritative leader data |
| `isKonductor: false` | nil | Accept — no data yet; katalog appears immediately, may show pending until leader responds |
| `isKonductor: false` | non-nil | Discard — keep last known-good snapshot |

The nil case is required: without it, a first connection that lands on the follower would leave `inst.Katalog` nil forever and the katalog would never appear in the index until a lucky tick hit the leader.

### 4 — Retry in `FetchCRDDetail`

Both the health call and the info call are retried up to 3 times until `isKonductor: true`. With 2 pods, P(hitting leader at least once in 3 tries) = 87.5%. The fallback renders with stale data rather than returning an error.

## Properties

- **No readiness probe changes** — all pods remain `1/1 Ready`; ArgoCD and Kubernetes show a healthy deployment
- **Replica-count agnostic** — `replicaCount: 1` continues to work; the single pod always wins election and sets `isKonductor: true`
- **Transparent failover** — when the leader pod is evicted and a follower wins, `isKonductor` flips on the new leader within one lease cycle; the CC snapshot updates on the next fetch tick
- **No shared state** — the signal travels in the existing HTTP responses; no ConfigMap, no etcd, no leader IP discovery

## Files changed

```
pkg/kordinator/crd_health.go
  + isKonductor atomic.Bool on OrkestraHealth
  + SetIsKonductor(bool) / IsKonductor() bool

pkg/kordinator/crd_health_handers.go
  + IsKonductor field on CRDHealthResponse and CRDInfoResponse
  + BuildCRDHealthHandler: add o *OrkestraHealth param, use o.IsKonductor()
  + BuildCRDInfoHandler: add o *OrkestraHealth param, use o.IsKonductor()

pkg/kordinator/dependency_kordinator.go
  + SetIsKonductor(true) at start of Kordinate()
  + SetIsKonductor(false) before leadership-loss shutdown

cmd/internal/runtime_konstructor.go
  + Move orkHealth construction before CRD route loop
  + Remove duplicate orkHealth declaration
  + Pass orkHealth to BuildCRDHealthHandler and BuildCRDInfoHandler

cmd/controlcenter/cc/client.go
  + DisableKeepAlives: true on HTTP transport
  + FetchCRDDetail: retry health call up to 3 times until isKonductor=true
  + FetchCRDDetail: retry info call up to 3 times until isKonductor=true

cmd/controlcenter/cc/types.go
  + IsKonductor bool on KatalogResponse, CRDHealth, CRDInfo

cmd/controlcenter/cc/controlcenter.go
  + fetchAllKatalogs: three-case cache-update guard on isKonductor

pkg/kordinator/docs/health-reporting/   (new folder)
  01-overview.md
  02-runtime.md
  03-control-center.md
  04-diagnosis.md

pkg/kordinator/docs/README.md
  + pointer to health-reporting/ subfolder
