### PR TITLE
docs: split external index and add known issue KI-002

### DIFF
--- a/documentation/concepts/operatorbox/07-external/03-best-practices.md
+++ b/documentation/concepts/operatorbox/07-external/03-best-practices.md
@@ -1,0 +1,142 @@
+# Best Practices
+
+---
+
+## Gate calls with `when:` to avoid unnecessary API calls
+
+External calls run on every reconcile by default. For calls that don't need to run every cycle, use `when:` to skip them. Write the result to a status field on first success — subsequent reconciles check the status field instead of calling the API.
+
+```yaml
+external:
+  - name: signImage
+    url: "{{ .spec.serviceUrl }}/sign"
+    method: POST
+    when:
+      - field: status.signedImage
+        notEquals: "{{ .spec.image }}"   # skip if already signed
+
+status:
+  fields:
+    - path: signedImage
+      value: "{{ .spec.image }}"
+      when:
+        - field: external.signImage.status
+          equals: "200"
+```
+
+The pattern: **call → write result to status → gate future calls on status**. No annotations, no counters — a status field and a condition.
+
+---
+
+## Distinguish transient failures from definitive rejections
+
+Not all failures are equal. An HTTP 5xx means the service is unavailable — retry makes sense. An HTTP 4xx means the service made a decision — retrying the same request will always get the same answer.
+
+Write a rejection-tracking status field only on 4xx. Use the `prefix:` operator to match status code ranges. Gate the call on both the success state and the rejection state:
+
+```yaml
+external:
+  - name: signImage
+    continueOnError: true
+    when:
+      - field: status.signedImage
+        notEquals: "{{ .spec.image }}"
+      - field: status.rejectedImage    # gate closes on definitive rejection
+        notEquals: "{{ .spec.image }}"
+
+status:
+  fields:
+    # 4xx — definitive rejection, close the gate
+    - path: rejectedImage
+      value: "{{ .spec.image }}"
+      when:
+        - field: external.signImage.called
+          equals: "true"
+        - field: external.signImage.status
+          prefix: "4"
+
+    # 5xx — transient, leave the gate open, retry next reconcile
+    - path: phase
+      value: "SigningUnavailable"
+      when:
+        - field: external.signImage.called
+          equals: "true"
+        - field: external.signImage.status
+          prefix: "5"
+```
+
+The reconcile loop is the retry. Gate correctly and retries are automatic where appropriate, suppressed where they are not.
+
+---
+
+## Use `continueOnError: false` for hard dependencies, `true` for policy decisions
+
+If a resource must never exist without the call succeeding, use `continueOnError: false` — the reconcile halts and `Ready=False` is written to the CR condition.
+
+If the call carries meaningful information even when it fails — a rejection reason, a flag value, an unavailability signal — use `continueOnError: true`. Gate resources with `when:` conditions on the call result. Status fields surface the details. The reconcile succeeds and the CR tells the full story.
+
+---
+
+## Calls can drive resource attributes, not just gate conditions
+
+`.external.*` fields are available in any template expression — including resource spec fields. This means a live flag value can set replica counts directly, not just control whether a resource is created:
+
+```yaml
+# Full capacity when flag is on
+deployments:
+  - name: "{{ .metadata.name }}"
+    replicas: "{{ .spec.replicas }}"
+    reconcile: true
+    when:
+      - field: external.flags.body
+        equals: "true"
+
+# Baseline when flag is off or the flag service is unavailable
+  - name: "{{ .metadata.name }}"
+    replicas: "1"
+    reconcile: true
+    when:
+      - field: external.flags.body
+        notEquals: "true"   # also catches empty body on service outage
+```
+
+Both entries target the same Deployment name. Exactly one fires per reconcile. `reconcile: true` ensures the existing Deployment is updated, not just gated.
+
+---
+
+## Keep tokens in environment variables
+
+Never put bearer tokens or API keys in the Katalog. Use `$ENV_VAR` in the `token:` field — the value is expanded via `os.ExpandEnv` at call time:
+
+```yaml
+token: "$API_TOKEN"        # correct — expanded at runtime
+token: "abc123secret"      # never — visible in the Katalog YAML
+```
+
+In production, mount the secret into the Orkestra pod via `values.yaml`:
+
+```yaml
+runtime:
+  extraEnvFrom:
+    - secretRef:
+        name: external-api-credentials
+```
+
+For local development with `--dev-server`, no token is needed — the mock server ignores auth headers.
+
+---
+
+## Match `timeout:` to your resync period
+
+If `resync: 15s` and the external call can take up to 10s, the operator spends most of each cycle waiting. Set `timeout:` to a fraction of the resync period — typically no more than 20–30%.
+
+---
+
+## Name calls with camelCase
+
+Call names must be valid Go identifiers. Hyphens break template access:
+
+```yaml
+name: healthCheck      # correct   → {{ .external.healthCheck.status }}
+name: health-check     # broken    → {{ .external.health-check.status }} fails to parse
+```

--- a/documentation/concepts/operatorbox/07-external/index.md
+++ b/documentation/concepts/operatorbox/07-external/index.md
@@ -1,254 +1,39 @@
 # External
 
-The `external:` block makes HTTP calls before any resource group runs. Results land in `.external.<name>.*` — every resource template, `when:` condition, and status field that follows can read them. One call can gate a Deployment, fill a ConfigMap, drive a replica count, or feed the token for the next call.
+`external:` makes HTTP calls before any resource group runs. Results land in `.external.<name>.*` and are available to every resource template, `when:` condition, and status field for the rest of that reconcile cycle. A single external call can gate a Deployment, embed a live config into a ConfigMap, sign an image, or supply the auth token for the next call in the sequence.
 
-```yaml
-operatorBox:
-  onReconcile:
-    external:
-      - name: healthCheck
-        url: "{{ .spec.serviceUrl }}/health"
-        expectedStatus: 200
-        continueOnError: true
-        timeout: 5s
+**Why it exists.** Operators often need to coordinate with the world outside the cluster — an upstream health check, a signing service, a feature flag API, an external auth provider. Without `external:`, you would write Go hooks for each. With `external:`, you declare the call and reference the result in templates. The operator handles the HTTP, the retry, the timeout, and the error surfacing.
 
-    deployments:
-      - name: "{{ .metadata.name }}"
-        when:
-          - field: external.healthCheck.status
-            equals: "200"
-```
+---
+
+## The key design decision
+
+Every external call is either a **hard prerequisite** or **optional enrichment**. This is `continueOnError`.
+
+`continueOnError: false` (the default) halts the reconcile when the call fails and writes `Ready=False` to the CR condition. Use this when the call is an infrastructure requirement — there is no meaningful state without it.
+
+`continueOnError: true` lets the reconcile continue when the call fails, with `.error` set and the result available in status fields. Use this when the call result carries meaning even on failure — a rejection, a degraded flag value, a cached config.
+
+The distinction matters: a 403 from a signing service is a policy decision, not an infrastructure failure. The operator should keep reconciling, surface the rejection in status, and enforce it through a `when:` gate on the Deployment — not halt with a raw error.
 
 ---
 
 ## Where external sits in the pipeline
 
 ```text
-informer cache → DeepCopy → normalize → mutation → validation
-    → cross-CRD reads                    (.cross.* available in url: and body:)
-    → external calls                     ← you are here
-    → resource groups (deployments, services, configMaps, …)
-    → read children → enrich
-    → status fields
+informer cache → normalize → mutation → validation
+    → cross-CRD reads          (.cross.* available in url: and body:)
+    → external calls           ← you are here
+    → resource groups
+    → enrich → status fields
 ```
 
-External runs after `cross:` context is injected — `.cross.*` is already accessible in `url:` and `body:` fields. Every call's result is available to every resource group and every status field that comes after it.
+External runs after `cross:` context is injected, so `.cross.*` is accessible in `url:` and `body:` fields. Every call's result is available to every resource group and status field that follows.
 
 ---
 
-## The primary design decision: required vs optional
+## Pages
 
-Every external call is either a **hard prerequisite** or **optional enrichment**. This is `continueOnError`.
-
-| Setting | Behaviour | Use when |
-|---|---|---|
-| `continueOnError: false` (default) | Failure halts the reconcile. `Ready=False` is written to the CR condition. The operator retries on the next resync. | The call is an infrastructure requirement — nothing should be created without it. |
-| `continueOnError: true` | Failure is logged. `.error` is set. The reconcile succeeds and resources are updated normally. | The call is a policy or enrichment decision — the system should keep running and the rejection should be visible in status, not as a reconcile error. |
-
-**The real distinction is where the failure should surface.**
-
-`continueOnError: false` surfaces failure as a reconcile error — visible in the CR condition, retried automatically. Use this when the service not responding means you have no information to act on (e.g., auth token fetch for a chained call).
-
-`continueOnError: true` surfaces failure in `.external.<name>.error` and through your status fields — a 403 from a signing service is a policy decision, not an infrastructure failure. The operator keeps reconciling, the status shows what happened, and the Deployment gate does the enforcement. Use this when the call result carries meaning even on failure.
-
----
-
-## Results in template context
-
-After a call completes, four fields are available under `.external.<name>`:
-
-| Field | Type | Value |
-|---|---|---|
-| `.status` | `string` | HTTP status code: `"200"`, `"403"`, `"503"`. Empty if the call failed before receiving a response. |
-| `.body` | `string` | First 4096 bytes of the response body. |
-| `.error` | `string` | Error message on failure. `""` on success. |
-| `.called` | `string` | `"true"` when the call ran. `"false"` when skipped by `when:`/`anyOf:`. |
-
-Access in any template expression or condition:
-
-```yaml
-# Gate a resource
-- field: external.healthCheck.status
-  equals: "200"
-
-# Embed the response body
-value: "{{ .external.appConfig.body }}"
-
-# Use a prior call's result in a later call
-token: "{{ .external.tokenFetch.body }}"
-
-# Compare against a CR field — template expressions resolve in equals: values
-- field: status.signedImage
-  equals: "{{ .spec.image }}"
-```
-
----
-
-## Try it — no real services needed
-
-All five examples run against the built-in mock dev server. `--dev-server` starts it on `:9999` and serves every endpoint the examples use:
-
-```bash
-ork init --pack use-cases
-```
-
-```bash
-cd external/01-health-gate     # gate a Deployment on a live health check
-ork run --dev-server
-
-cd external/02-config-inject   # embed an API response into a ConfigMap every reconcile
-ork run --dev-server
-
-cd external/03-image-signing   # sign once per image — 4xx locks retries, 5xx stays open
-ork run --dev-server
-
-cd external/04-chained         # chain two calls — second uses the first call's token
-ork run --dev-server
-
-cd external/05-feature-flags   # external call drives replica count, toggle live without restart
-ork run --dev-server
-```
-
-To toggle the feature flag while the operator is running:
-```bash
-curl -X POST http://localhost:9999/flags/my-app/v2Enabled/toggle
-```
-
----
-
-## Best practices
-
-### Gate calls with `when:` to avoid unnecessary API calls
-
-External calls run on every reconcile by default. For calls that don't need to run every cycle, use `when:` to skip them. Write the result to a status field on first success — subsequent reconciles check the status field instead of calling the API.
-
-```yaml
-external:
-  - name: signImage
-    url: "{{ .spec.serviceUrl }}/sign"
-    method: POST
-    when:
-      - field: status.signedImage
-        notEquals: "{{ .spec.image }}"   # skip if already signed
-
-status:
-  fields:
-    - path: signedImage
-      value: "{{ .spec.image }}"
-      when:
-        - field: external.signImage.status
-          equals: "200"
-```
-
-The pattern: **call → write result to status → gate future calls on status**. No annotations, no counters — a status field and a condition.
-
-### Distinguish transient failures from definitive rejections
-
-Not all failures are equal. An HTTP 5xx means the service is unavailable — retry makes sense. An HTTP 4xx means the service made a decision — retrying the same request will always get the same answer.
-
-Write a `rejectedImage` (or equivalent) status field only on 4xx. Use the `prefix:` operator to match status code ranges. Gate the call on both the success status and the rejection status:
-
-```yaml
-external:
-  - name: signImage
-    continueOnError: true
-    when:
-      - field: status.signedImage
-        notEquals: "{{ .spec.image }}"
-      - field: status.rejectedImage    # closed on definitive rejection
-        notEquals: "{{ .spec.image }}"
-
-status:
-  fields:
-    # Lock out retries on 4xx — the signing service made a policy decision
-    - path: rejectedImage
-      value: "{{ .spec.image }}"
-      when:
-        - field: external.signImage.called
-          equals: "true"
-        - field: external.signImage.status
-          prefix: "4"
-
-    # Leave the gate open on 5xx — the service may recover, retry next reconcile
-    - path: phase
-      value: "SigningUnavailable"
-      when:
-        - field: external.signImage.called
-          equals: "true"
-        - field: external.signImage.status
-          prefix: "5"
-```
-
-The reconcile loop is the retry. Gate the call correctly and retries are automatic where appropriate, suppressed where not.
-
-### Use `continueOnError: false` for hard dependencies, `true` for policy decisions
-
-If a resource must never exist without the call succeeding, use `continueOnError: false` — the reconcile halts and the caller sees a clear `Ready=False` condition.
-
-If the call carries meaningful information even when it fails — a rejection reason, a flag value, an unavailability signal — use `continueOnError: true`. Gate resources with `when:` conditions on the call result. Status fields surface the details. The reconcile succeeds and the CR tells the full story.
-
-### External calls can drive resource attributes, not just gate conditions
-
-`external.*` fields are available everywhere in the template context — including in resource spec fields, not just `when:` conditions. Combine with two deployment entries for clean replica-count switching:
-
-```yaml
-external:
-  - name: flags
-    url: "{{ .spec.serviceUrl }}/flags/{{ .metadata.name }}/v2Enabled"
-    continueOnError: true
-
-deployments:
-  - name: "{{ .metadata.name }}"
-    replicas: "{{ .spec.replicas }}"   # full capacity when flag is on
-    reconcile: true
-    when:
-      - field: external.flags.body
-        equals: "true"
-
-  - name: "{{ .metadata.name }}"
-    replicas: "1"                      # baseline when flag is off or service is down
-    reconcile: true
-    when:
-      - field: external.flags.body
-        notEquals: "true"              # also catches empty body on service outage
-```
-
-### Keep tokens in environment variables
-
-Never put bearer tokens or API keys in the Katalog. Use `$ENV_VAR` in the `token:` field:
-
-```yaml
-token: "$API_TOKEN"        # correct — expanded via os.ExpandEnv at runtime
-token: "abc123secret"      # never — visible in the Katalog YAML
-```
-
-In production, mount the secret into the Orkestra runtime pod via `values.yaml`:
-
-```yaml
-runtime:
-  extraEnvFrom:
-    - secretRef:
-        name: external-api-credentials
-```
-
-For local development with `--dev-server`, no token is needed — the mock server ignores auth headers entirely.
-
-### Match `timeout:` to your resync period
-
-If `resync: 15s` and the external call can take up to 10s, the operator spends most of each cycle waiting. Set `timeout:` to a fraction of the resync period — typically no more than 20–30%.
-
-### Name calls with camelCase
-
-Call names must be valid Go identifiers. Hyphens break template access.
-
-```yaml
-name: healthCheck      # correct   → {{ .external.healthCheck.status }}
-name: health-check     # broken    → {{ .external.health-check.status }} fails
-```
-
----
-
-## Where to go next
-
-- [Patterns](01-patterns.md) — health gates, config injection, image signing with rejection tracking, chaining, feature flag rollouts
-- [Reference](02-reference.md) — full field table, constraints, template expression support, env var expansion
+- [Patterns](01-patterns.md) — health gate, config injection, image signing with rejection tracking, chaining, feature flag rollout
+- [Best practices](03-best-practices.md) — when to gate calls, 4xx vs 5xx, driving resource attributes, tokens, timeouts, naming
+- [Reference](02-reference.md) — full field table, wire format, result context, constraints

--- a/documentation/known-issues/index.md
+++ b/documentation/known-issues/index.md
@@ -7,6 +7,7 @@ Pre-v1 issues tracked here. Each entry is a real limitation — not a bug in the
 | # | Title | Affects | Status |
 |---|-------|---------|--------|
 | [KI-001](./ki-001-gateway-stats-multi-replica.md) | Gateway webhook stats show zeros with multiple replicas | Gateway `/katalog` endpoint | Open — pre-v1 |
+| [KI-002](./ki-002-resource-update-conflict.md) | Transient resource update conflict on fast reconciles | Deployments, StatefulSets, ReplicaSets, Pods | Mitigated — pre-v1 SSA planned |
 
 ---
 

--- a/documentation/known-issues/ki-002-resource-update-conflict.md
+++ b/documentation/known-issues/ki-002-resource-update-conflict.md
@@ -1,0 +1,40 @@
+# KI-002 — Transient resource update conflict on fast reconciles
+
+**Status:** Mitigated — pre-v1 architectural resolution planned (SSA)
+**Affects:** Deployments, StatefulSets, ReplicaSets, Pods — any resource updated via `reconcile: true`
+
+---
+
+## What you see
+
+A log line like:
+
+```
+level=error error="deployment.Update: updating deployment \"my-app\": Operation cannot be fulfilled
+on deployments.apps \"my-app\": the object has been modified; please apply your changes to the
+latest version and try again"
+```
+
+followed immediately by a successful reconcile on the next cycle. No resources are lost or corrupted.
+
+---
+
+## Why it happens
+
+Orkestra's reconcile path uses the classic Get → modify → Update pattern. A status patch at the end of each reconcile increments the resource version of the CR, which re-queues an immediate reconcile. In fast-resync or high-churn scenarios, a second reconcile can begin before the first Update has fully committed, producing a version conflict.
+
+This was most pronounced when `SyncContainerSpec` and `SyncPodSpec` compared all fields unconditionally — Kubernetes defaults like `ServiceAccountName: "default"` and `Protocol: "TCP"` differed from the zero values in the desired spec on every cycle, triggering unnecessary Updates that collided with status patches. The declared-intent guards introduced in `sync.go` eliminated the practical conditions under which this conflict occurred.
+
+---
+
+## Workaround
+
+No action required. The reconciler retries on the next resync and converges correctly. If you see repeated conflict errors rather than a single transient one, check whether a field is being compared without a declared-intent guard in the relevant `Sync*` function.
+
+---
+
+## Resolution plan
+
+Server Side Apply (SSA) is the architectural solution. Rather than Get → modify → Update, the operator sends only the fields it owns and Kubernetes merges them server-side using field ownership tracking. SSA eliminates the version conflict entirely because the server handles the merge — no resource version check is required.
+
+Scheduled for resolution before v1.


### PR DESCRIPTION
## What this PR does

Two documentation changes made after the main session commit.

### External concept docs restructured

`07-external/index.md` was carrying five distinct concerns in one file — pipeline position, `continueOnError` semantics, results reference, a Try it block, and a full best practices section. The index is now an orientation page only: what `external:` is, why it exists, the one key design decision (`continueOnError`), pipeline position, and links to the three sub-pages.

Best practices moved to a new `03-best-practices.md` — when to gate calls with `when:`, distinguishing 4xx definitive rejections from 5xx transient failures, driving resource attributes not just gate conditions, token handling, timeout sizing, camelCase naming.

### KI-002 — Transient resource update conflict

A known issue entry for the `the object has been modified` conflict error that can appear in operator logs during fast-reconcile or high-churn scenarios. The issue is mitigated in practice — the declared-intent guards in `sync.go` eliminated the conditions that caused it by stopping unnecessary Updates triggered by Kubernetes defaults differing from zero-value desired specs. Server Side Apply is the architectural resolution before v1.
