### PR TITLE
update integration test signatures and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ ork run
 
 `ork init` scaffolds a `katalog.yaml`, `crd.yaml`, and `cr.yaml` in the current directory — like `terraform init`.
 
+**→ [Learning to Orkestrate](https://orkestra.sh/docs/getting-started/learning-to-orkestrate)** — the guided path from first operator to full platform. Every capability has a runnable example.
+
 ---
 
 ### Control Center
@@ -134,8 +136,6 @@ In another terminal:
 ork control
 ```
 > → localhost:8081 · username:password → orkestra
-
-**→ [Learning to Orkestrate](https://orkestra.sh/docs/getting-started/learning-to-orkestrate)** — the guided path from first operator to full platform. Every capability has a runnable example.
 
 ![Control Center — multi-Runtime view](./documentation/assets/controlcenter/public/control-center.png)
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -112,12 +112,65 @@ setup-envtest use 1.32.x --bin-dir ~/.envtest-bins
 
 ---
 
-### 3. E2E tests — not yet written
+### 3. E2E tests — `ork e2e`
 
-End-to-end tests would run `ork` as a real process against a real cluster
-(e.g. kind) and verify that creating a CR causes the expected Deployments,
-Services, and health transitions. They are the planned next layer after
-integration coverage matures.
+E2E tests are declarative YAML documents (`kind: E2E`) executed by `ork e2e`.
+They run `ork` as a real process against a real cluster and verify that
+creating a CR causes the expected Deployments, Services, and health transitions.
+
+**How it works:**
+
+```
+kind cluster → CRD apply → setup manifests → bundle generate+apply
+  → ork helm install → CR apply → expectation polling → teardown
+```
+
+Teardown always runs — owned clusters are deleted unless `--keep-cluster` is
+set; borrowed clusters (`--use-current` / `--cluster`) are cleaned up but not
+destroyed.
+
+**Running an E2E spec:**
+
+```bash
+ork e2e ./e2e.yaml                        # provisions a new kind cluster
+ork e2e ./e2e.yaml --use-current          # uses the current kube context
+ork e2e ./e2e.yaml --cluster my-ctx       # uses a specific named context
+ork e2e ./e2e.yaml --keep-cluster         # skips cluster teardown (debug)
+```
+
+**Writing an E2E spec (`kind: E2E`):**
+
+```yaml
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: website-smoke
+spec:
+  katalog: ./katalog.yaml
+  cr: ./website-cr.yaml
+  cluster:
+    provider: kind          # default
+    name: ork-e2e           # default
+  expect:
+    - after: cr-applied
+      timeout: 60s
+      resources:
+        - kind: Deployment
+          name: website
+          namespace: default
+          fields:
+            spec.replicas: 1
+        - kind: Service
+          name: website-svc
+          namespace: default
+```
+
+Expectations are polled until they pass or the timeout expires. Each
+`resources` entry can check field values, existence, and command exit codes.
+Results are returned as a `*Result` with per-case timings — `ork registry push`
+embeds them as OCI annotations.
+
+E2E specs live alongside the Katalog they test, not under `tests/`.
 
 ---
 

--- a/tests/integration/komposer/sources_test.go
+++ b/tests/integration/komposer/sources_test.go
@@ -31,7 +31,7 @@ func writeKatalogFile(t *testing.T, name string, crdNames ...string) string {
 func TestKomposer_InlineOverride_WinsOverSource(t *testing.T) {
 	sourceKatalog := writeKatalogFile(t, "source", "website", "database")
 
-	komposerContent := "apiVersion: orkestra.orkspace.io/v1\nkind: Komposer\nmetadata:\n  name: override-test\nsources:\n  files:\n    - url: " + sourceKatalog + "\nspec:\n  crds:\n    website:\n      enabled: false\n"
+	komposerContent := "apiVersion: orkestra.orkspace.io/v1\nkind: Komposer\nmetadata:\n  name: override-test\nimports:\n  files:\n    - url: " + sourceKatalog + "\nspec:\n  crds:\n    website:\n      enabled: false\n"
 	f, err := os.CreateTemp("", "*.yaml")
 	if err != nil {
 		t.Fatalf("creating temp file: %v", err)
@@ -70,7 +70,7 @@ func TestKomposer_MultipleFileSources_AllMerged(t *testing.T) {
 	srcA := writeKatalogFile(t, "source-a", "crd-a1", "crd-a2")
 	srcB := writeKatalogFile(t, "source-b", "crd-b1")
 
-	content := "apiVersion: orkestra.orkspace.io/v1\nkind: Komposer\nmetadata:\n  name: multi-source\nsources:\n  files:\n    - url: " + srcA + "\n    - url: " + srcB + "\nspec:\n  crds: {}\n"
+	content := "apiVersion: orkestra.orkspace.io/v1\nkind: Komposer\nmetadata:\n  name: multi-source\nimports:\n  files:\n    - url: " + srcA + "\n    - url: " + srcB + "\nspec:\n  crds: {}\n"
 	f, _ := os.CreateTemp("", "*.yaml")
 	f.WriteString(content)
 	f.Close()

--- a/tests/integration/kubeclient/patch_test.go
+++ b/tests/integration/kubeclient/patch_test.go
@@ -151,7 +151,7 @@ func TestPatchLabels_AddsLabels(t *testing.T) {
 	obj := createProbe(t, ctx, "lbl-add", "default")
 
 	labels := map[string]string{"env": "test", "managed-by": "orkestra"}
-	if err := kube.PatchLabels(ctx, obj, probeGVR, labels); err != nil {
+	if err := kube.PatchLabels(ctx, obj, probeGVR, nil, labels); err != nil {
 		t.Fatalf("PatchLabels: %v", err)
 	}
 
@@ -184,7 +184,7 @@ func TestPatchLabels_DoesNotRemoveExistingLabels(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 
-	if err := kube.PatchLabels(ctx, created, probeGVR, map[string]string{"new": "label"}); err != nil {
+	if err := kube.PatchLabels(ctx, created, probeGVR, nil, map[string]string{"new": "label"}); err != nil {
 		t.Fatalf("PatchLabels: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

- `tests/integration/kubeclient/patch_test.go`: `PatchLabels` gained a `base`
  parameter (`base, desired map[string]string`). Two test call sites still used
  the old 4-arg form — updated to pass `nil` as base (no prior labels to track
  for deletion).

- `tests/integration/komposer/sources_test.go`: Two tests that expect `Merge()`
  to succeed were writing `sources:` in their Komposer YAML. The schema field
  is `imports:`. Updated both inline YAML strings to use `imports:`.
  The two tests that already passed (`CannotSourceAnotherKomposer`,
  `KatalogCannotDeclareSourcesBlock`) intentionally use `sources:` — they
  expect a validation error, so they are left unchanged.

- `tests/README.md`: Replaced the "E2E tests — not yet written" placeholder
  with documentation for `ork e2e` and the `kind: E2E` spec format.

## Test plan

- [x] `make test-integration` passes (komposer and kubeclient packages)
