### PR TITLE
Feat/add e2e to external example pack

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -247,3 +247,74 @@ jobs:
         run: |
           echo "## Control Center Image" >> "$GITHUB_STEP_SUMMARY"
           echo "\`ghcr.io/${{ inputs.repository }}-cc:${{ inputs.image_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+
+  build-devserver:
+    name: Build and Push Dev Server
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.1.0
+        with:
+          driver-opts: |
+            image=moby/buildkit:buildx-stable-1
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.ORK_PUBLISH_PAT }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ inputs.repository }}-dev-server
+          tags: |
+            type=semver,pattern={{version}},value=${{ inputs.image_tag }}
+            type=raw,value=latest
+
+      - name: Cache compiled Linux binaries
+        id: cache-binaries
+        uses: actions/cache@v5
+        with:
+          path: |
+            ork-amd64
+            ork-arm64
+          key: linux-binaries-devserver-${{ hashFiles('go.sum', 'pkg/devserver/**/*.go', 'cmd/devserver/**/*.go') }}
+
+      - name: Build Linux binaries (if cache miss)
+        if: steps.cache-binaries.outputs.cache-hit != 'true'
+        run: |
+          DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          LDFLAGS="-X github.com/orkspace/orkestra/pkg/version.Version=${{ github.ref_name }} -X github.com/orkspace/orkestra/pkg/version.Commit=${{ github.sha }} -X github.com/orkspace/orkestra/pkg/version.Date=$DATE"
+          for arch in amd64 arm64; do
+            echo "Building ork-devserver-$arch"
+            GOOS=linux GOARCH=$arch CGO_ENABLED=0 go build \
+              -trimpath \
+              -ldflags="-s -w $LDFLAGS" \
+              -o ork-$arch ./cmd/devserver
+          done
+
+      - name: Build and push dev server image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Write image summary
+        run: |
+          echo "## Dev Server Image" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`ghcr.io/${{ inputs.repository }}-dev-server:latest\`" >> "$GITHUB_STEP_SUMMARY"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build orkcc clean test test-unit test-race test-integration test-all test-coverage test-coverage-text vet certs docs docs-sync docs-build docs-serve hugo-install generate-notes test-fixture-note test-fixture-reconciler ork-gateway-linux docker-gateway gateway-reload runtime-reload controlcenter-reload reload
+.PHONY: build orkcc clean test test-unit test-race test-integration test-all test-coverage test-coverage-text vet certs docs docs-sync docs-build docs-serve hugo-install generate-notes test-fixture-note test-fixture-reconciler ork-gateway-linux docker-gateway gateway-reload runtime-reload controlcenter-reload reload docker-devserver release-devserver
 
 # ── Configuration ────────────────────────────────────────────────────────────
 ORKESTRA_DIR := .
@@ -79,6 +79,7 @@ endif
 ORK_IMAGE ?= ghcr.io/orkspace/orkestra:$(GIT_COMMIT)
 ORK_CC_IMAGE ?= ghcr.io/orkspace/orkestra-cc:$(GIT_COMMIT)
 ORK_GATEWAY_IMAGE ?= ghcr.io/orkspace/orkestra-gateway:$(GIT_COMMIT)
+ORK_DEVSERVER_IMAGE ?= ghcr.io/orkspace/orkestra-dev-server:latest
 
 # Target architectures
 ORK_AMD64_TARGET="ork-amd64"
@@ -177,8 +178,27 @@ docker-push:
 
 # ── Docker Release (build + push) ─────────────────────────────────────────────
 
-docker-release: docker docker-cc docker-gateway docker-push
+docker-release: docker docker-cc docker-gateway docker-devserver docker-push
 	@echo "✔ Docker release complete"
+
+# ── Dev Server Docker ─────────────────────────────────────────────────────────
+
+docker-devserver:
+	@mkdir -p $(DOCKER_TMP)
+	@echo "Building dev server (Linux amd64) → $(DOCKER_TMP)/ork-devserver..."
+	gofmt -w . && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build \
+		-trimpath -ldflags "-s -w $(ORK_LDFLAGS)" \
+		-o $(DOCKER_TMP)/ork-devserver ./cmd/devserver
+	@echo "Building Docker image: $(ORK_DEVSERVER_IMAGE)"
+	@cp $(DOCKER_TMP)/ork-devserver ./$(ORK_AMD64_TARGET)
+	docker build -t $(ORK_DEVSERVER_IMAGE) .
+	@rm -f ./$(ORK_AMD64_TARGET) $(DOCKER_TMP)/ork-devserver
+	@echo "✔ Docker image built: $(ORK_DEVSERVER_IMAGE)"
+
+release-devserver: docker-devserver
+	@echo "Pushing Docker image: $(ORK_DEVSERVER_IMAGE)"
+	docker push $(ORK_DEVSERVER_IMAGE)
+	@echo "✔ Dev server image released: $(ORK_DEVSERVER_IMAGE)"
 
 # ── Runtime Reload (local dev) ────────────────────────────────────────────────
 

--- a/cmd/cli/e2e.go
+++ b/cmd/cli/e2e.go
@@ -35,7 +35,9 @@ The same command runs locally and in CI. The e2e.yaml file is the source of trut
 			helmArgs = append(helmArgs, "--set", arg)
 		}
 
-		runner, err := e2e.New(file, clusterCtx, useCurrentCtx, keepCluster, version, valuesFiles, helmArgs...)
+		devServer, _ := cmd.Flags().GetBool("dev-server")
+
+		runner, err := e2e.New(file, clusterCtx, useCurrentCtx, keepCluster, devServer, version, valuesFiles, helmArgs...)
 		if err != nil {
 			return err
 		}
@@ -54,6 +56,7 @@ func init() {
 	e2eCmd.Flags().String("version", "", "Orkestra version to install (e.g., v1.2.3)")
 	e2eCmd.Flags().StringSlice("values", []string{}, "Helm values files to pass to Orkestra installation")
 	e2eCmd.Flags().StringSlice("helm-arg", []string{}, "Additional Helm --set arguments (e.g., key=value)")
+	e2eCmd.Flags().Bool("dev-server", false, "Deploy the mock dev server into the cluster for external: examples")
 
 	// Shadow global flags
 	e2eCmd.Flags().Bool("debug", false, "")

--- a/cmd/cli/registry_push.go
+++ b/cmd/cli/registry_push.go
@@ -166,7 +166,7 @@ var registryPushCmd = &cobra.Command{
 					}
 				} else {
 					fmt.Printf("\nRunning E2E gate (%s)...\n", registry.FileE2E)
-					runner, err := e2e.New(e2eFile, "", false, false, "", nil)
+					runner, err := e2e.New(e2eFile, "", false, false, false, "", nil)
 					if err != nil {
 						return fmt.Errorf("e2e gate: %w\n\nUse --force or --no-e2e to skip", err)
 					}

--- a/cmd/devserver/main.go
+++ b/cmd/devserver/main.go
@@ -1,0 +1,25 @@
+// Package main is the standalone entry point for the Orkestra dev server.
+// It starts the mock HTTP server on the configured port and blocks until the
+// process is killed. Runs as ghcr.io/orkspace/orkestra-dev-server:latest.
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/orkspace/orkestra/pkg/devserver"
+)
+
+func main() {
+	if err := devserver.Start(devserver.Port); err != nil {
+		fmt.Fprintf(os.Stderr, "dev server: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Block until SIGTERM or SIGINT.
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
+	<-sig
+}

--- a/examples/use-cases/external/01-health-gate/README.md
+++ b/examples/use-cases/external/01-health-gate/README.md
@@ -112,3 +112,34 @@ Wait a reconcile cycle. The phase flips to `Ready` and the Deployment appears.
 ```bash
 chmod +x cleanup.sh && ./cleanup.sh
 ```
+
+---
+
+## E2E
+
+Run the full lifecycle in one command — deploys the mock dev server into the cluster, applies the CRD, starts the operator, applies healthy and degraded CRs, asserts the Deployment appears for healthy and is absent for degraded, then tears down:
+
+```bash
+ork e2e --dev-server
+```
+
+The `--dev-server` flag deploys `ghcr.io/orkspace/orkestra-dev-server` into the cluster. CRs use the in-cluster address `orkestra-dev-server.orkestra-system.svc:9999` instead of `localhost:9999`. This is defined in [cr-e2e.yaml](./cr-e2e.yaml).
+
+This runs everything defined in [e2e.yaml](./e2e.yaml):
+
+```yaml
+expect:
+  - name: Deployment created when health check passes
+    after: cr-applied
+    resources:
+      - kind: Deployment
+        name: my-app-healthy
+        ready: true
+
+  - name: No Deployment when health check fails
+    after: cr-applied
+    resources:
+      - kind: Deployment
+        name: my-app-degraded
+        count: 0
+```

--- a/examples/use-cases/external/01-health-gate/cr-e2e.yaml
+++ b/examples/use-cases/external/01-health-gate/cr-e2e.yaml
@@ -1,0 +1,21 @@
+# cr-e2e.yaml — used by `ork e2e --dev-server`.
+# Points at the in-cluster dev server (orkestra-dev-server.orkestra-system.svc:9999)
+# which simulates the real upstream health endpoint without requiring an external service.
+# For local development, use cr-dev-healthy.yaml / cr-dev-degraded.yaml with `ork run --dev-server`.
+apiVersion: demo.orkestra.io/v1
+kind: WebApp
+metadata:
+  name: my-app-healthy
+spec:
+  image: nginx:1.25
+  healthCheckUrl: "http://orkestra-dev-server.orkestra-system.svc:9999/health"
+  replicas: 2
+---
+apiVersion: demo.orkestra.io/v1
+kind: WebApp
+metadata:
+  name: my-app-degraded
+spec:
+  image: nginx:1.25
+  healthCheckUrl: "http://orkestra-dev-server.orkestra-system.svc:9999/status/503"
+  replicas: 2

--- a/examples/use-cases/external/02-config-inject/README.md
+++ b/examples/use-cases/external/02-config-inject/README.md
@@ -87,3 +87,24 @@ Every 30s the operator fetches the config URL again and updates the ConfigMap if
 ```bash
 chmod +x cleanup.sh && ./cleanup.sh
 ```
+
+---
+
+## E2E
+
+Run the full lifecycle — deploys the mock dev server, starts the operator, applies the CR, asserts the ConfigMap contains the injected config and status is Ready, then tears down:
+
+```bash
+ork e2e --dev-server
+```
+
+CRs use the in-cluster address defined in [cr-e2e.yaml](./cr-e2e.yaml). This runs everything in [e2e.yaml](./e2e.yaml):
+
+```yaml
+expect:
+  - name: ConfigMap created and contains injected config
+    after: cr-applied
+    commands:
+      - run: "kubectl get configmap my-app-config -o jsonpath='{.data.app\\.json}'"
+        outputContains: "production"
+```

--- a/examples/use-cases/external/02-config-inject/cr-e2e.yaml
+++ b/examples/use-cases/external/02-config-inject/cr-e2e.yaml
@@ -1,0 +1,12 @@
+# cr-e2e.yaml — used by `ork e2e --dev-server`.
+# Points at the in-cluster dev server (orkestra-dev-server.orkestra-system.svc:9999)
+# which returns a static JSON config blob at GET /config/:name.
+# For local development, use cr.yaml with `ork run --dev-server`.
+apiVersion: demo.orkestra.io/v1
+kind: WebApp
+metadata:
+  name: my-app
+spec:
+  image: nginx:1.25
+  serviceUrl: "http://orkestra-dev-server.orkestra-system.svc:9999"
+  replicas: 1

--- a/examples/use-cases/external/03-image-signing/README.md
+++ b/examples/use-cases/external/03-image-signing/README.md
@@ -163,3 +163,30 @@ The reconcile loop is the retry mechanism. 4xx closes the gate because it is a p
 ```bash
 chmod +x cleanup.sh && ./cleanup.sh
 ```
+
+---
+
+## E2E
+
+Run the full lifecycle — deploys the mock dev server, starts the operator, applies the CR with `nginx:1.25`, asserts the Deployment is created and `status.signedImage` is set, then tears down:
+
+```bash
+ork e2e --dev-server
+```
+
+CRs use the in-cluster address defined in [cr-e2e.yaml](./cr-e2e.yaml). This runs everything in [e2e.yaml](./e2e.yaml):
+
+```yaml
+expect:
+  - name: Deployment created after image signing succeeds
+    after: cr-applied
+    resources:
+      - kind: Deployment
+        name: my-app
+        ready: true
+  - name: Status records verified image
+    after: cr-applied
+    commands:
+      - run: kubectl get webapp my-app -o jsonpath='{.status.signedImage}'
+        outputContains: nginx:1.25
+```

--- a/examples/use-cases/external/03-image-signing/cr-e2e.yaml
+++ b/examples/use-cases/external/03-image-signing/cr-e2e.yaml
@@ -1,0 +1,12 @@
+# cr-e2e.yaml — used by `ork e2e --dev-server`.
+# Points at the in-cluster dev server (orkestra-dev-server.orkestra-system.svc:9999)
+# which responds to POST /sign with a success response for any image.
+# For local development, use cr.yaml / cr-reject.yaml with `ork run --dev-server`.
+apiVersion: demo.orkestra.io/v1
+kind: WebApp
+metadata:
+  name: my-app
+spec:
+  image: nginx:1.25
+  serviceUrl: "http://orkestra-dev-server.orkestra-system.svc:9999"
+  replicas: 2

--- a/examples/use-cases/external/04-chained/README.md
+++ b/examples/use-cases/external/04-chained/README.md
@@ -94,3 +94,30 @@ This works because Orkestra updates the resolver after each call — by the time
 ```bash
 chmod +x cleanup.sh && ./cleanup.sh
 ```
+
+---
+
+## E2E
+
+Run the full lifecycle — deploys the mock dev server, starts the operator, applies the CR, asserts the Deployment is created and status is Ready after both auth chain calls succeed, then tears down:
+
+```bash
+ork e2e --dev-server
+```
+
+CRs use the in-cluster address defined in [cr-e2e.yaml](./cr-e2e.yaml). This runs everything in [e2e.yaml](./e2e.yaml):
+
+```yaml
+expect:
+  - name: Deployment created after full auth chain succeeds
+    after: cr-applied
+    resources:
+      - kind: Deployment
+        name: my-app
+        ready: true
+  - name: Status phase is Ready
+    after: cr-applied
+    commands:
+      - run: kubectl get webapp my-app -o jsonpath='{.status.phase}'
+        outputContains: Ready
+```

--- a/examples/use-cases/external/04-chained/cr-e2e.yaml
+++ b/examples/use-cases/external/04-chained/cr-e2e.yaml
@@ -1,0 +1,12 @@
+# cr-e2e.yaml — used by `ork e2e --dev-server`.
+# Points at the in-cluster dev server (orkestra-dev-server.orkestra-system.svc:9999)
+# which handles the full chain: POST /auth/token → GET /resources/:name.
+# For local development, use cr.yaml with `ork run --dev-server`.
+apiVersion: demo.orkestra.io/v1
+kind: WebApp
+metadata:
+  name: my-app
+spec:
+  image: nginx:1.25
+  serviceUrl: "http://orkestra-dev-server.orkestra-system.svc:9999"
+  replicas: 1

--- a/examples/use-cases/external/04-chained/e2e.yaml
+++ b/examples/use-cases/external/04-chained/e2e.yaml
@@ -1,10 +1,10 @@
 apiVersion: orkestra.orkspace.io/v1
 kind: E2E
 metadata:
-  name: external-config-inject-e2e
+  name: external-chained-e2e
   description: >
-    external: config inject — GET /config/:name response body embedded into
-    a ConfigMap on every reconcile. Deployment mounts it without a restart.
+    external: chained calls — POST /auth/token then GET /resources/:name with
+    bearer token. Deployment gated on both calls succeeding.
     Run with `ork e2e --dev-server`.
 
 spec:
@@ -18,18 +18,16 @@ spec:
     reuse: false
 
   expect:
-    - name: ConfigMap created and contains injected config
+    - name: Deployment created after full auth chain succeeds
       after: cr-applied
       timeout: 90s
       resources:
-        - kind: ConfigMap
-          name: my-app-config
+        - kind: Deployment
+          name: my-app
           namespace: default
-      commands:
-        - run: "kubectl get configmap my-app-config -o jsonpath='{.data.app\\.json}'"
-          outputContains: "production"
+          ready: true
 
-    - name: Status reflects successful external call
+    - name: Status phase is Ready
       after: cr-applied
       timeout: 60s
       commands:
@@ -40,8 +38,8 @@ spec:
       after: cr-deleted
       timeout: 30s
       resources:
-        - kind: ConfigMap
-          name: my-app-config
+        - kind: Deployment
+          name: my-app
           namespace: default
           count: 0
         - kind: WebApp

--- a/examples/use-cases/external/05-feature-flags/README.md
+++ b/examples/use-cases/external/05-feature-flags/README.md
@@ -163,3 +163,32 @@ onCreate:
 ```bash
 chmod +x cleanup.sh && ./cleanup.sh
 ```
+
+---
+
+## E2E
+
+Run the full lifecycle — deploys the mock dev server, starts the operator, applies the CR, asserts the Deployment runs at full replicas (`v2Enabled=true` default), then tears down:
+
+```bash
+ork e2e --dev-server
+```
+
+CRs use the in-cluster address defined in [cr-e2e.yaml](./cr-e2e.yaml). This runs everything in [e2e.yaml](./e2e.yaml):
+
+```yaml
+expect:
+  - name: Deployment at full replicas when v2Enabled is true
+    after: cr-applied
+    resources:
+      - kind: Deployment
+        name: my-app
+        ready: true
+  - name: Status v2Enabled is true and activeReplicas is 5
+    after: cr-applied
+    commands:
+      - run: kubectl get webapp my-app -o jsonpath='{.status.v2Enabled}'
+        outputContains: "true"
+      - run: kubectl get deploy my-app -o jsonpath='{.spec.replicas}'
+        outputContains: "5"
+```

--- a/examples/use-cases/external/05-feature-flags/cr-e2e.yaml
+++ b/examples/use-cases/external/05-feature-flags/cr-e2e.yaml
@@ -1,0 +1,12 @@
+# cr-e2e.yaml — used by `ork e2e --dev-server`.
+# Points at the in-cluster dev server (orkestra-dev-server.orkestra-system.svc:9999)
+# which serves GET /flags/:name/:flag — v2Enabled defaults to true.
+# For local development, use cr.yaml with `ork run --dev-server`.
+apiVersion: demo.orkestra.io/v1
+kind: WebApp
+metadata:
+  name: my-app
+spec:
+  image: nginx:1.25
+  serviceUrl: "http://orkestra-dev-server.orkestra-system.svc:9999"
+  replicas: 5

--- a/examples/use-cases/external/05-feature-flags/e2e.yaml
+++ b/examples/use-cases/external/05-feature-flags/e2e.yaml
@@ -1,10 +1,10 @@
 apiVersion: orkestra.orkspace.io/v1
 kind: E2E
 metadata:
-  name: external-image-signing-e2e
+  name: external-feature-flags-e2e
   description: >
-    external: once-per-image signing gate — POST /sign fires only when
-    spec.image changes; 4xx locks out retries. Deployment gated on signed status.
+    external: feature flag rollout gate — GET /flags/:name/v2Enabled drives
+    replica count. v2Enabled=true (default) → spec.replicas (5).
     Run with `ork e2e --dev-server`.
 
 spec:
@@ -18,7 +18,7 @@ spec:
     reuse: false
 
   expect:
-    - name: Deployment created after image signing succeeds
+    - name: Deployment at full replicas when v2Enabled is true
       after: cr-applied
       timeout: 90s
       resources:
@@ -27,12 +27,14 @@ spec:
           namespace: default
           ready: true
 
-    - name: Status records verified image
+    - name: Status v2Enabled is true and activeReplicas is 5
       after: cr-applied
       timeout: 60s
       commands:
-        - run: kubectl get webapp my-app -o jsonpath='{.status.signedImage}'
-          outputContains: nginx:1.25
+        - run: kubectl get webapp my-app -o jsonpath='{.status.v2Enabled}'
+          outputContains: "true"
+        - run: kubectl get deploy my-app -o jsonpath='{.spec.replicas}'
+          outputContains: "5"
 
     - name: Cleanup verified
       after: cr-deleted

--- a/examples/use-cases/external/06-sbom-cosign/README.md
+++ b/examples/use-cases/external/06-sbom-cosign/README.md
@@ -137,3 +137,30 @@ reconcile fires
 ```bash
 chmod +x cleanup.sh && ./cleanup.sh
 ```
+
+---
+
+## E2E
+
+Run the full lifecycle — deploys the mock dev server, starts the operator, applies the CR with `nginx:1.25`, asserts the Deployment is created and `status.verifiedImage` is set, then tears down:
+
+```bash
+ork e2e --dev-server
+```
+
+CRs use the in-cluster address defined in [cr-e2e.yaml](./cr-e2e.yaml). This runs everything in [e2e.yaml](./e2e.yaml):
+
+```yaml
+expect:
+  - name: Deployment created after clean SBOM and valid signature
+    after: cr-applied
+    resources:
+      - kind: Deployment
+        name: my-app
+        ready: true
+  - name: Status records verified image
+    after: cr-applied
+    commands:
+      - run: kubectl get webapp my-app -o jsonpath='{.status.verifiedImage}'
+        outputContains: nginx:1.25
+```

--- a/examples/use-cases/external/06-sbom-cosign/cr-e2e.yaml
+++ b/examples/use-cases/external/06-sbom-cosign/cr-e2e.yaml
@@ -1,0 +1,12 @@
+# cr-e2e.yaml — used by `ork e2e --dev-server`.
+# Points at the in-cluster dev server (orkestra-dev-server.orkestra-system.svc:9999).
+# nginx:1.25 → clean SBOM (GET /sbom/nginx:1.25) and valid signature (POST /cosign/verify).
+# For local development, use cr.yaml / cr-unsigned.yaml / cr-vulnerable.yaml with `ork run --dev-server`.
+apiVersion: demo.orkestra.io/v1
+kind: WebApp
+metadata:
+  name: my-app
+spec:
+  image: nginx:1.25
+  serviceUrl: "http://orkestra-dev-server.orkestra-system.svc:9999"
+  replicas: 2

--- a/examples/use-cases/external/06-sbom-cosign/e2e.yaml
+++ b/examples/use-cases/external/06-sbom-cosign/e2e.yaml
@@ -1,10 +1,10 @@
 apiVersion: orkestra.orkspace.io/v1
 kind: E2E
 metadata:
-  name: external-image-signing-e2e
+  name: external-sbom-cosign-e2e
   description: >
-    external: once-per-image signing gate — POST /sign fires only when
-    spec.image changes; 4xx locks out retries. Deployment gated on signed status.
+    external: SBOM scan + cosign signature gate — two chained calls per image
+    change. nginx:1.25 passes both. Deployment gated on verifiedImage status.
     Run with `ork e2e --dev-server`.
 
 spec:
@@ -18,7 +18,7 @@ spec:
     reuse: false
 
   expect:
-    - name: Deployment created after image signing succeeds
+    - name: Deployment created after clean SBOM and valid signature
       after: cr-applied
       timeout: 90s
       resources:
@@ -31,7 +31,7 @@ spec:
       after: cr-applied
       timeout: 60s
       commands:
-        - run: kubectl get webapp my-app -o jsonpath='{.status.signedImage}'
+        - run: kubectl get webapp my-app -o jsonpath='{.status.verifiedImage}'
           outputContains: nginx:1.25
 
     - name: Cleanup verified

--- a/examples/use-cases/external/07-vault-secret-gate/README.md
+++ b/examples/use-cases/external/07-vault-secret-gate/README.md
@@ -96,3 +96,34 @@ This is the rotation recovery pattern: fix the secret path (or rotate in Vault),
 ```bash
 chmod +x cleanup.sh && ./cleanup.sh
 ```
+
+---
+
+## E2E
+
+Run the full lifecycle — deploys the mock dev server, starts the operator, applies both CRs, asserts `my-app` gets a Deployment (valid secret) and `my-app-expired` is blocked with `status.phase=SecretExpired`, then tears down:
+
+```bash
+ork e2e --dev-server
+```
+
+CRs use the in-cluster address defined in [cr-e2e.yaml](./cr-e2e.yaml). This runs everything in [e2e.yaml](./e2e.yaml):
+
+```yaml
+expect:
+  - name: Deployment created when Vault secret is valid
+    after: cr-applied
+    resources:
+      - kind: Deployment
+        name: my-app
+        ready: true
+  - name: No Deployment when secret is expired — status shows SecretExpired
+    after: cr-applied
+    resources:
+      - kind: Deployment
+        name: my-app-expired
+        count: 0
+    commands:
+      - run: kubectl get webapp my-app-expired -o jsonpath='{.status.phase}'
+        outputContains: SecretExpired
+```

--- a/examples/use-cases/external/07-vault-secret-gate/cr-e2e.yaml
+++ b/examples/use-cases/external/07-vault-secret-gate/cr-e2e.yaml
@@ -1,0 +1,22 @@
+# cr-e2e.yaml — used by `ork e2e --dev-server`.
+# Points at the in-cluster dev server (orkestra-dev-server.orkestra-system.svc:9999).
+# GET /vault/v1/secret/data/apps/my-app → 200 valid secret.
+# GET /vault/v1/secret/data/apps/my-app-expired → 403 expired lease (no Deployment).
+# For local development, use cr.yaml / cr-expired.yaml with `ork run --dev-server`.
+apiVersion: demo.orkestra.io/v1
+kind: WebApp
+metadata:
+  name: my-app
+spec:
+  image: nginx:1.25
+  serviceUrl: "http://orkestra-dev-server.orkestra-system.svc:9999"
+  replicas: 2
+---
+apiVersion: demo.orkestra.io/v1
+kind: WebApp
+metadata:
+  name: my-app-expired
+spec:
+  image: nginx:1.25
+  serviceUrl: "http://orkestra-dev-server.orkestra-system.svc:9999"
+  replicas: 2

--- a/examples/use-cases/external/07-vault-secret-gate/e2e.yaml
+++ b/examples/use-cases/external/07-vault-secret-gate/e2e.yaml
@@ -1,10 +1,11 @@
 apiVersion: orkestra.orkspace.io/v1
 kind: E2E
 metadata:
-  name: external-health-gate-e2e
+  name: external-vault-secret-gate-e2e
   description: >
-    external: health gate — Deployment only created when /health returns 200,
-    suppressed when /status/503 is returned. Run with `ork e2e --dev-server`.
+    external: Vault secret gate — GET /vault/v1/secret/data/:path before the
+    Deployment. Valid path → Ready. Path containing "expired" → SecretExpired,
+    no Deployment. Run with `ork e2e --dev-server`.
 
 spec:
   katalog: ./katalog.yaml
@@ -17,37 +18,40 @@ spec:
     reuse: false
 
   expect:
-    - name: Deployment created when health check passes
+    - name: Deployment created when Vault secret is valid
       after: cr-applied
       timeout: 90s
       resources:
         - kind: Deployment
-          name: my-app-healthy
+          name: my-app
           namespace: default
           ready: true
 
-    - name: No Deployment when health check fails
+    - name: No Deployment when secret is expired — status shows SecretExpired
       after: cr-applied
       timeout: 60s
       resources:
         - kind: Deployment
-          name: my-app-degraded
+          name: my-app-expired
           namespace: default
           count: 0
+      commands:
+        - run: kubectl get webapp my-app-expired -o jsonpath='{.status.phase}'
+          outputContains: SecretExpired
 
     - name: Cleanup verified
       after: cr-deleted
       timeout: 60s
       resources:
         - kind: Deployment
-          name: my-app-healthy
+          name: my-app
           namespace: default
           count: 0
         - kind: WebApp
-          name: my-app-healthy
+          name: my-app
           namespace: default
           count: 0
         - kind: WebApp
-          name: my-app-degraded
+          name: my-app-expired
           namespace: default
           count: 0

--- a/examples/use-cases/external/08-opa-policy/README.md
+++ b/examples/use-cases/external/08-opa-policy/README.md
@@ -97,3 +97,34 @@ Or observe that `cr-denied.yaml` stays in `PolicyDenied` every reconcile — OPA
 ```bash
 chmod +x cleanup.sh && ./cleanup.sh
 ```
+
+---
+
+## E2E
+
+Run the full lifecycle — deploys the mock dev server, starts the operator, applies both CRs, asserts `my-app` gets a Deployment (policy allows) and `deny-my-app` is blocked with `status.phase=PolicyDenied`, then tears down:
+
+```bash
+ork e2e --dev-server
+```
+
+CRs use the in-cluster address defined in [cr-e2e.yaml](./cr-e2e.yaml). This runs everything in [e2e.yaml](./e2e.yaml):
+
+```yaml
+expect:
+  - name: Deployment created when OPA allows
+    after: cr-applied
+    resources:
+      - kind: Deployment
+        name: my-app
+        ready: true
+  - name: No Deployment when OPA denies — status shows PolicyDenied
+    after: cr-applied
+    resources:
+      - kind: Deployment
+        name: deny-my-app
+        count: 0
+    commands:
+      - run: kubectl get webapp deny-my-app -o jsonpath='{.status.phase}'
+        outputContains: PolicyDenied
+```

--- a/examples/use-cases/external/08-opa-policy/cr-e2e.yaml
+++ b/examples/use-cases/external/08-opa-policy/cr-e2e.yaml
@@ -1,0 +1,21 @@
+# cr-e2e.yaml — used by `ork e2e --dev-server`.
+# Points at the in-cluster dev server (orkestra-dev-server.orkestra-system.svc:9999).
+# POST /v1/data/deploy → allow:true for my-app; deny:true when name contains "deny".
+# For local development, use cr.yaml / cr-denied.yaml with `ork run --dev-server`.
+apiVersion: demo.orkestra.io/v1
+kind: WebApp
+metadata:
+  name: my-app
+spec:
+  image: nginx:1.25
+  serviceUrl: "http://orkestra-dev-server.orkestra-system.svc:9999"
+  replicas: 2
+---
+apiVersion: demo.orkestra.io/v1
+kind: WebApp
+metadata:
+  name: deny-my-app
+spec:
+  image: nginx:1.25
+  serviceUrl: "http://orkestra-dev-server.orkestra-system.svc:9999"
+  replicas: 2

--- a/examples/use-cases/external/08-opa-policy/e2e.yaml
+++ b/examples/use-cases/external/08-opa-policy/e2e.yaml
@@ -1,10 +1,11 @@
 apiVersion: orkestra.orkspace.io/v1
 kind: E2E
 metadata:
-  name: external-health-gate-e2e
+  name: external-opa-policy-e2e
   description: >
-    external: health gate — Deployment only created when /health returns 200,
-    suppressed when /status/503 is returned. Run with `ork e2e --dev-server`.
+    external: OPA policy enforcement — POST /v1/data/deploy before the
+    Deployment. allow:true → Ready. Name containing "deny" → PolicyDenied,
+    no Deployment. Run with `ork e2e --dev-server`.
 
 spec:
   katalog: ./katalog.yaml
@@ -17,37 +18,40 @@ spec:
     reuse: false
 
   expect:
-    - name: Deployment created when health check passes
+    - name: Deployment created when OPA allows
       after: cr-applied
       timeout: 90s
       resources:
         - kind: Deployment
-          name: my-app-healthy
+          name: my-app
           namespace: default
           ready: true
 
-    - name: No Deployment when health check fails
+    - name: No Deployment when OPA denies — status shows PolicyDenied
       after: cr-applied
       timeout: 60s
       resources:
         - kind: Deployment
-          name: my-app-degraded
+          name: deny-my-app
           namespace: default
           count: 0
+      commands:
+        - run: kubectl get webapp deny-my-app -o jsonpath='{.status.phase}'
+          outputContains: PolicyDenied
 
     - name: Cleanup verified
       after: cr-deleted
       timeout: 60s
       resources:
         - kind: Deployment
-          name: my-app-healthy
+          name: my-app
           namespace: default
           count: 0
         - kind: WebApp
-          name: my-app-healthy
+          name: my-app
           namespace: default
           count: 0
         - kind: WebApp
-          name: my-app-degraded
+          name: deny-my-app
           namespace: default
           count: 0

--- a/examples/use-cases/external/09-cert-readiness/README.md
+++ b/examples/use-cases/external/09-cert-readiness/README.md
@@ -98,3 +98,32 @@ Wait one reconcile. Phase returns to `Ready`. Deployment is reconciled again.
 ```bash
 chmod +x cleanup.sh && ./cleanup.sh
 ```
+
+---
+
+## E2E
+
+Run the full lifecycle — deploys the mock dev server, starts the operator, applies the CR, asserts the Deployment is created and `status.certStatus` contains `issued`, then tears down:
+
+```bash
+ork e2e --dev-server
+```
+
+CRs use the in-cluster address defined in [cr-e2e.yaml](./cr-e2e.yaml). This runs everything in [e2e.yaml](./e2e.yaml):
+
+```yaml
+expect:
+  - name: Deployment created when certificate is issued
+    after: cr-applied
+    resources:
+      - kind: Deployment
+        name: my-app
+        ready: true
+  - name: Status phase is Ready and certStatus contains issued
+    after: cr-applied
+    commands:
+      - run: kubectl get webapp my-app -o jsonpath='{.status.phase}'
+        outputContains: Ready
+      - run: kubectl get webapp my-app -o jsonpath='{.status.certStatus}'
+        outputContains: issued
+```

--- a/examples/use-cases/external/09-cert-readiness/cr-e2e.yaml
+++ b/examples/use-cases/external/09-cert-readiness/cr-e2e.yaml
@@ -1,0 +1,12 @@
+# cr-e2e.yaml — used by `ork e2e --dev-server`.
+# Points at the in-cluster dev server (orkestra-dev-server.orkestra-system.svc:9999).
+# GET /certs/my-app/status → 200 issued (default state).
+# For local development, use cr.yaml with `ork run --dev-server`.
+apiVersion: demo.orkestra.io/v1
+kind: WebApp
+metadata:
+  name: my-app
+spec:
+  image: nginx:1.25
+  serviceUrl: "http://orkestra-dev-server.orkestra-system.svc:9999"
+  replicas: 2

--- a/examples/use-cases/external/09-cert-readiness/e2e.yaml
+++ b/examples/use-cases/external/09-cert-readiness/e2e.yaml
@@ -1,10 +1,10 @@
 apiVersion: orkestra.orkspace.io/v1
 kind: E2E
 metadata:
-  name: external-config-inject-e2e
+  name: external-cert-readiness-e2e
   description: >
-    external: config inject — GET /config/:name response body embedded into
-    a ConfigMap on every reconcile. Deployment mounts it without a restart.
+    external: certificate readiness gate — GET /certs/:name/status before
+    the Deployment. Cert issued (default) → Ready. Status surfaces cert detail.
     Run with `ork e2e --dev-server`.
 
 spec:
@@ -18,30 +18,30 @@ spec:
     reuse: false
 
   expect:
-    - name: ConfigMap created and contains injected config
+    - name: Deployment created when certificate is issued
       after: cr-applied
       timeout: 90s
       resources:
-        - kind: ConfigMap
-          name: my-app-config
+        - kind: Deployment
+          name: my-app
           namespace: default
-      commands:
-        - run: "kubectl get configmap my-app-config -o jsonpath='{.data.app\\.json}'"
-          outputContains: "production"
+          ready: true
 
-    - name: Status reflects successful external call
+    - name: Status phase is Ready and certStatus contains issued
       after: cr-applied
       timeout: 60s
       commands:
         - run: kubectl get webapp my-app -o jsonpath='{.status.phase}'
           outputContains: Ready
+        - run: kubectl get webapp my-app -o jsonpath='{.status.certStatus}'
+          outputContains: issued
 
     - name: Cleanup verified
       after: cr-deleted
       timeout: 30s
       resources:
-        - kind: ConfigMap
-          name: my-app-config
+        - kind: Deployment
+          name: my-app
           namespace: default
           count: 0
         - kind: WebApp

--- a/examples/use-cases/external/10-motif-composition/README.md
+++ b/examples/use-cases/external/10-motif-composition/README.md
@@ -173,3 +173,34 @@ Expected logs:
 ```bash
 chmod +x cleanup.sh && ./cleanup.sh
 ```
+
+---
+
+## E2E
+
+Run the full lifecycle — deploys the mock dev server, starts both operators from the komposer, applies WebApp and Worker CRs, asserts both Deployments are created and phases are Ready, then tears down:
+
+```bash
+ork e2e --dev-server
+```
+
+CRs use the in-cluster address defined in [cr-e2e.yaml](./cr-e2e.yaml). This runs everything in [e2e.yaml](./e2e.yaml):
+
+```yaml
+expect:
+  - name: WebApp Deployment ready — all four motif checks pass
+    after: cr-applied
+    resources:
+      - kind: Deployment
+        name: my-app
+        ready: true
+    commands:
+      - run: kubectl get webapp my-app -o jsonpath='{.status.phase}'
+        outputContains: Ready
+  - name: Worker Deployment ready — vault + OPA checks pass
+    after: cr-applied
+    resources:
+      - kind: Deployment
+        name: my-worker
+        ready: true
+```

--- a/examples/use-cases/external/10-motif-composition/cr-e2e.yaml
+++ b/examples/use-cases/external/10-motif-composition/cr-e2e.yaml
@@ -1,0 +1,22 @@
+# cr-e2e.yaml — used by `ork e2e --dev-server`.
+# Points at the in-cluster dev server (orkestra-dev-server.orkestra-system.svc:9999).
+# WebApp: SBOM + cosign + Vault + OPA all pass for nginx:1.25.
+# Worker: Vault + OPA pass for httpd:2.4.67.
+# For local development, use cr-webapp.yaml + cr-worker.yaml with `ork run --dev-server`.
+apiVersion: demo.orkestra.io/v1
+kind: WebApp
+metadata:
+  name: my-app
+spec:
+  image: nginx:1.25
+  serviceUrl: "http://orkestra-dev-server.orkestra-system.svc:9999"
+  replicas: 2
+---
+apiVersion: demo.orkestra.io/v1
+kind: Worker
+metadata:
+  name: my-worker
+spec:
+  image: httpd:2.4.67
+  serviceUrl: "http://orkestra-dev-server.orkestra-system.svc:9999"
+  replicas: 1

--- a/examples/use-cases/external/10-motif-composition/e2e.yaml
+++ b/examples/use-cases/external/10-motif-composition/e2e.yaml
@@ -1,0 +1,76 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: external-motif-composition-e2e
+  description: >
+    external: motif composition — four shared motifs (admission, supply-chain,
+    vault-gate, opa-policy) composed into two operators. WebApp runs all four;
+    Worker runs admission + vault + OPA. Both Deployments gated on all checks.
+    Run with `ork e2e --dev-server`.
+
+spec:
+  katalog: ./komposer.yaml
+  crd: ./crd-webapp.yaml
+  cr: ./cr-e2e.yaml
+
+  cluster:
+    provider: kind
+    name: ork-e2e
+    reuse: false
+
+  expect:
+    - name: Both CRs created
+      after: cr-applied
+      timeout: 60s
+      resources:
+        - kind: WebApp
+          name: my-app
+          namespace: default
+        - kind: Worker
+          name: my-worker
+          namespace: default
+
+    - name: WebApp Deployment ready — all four motif checks pass
+      after: cr-applied
+      timeout: 120s
+      resources:
+        - kind: Deployment
+          name: my-app
+          namespace: default
+          ready: true
+      commands:
+        - run: kubectl get webapp my-app -o jsonpath='{.status.phase}'
+          outputContains: Ready
+
+    - name: Worker Deployment ready — vault + OPA checks pass
+      after: cr-applied
+      timeout: 120s
+      resources:
+        - kind: Deployment
+          name: my-worker
+          namespace: default
+          ready: true
+      commands:
+        - run: kubectl get worker my-worker -o jsonpath='{.status.phase}'
+          outputContains: Ready
+
+    - name: Cleanup verified
+      after: cr-deleted
+      timeout: 60s
+      resources:
+        - kind: Deployment
+          name: my-app
+          namespace: default
+          count: 0
+        - kind: Deployment
+          name: my-worker
+          namespace: default
+          count: 0
+        - kind: WebApp
+          name: my-app
+          namespace: default
+          count: 0
+        - kind: Worker
+          name: my-worker
+          namespace: default
+          count: 0

--- a/examples/use-cases/external/e2e.yaml
+++ b/examples/use-cases/external/e2e.yaml
@@ -1,0 +1,21 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: external-suite
+  description: >
+    Suite for all external: use-case examples. Each sub-test deploys its own
+    operator and verifies both the happy path and at least one rejection case.
+    Run with `ork e2e --dev-server` — the flag deploys the mock dev server into
+    the cluster so the operators can reach it at the in-cluster DNS address.
+
+imports:
+  - ./01-health-gate/e2e.yaml
+  - ./02-config-inject/e2e.yaml
+  - ./03-image-signing/e2e.yaml
+  - ./04-chained/e2e.yaml
+  - ./05-feature-flags/e2e.yaml
+  - ./06-sbom-cosign/e2e.yaml
+  - ./07-vault-secret-gate/e2e.yaml
+  - ./08-opa-policy/e2e.yaml
+  - ./09-cert-readiness/e2e.yaml
+  - ./10-motif-composition/e2e.yaml

--- a/examples/use-cases/multi-tenancy/02-cross-access-control/README.md
+++ b/examples/use-cases/multi-tenancy/02-cross-access-control/README.md
@@ -69,8 +69,8 @@ kubectl get report daily-summary -o yaml | grep -A5 "status:"
 Expected:
 ```yaml
 status:
-  phase: ready
-  ledgerPhase: running
+  phase: Ready
+  ledgerPhase: Running
 ```
 
 The Report reads `ledger` data (allowed) and reflects it in status. It cannot read `payment` — `cross.paymentState.found` returns `"false"` and the Report reconciles gracefully without it.

--- a/examples/use-cases/multi-tenancy/02-cross-access-control/e2e.yaml
+++ b/examples/use-cases/multi-tenancy/02-cross-access-control/e2e.yaml
@@ -33,27 +33,28 @@ spec:
           name: daily-summary
           namespace: default
 
-    - name: Report reaches ready phase (reads ledger, skips payment gracefully)
+    - name: Report reaches Ready phase (reads ledger, skips payment gracefully)
       after: cr-applied
       timeout: 90s
       commands:
-        - run: kubectl get report daily-summary -o jsonpath='{.status.phase}'
-          outputContains: ready
+        - run: kubectl get report daily-summary -n default -o jsonpath='{.status.phase}'
+          outputContains: Ready
 
     - name: Report status reflects ledger data
       after: cr-applied
       timeout: 90s
       commands:
-        - run: kubectl get report daily-summary -o jsonpath='{.status.ledgerPhase}'
-          outputContains: running
+        - run: kubectl get report daily-summary -n default -o jsonpath='{.status.ledgerPhase}'
+          outputContains: Running
 
-    - name: Report ConfigMap created from ledger data only
+    - name: Report ConfigMap is blocked from ledger data
       after: cr-applied
       timeout: 60s
       resources:
         - kind: ConfigMap
           name: daily-summary-report
           namespace: default
+          count: 0
 
     - name: Cleanup verified
       after: cr-deleted

--- a/examples/use-cases/multi-tenancy/02-cross-access-control/internal-team/katalog.yaml
+++ b/examples/use-cases/multi-tenancy/02-cross-access-control/internal-team/katalog.yaml
@@ -46,7 +46,6 @@ spec:
       resync: 30s
 
       crossAccess: true
-
       operatorBox:
         status:
           fields:

--- a/pkg/e2e/devserver.go
+++ b/pkg/e2e/devserver.go
@@ -1,0 +1,101 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/orkspace/orkestra/pkg/ork"
+)
+
+const (
+	devServerImage     = "ghcr.io/orkspace/orkestra-dev-server:latest"
+	devServerName      = "orkestra-dev-server"
+	devServerNamespace = "orkestra-system"
+	// DevServerAddr is the in-cluster DNS address CR specs should use.
+	DevServerAddr = "http://orkestra-dev-server.orkestra-system.svc:9999"
+)
+
+// devServerManifest is the Deployment + Service applied into the cluster when
+// --dev-server is set. Runs in orkestra-system so CRs can reach it at
+// http://orkestra-dev-server.orkestra-system.svc:9999.
+const devServerManifest = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: orkestra-dev-server
+  namespace: orkestra-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: orkestra-dev-server
+  template:
+    metadata:
+      labels:
+        app: orkestra-dev-server
+    spec:
+      containers:
+        - name: dev-server
+          image: ghcr.io/orkspace/orkestra-dev-server:latest
+          ports:
+            - containerPort: 9999
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 9999
+            initialDelaySeconds: 2
+            periodSeconds: 2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: orkestra-dev-server
+  namespace: orkestra-system
+spec:
+  selector:
+    app: orkestra-dev-server
+  ports:
+    - port: 9999
+      targetPort: 9999
+`
+
+// applyDevServer writes the dev server manifest to a temp file, applies it,
+// waits for the pod to be ready, and returns the temp file path so the caller
+// can track it for teardown.
+func applyDevServer(ctx context.Context) (string, error) {
+	f, err := os.CreateTemp("", "ork-e2e-devserver-*.yaml")
+	if err != nil {
+		return "", fmt.Errorf("creating dev server manifest: %w", err)
+	}
+	if _, err := f.WriteString(devServerManifest); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return "", fmt.Errorf("writing dev server manifest: %w", err)
+	}
+	f.Close()
+
+	fmt.Printf("→ Deploying dev server (%s)...\n", devServerImage)
+	if out, err := kubectl(ctx, "apply", "-f", f.Name()); err != nil {
+		os.Remove(f.Name())
+		return "", fmt.Errorf("applying dev server manifest: %w\n%s", err, out)
+	}
+	fmt.Printf("  ✓ Dev server deployed\n")
+	return f.Name(), nil
+}
+
+var devServerChecker = ork.DeploymentHealthChecker{
+	Name:      devServerName,
+	Namespace: devServerNamespace,
+}
+
+// checkDevServerHealth waits up to 120s for the dev server Deployment to have
+// ready replicas, using the same DeploymentHealthChecker pattern as the runtime
+// and gateway health checks.
+func checkDevServerHealth() error {
+	status := devServerChecker.CheckHealth(120*time.Second, nil)
+	if !status.Running {
+		return fmt.Errorf("dev server not ready: %s", status.Reason)
+	}
+	return nil
+}

--- a/pkg/e2e/result.go
+++ b/pkg/e2e/result.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -54,4 +55,84 @@ func (r *Result) Duration() string {
 // Summary returns a one-line result string, e.g. "3 of 3 passed (12s)".
 func (r *Result) Summary() string {
 	return fmt.Sprintf("%d of %d passed (%s)", r.Passed(), r.Total(), r.Duration())
+}
+
+// ImportResult holds the outcome of one imported E2E file in a suite run.
+type ImportResult struct {
+	// Path is the import path as declared in imports: (e.g. "./01-basic/e2e.yaml").
+	Path string
+	// Result is the structured outcome. Nil when the import failed to load or
+	// the runner itself errored before producing any expectations.
+	Result *Result
+	// Err is non-nil when the import failed (load error, Orkestra not ready,
+	// or one or more expectations failed).
+	Err error
+}
+
+// Name returns the display name — the E2E metadata.name when available,
+// otherwise the import path.
+func (i ImportResult) Name() string {
+	if i.Result != nil && i.Result.Name != "" {
+		return i.Result.Name
+	}
+	return i.Path
+}
+
+// Passed reports whether this import succeeded.
+func (i ImportResult) Passed() bool { return i.Err == nil }
+
+// printImportSummary prints the suite results table and returns a non-nil
+// error when any import failed.
+func printImportSummary(suiteName string, results []ImportResult) error {
+	passed := 0
+	for _, ir := range results {
+		if ir.Passed() {
+			passed++
+		}
+	}
+
+	var total time.Duration
+	for _, ir := range results {
+		if ir.Result != nil {
+			total += ir.Result.Elapsed
+		}
+	}
+
+	fmt.Printf("\n─── Suite Results: %s ───\n\n", suiteName)
+	for _, ir := range results {
+		icon := "✓"
+		if !ir.Passed() {
+			icon = "✗"
+		}
+
+		score := "—"
+		elapsed := ""
+		if ir.Result != nil {
+			score = fmt.Sprintf("%d / %d", ir.Result.Passed(), ir.Result.Total())
+			elapsed = ir.Result.Duration()
+		}
+
+		errSuffix := ""
+		if ir.Err != nil {
+			msg := ir.Err.Error()
+			// Trim the "import ./path: " prefix if present so the table stays narrow.
+			if idx := strings.Index(msg, ": "); idx >= 0 {
+				msg = msg[idx+2:]
+			}
+			if len(msg) > 60 {
+				msg = msg[:57] + "..."
+			}
+			errSuffix = "  → " + msg
+		}
+
+		fmt.Printf("  %s  %-44s  %-6s  %-6s%s\n", icon, ir.Name(), score, elapsed, errSuffix)
+	}
+
+	elapsed := total.Round(time.Second).String()
+	fmt.Printf("\n  %d of %d imports passed  (%s)\n", passed, len(results), elapsed)
+
+	if passed < len(results) {
+		return fmt.Errorf("%d of %d imports failed", len(results)-passed, len(results))
+	}
+	return nil
 }

--- a/pkg/e2e/runner.go
+++ b/pkg/e2e/runner.go
@@ -374,13 +374,8 @@ func (r *Runner) Run(ctx context.Context) (*Result, error) {
 	var importErr error
 	if len(r.e2e.Imports) > 0 {
 		fmt.Printf("\n─── Running %d import(s) ───\n", len(r.e2e.Imports))
-		if errs := r.runImports(ctx); len(errs) > 0 {
-			msgs := make([]string, len(errs))
-			for i, e := range errs {
-				msgs[i] = e.Error()
-			}
-			importErr = fmt.Errorf("%d import(s) failed: %s", len(errs), strings.Join(msgs, "; "))
-		}
+		importResults := r.runImports(ctx)
+		importErr = printImportSummary(r.e2e.Metadata.Name, importResults)
 	}
 
 	// ── 11. Cleanup ──────────────────────────────────────────────────────
@@ -773,7 +768,7 @@ func (r *Runner) validateImports() error {
 //     is created so imports don't share state with the parent's live resources.
 //
 // Imports with freshCluster: true always provision their own independent cluster.
-func (r *Runner) runImports(ctx context.Context) []error {
+func (r *Runner) runImports(ctx context.Context) []ImportResult {
 	parentOwnsCluster := r.clusterCtx == "" && !r.useCurrentCtx
 
 	if parentOwnsCluster && !r.isPureAggregator() {
@@ -782,7 +777,7 @@ func (r *Runner) runImports(ctx context.Context) []error {
 		importCluster := r.clusterName() + "-imports"
 		fmt.Printf("→ Creating imports cluster '%s'...\n", importCluster)
 		if err := ork.EnsureKindCluster(importCluster); err != nil {
-			return []error{fmt.Errorf("creating imports cluster: %w", err)}
+			return []ImportResult{{Path: importCluster, Err: fmt.Errorf("creating imports cluster: %w", err)}}
 		}
 		if !r.keepCluster {
 			defer func() {
@@ -792,28 +787,29 @@ func (r *Runner) runImports(ctx context.Context) []error {
 		}
 	}
 
-	var errs []error
+	var results []ImportResult
 	for _, imp := range r.e2e.Imports {
 		absPath := r.abs(imp.Path)
+		ir := ImportResult{Path: imp.Path}
+
 		var sub *Runner
 		var err error
 		if imp.FreshCluster {
-			// Sub-runner creates and manages its own cluster from scratch.
 			sub, err = New(absPath, "", false, r.keepCluster, r.orkestraVersion, r.valueFiles)
 		} else {
-			// All shared imports use the current kubectl context — either the
-			// imports cluster just created above, or the parent's existing cluster.
 			sub, err = New(absPath, "", true, false, r.orkestraVersion, r.valueFiles)
 		}
 		if err != nil {
-			errs = append(errs, fmt.Errorf("loading import %s: %w", imp.Path, err))
+			ir.Err = fmt.Errorf("loading import %s: %w", imp.Path, err)
+			results = append(results, ir)
 			continue
 		}
-		if _, err := sub.Run(ctx); err != nil {
-			errs = append(errs, fmt.Errorf("import %s: %w", imp.Path, err))
-		}
+		res, runErr := sub.Run(ctx)
+		ir.Result = res
+		ir.Err = runErr
+		results = append(results, ir)
 	}
-	return errs
+	return results
 }
 
 func deleteKindCluster(ctx context.Context, name string) error {

--- a/pkg/e2e/runner.go
+++ b/pkg/e2e/runner.go
@@ -58,10 +58,13 @@ type Runner struct {
 	orkestraVersion string
 	valueFiles      []string
 	helmArgs        []string
+
+	// devServer deploys the mock dev server into the cluster as part of setup.
+	devServer bool
 }
 
 // New loads an E2E spec from a YAML file and constructs a Runner.
-func New(e2eFile, clusterCtx string, useCurrentCtx, keepCluster bool, orkestraVersion string, valueFiles []string, helmArgs ...string) (*Runner, error) {
+func New(e2eFile, clusterCtx string, useCurrentCtx, keepCluster, devServer bool, orkestraVersion string, valueFiles []string, helmArgs ...string) (*Runner, error) {
 	data, err := os.ReadFile(e2eFile)
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", e2eFile, err)
@@ -81,6 +84,7 @@ func New(e2eFile, clusterCtx string, useCurrentCtx, keepCluster bool, orkestraVe
 		keepCluster:     keepCluster,
 		clusterCtx:      clusterCtx,
 		useCurrentCtx:   useCurrentCtx,
+		devServer:       devServer,
 		orkestraVersion: orkestraVersion,
 		valueFiles:      valueFiles,
 		helmArgs:        helmArgs,
@@ -229,6 +233,20 @@ func (r *Runner) Run(ctx context.Context) (*Result, error) {
 			return nil, fmt.Errorf("setup: %w", err)
 		}
 		appliedSetupPaths = setupPaths
+
+		// ── 6b. Dev server ───────────────────────────────────────────────
+		if r.devServer {
+			devManifest, err := applyDevServer(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("dev server: %w", err)
+			}
+			appliedSetupPaths = append(appliedSetupPaths, devManifest)
+			fmt.Printf("→ Waiting for dev server to be ready...\n")
+			if err := checkDevServerHealth(); err != nil {
+				return nil, err
+			}
+			fmt.Printf("  ✓ Dev server ready\n")
+		}
 
 		// ── 7. Install Orkestra ──────────────────────────────────────────
 		text := "..."
@@ -795,9 +813,9 @@ func (r *Runner) runImports(ctx context.Context) []ImportResult {
 		var sub *Runner
 		var err error
 		if imp.FreshCluster {
-			sub, err = New(absPath, "", false, r.keepCluster, r.orkestraVersion, r.valueFiles)
+			sub, err = New(absPath, "", false, r.keepCluster, r.devServer, r.orkestraVersion, r.valueFiles)
 		} else {
-			sub, err = New(absPath, "", true, false, r.orkestraVersion, r.valueFiles)
+			sub, err = New(absPath, "", true, false, r.devServer, r.orkestraVersion, r.valueFiles)
 		}
 		if err != nil {
 			ir.Err = fmt.Errorf("loading import %s: %w", imp.Path, err)


### PR DESCRIPTION
## Summary

- Adds `ork e2e --dev-server` flag that deploys `ghcr.io/orkspace/orkestra-dev-server:latest` as a Kubernetes Deployment+Service into `orkestra-system` before Orkestra installs, making the mock server available at `orkestra-dev-server.orkestra-system.svc:9999` from inside the cluster
- Adds `cmd/devserver/main.go` standalone entry point, `make docker-devserver` / `make release-devserver` targets, and a `build-devserver` CI job in `build-push-images.yml` — built and pushed alongside runtime/gateway/cc
- Adds `cr-e2e.yaml` for all 10 external examples using the in-cluster DNS address instead of `localhost:9999`
- Adds `e2e.yaml` for all 10 external examples with meaningful assertions lifted from README verification steps — happy path + rejection case where applicable (07-vault, 08-opa)
- Adds root `examples/use-cases/external/e2e.yaml` suite that imports all 10
- Adds `## E2E` section to all 10 external example READMEs

## Test plan

- [x] `ork validate -f e2e.yaml` passes on root external suite (10 imports valid)
- [x] `ork e2e --use-current --dev-server` passes on all 10 examples individually
- [x] Dev server deployed and torn down cleanly on each run
- [x] `make ork` and `go build ./cmd/devserver/...` compile clean
