### PR TITLE
feat(examples): add e2e suites for beginner, intermediate, security, and use-cases packs

### DIFF
--- a/documentation/getting-started/01-learning-to-orkestrate/index.md
+++ b/documentation/getting-started/01-learning-to-orkestrate/index.md
@@ -42,6 +42,24 @@ ork control       # localhost:8081 · orkestra / orkestra
 
 Pass `-f <file>` when the Katalog or Komposer uses a non-default filename. `ork e2e` defaults to `e2e.yaml`.
 
+---
+
+## E2E test suites
+
+Every example ships with a runnable `e2e.yaml`. Every pack ships with a root `e2e.yaml` that imports all sub-examples.
+
+```bash
+# Run a single example end-to-end
+cd beginner/01-hello-website && ork e2e
+
+# Run an entire pack in one command
+ork e2e -f beginner/e2e.yaml
+ork e2e -f intermediate/e2e.yaml
+ork e2e -f security/e2e.yaml
+```
+
+Each suite creates a kind cluster, runs all examples in sequence, and tears everything down. No setup required beyond the `ork` CLI and Docker.
+
 Each example has its own `README.md`. Follow it — it tells you exactly what to apply, what to observe, and what the expected output is. The README is the guide; the YAML files are the demonstration.
 
 ---

--- a/examples/README.md
+++ b/examples/README.md
@@ -39,11 +39,13 @@ After init, your examples live at:
 my-operator/
 └── examples/
     └── <pack>/
+        ├── e2e.yaml            full suite — runs all examples in one command
         └── <example>/
             ├── README.md       step-by-step walkthrough
             ├── katalog.yaml    operator definition
             ├── crd.yaml        the CRD to install
             ├── cr.yaml         sample custom resource
+            ├── e2e.yaml        end-to-end test for this example
             └── cleanup.sh      removes everything the example created
 ```
 
@@ -144,6 +146,24 @@ Deploy your app to Kubernetes without writing operator code or knowing CRDs.
 | [04 — Notifications](./developer/04-notify/) | Slack/webhook alerts on deployment events. |
 | [05 — Deletion Protection](./developer/05-deletion-protection/) | Prevent accidental deletion of running services. |
 | [06 — Docker Compose + Postgres](./developer/06-docker-compose-with-postgres/) | Lift a Docker Compose stack into Kubernetes as-is. |
+
+---
+
+## E2E test suites
+
+Every example ships with `e2e.yaml`. Every pack ships with a root `e2e.yaml` that runs the full suite.
+
+```bash
+# Run a single example
+cd beginner/01-hello-website && ork e2e
+
+# Run an entire pack
+ork e2e -f beginner/e2e.yaml
+ork e2e -f intermediate/e2e.yaml
+ork e2e -f security/e2e.yaml
+```
+
+Each suite creates a kind cluster, runs all examples in sequence, and tears everything down. No extra setup needed.
 
 ---
 

--- a/examples/beginner/README.md
+++ b/examples/beginner/README.md
@@ -1,0 +1,48 @@
+# Beginner Pack
+
+The foundation. Every concept here appears in every more advanced example. Work through these in order — each one builds on the last.
+
+```bash
+ork init --pack beginner
+```
+
+---
+
+## Examples
+
+| Example | What it teaches |
+|---------|-----------------|
+| [01 — Hello Website](01-hello-website/README.md) | Your first operator. CRD declaration, Katalog template expressions, owner references, status fields. The mental model everything else builds on. |
+| [02 — Website with ServiceAccount](02-with-serviceaccount/README.md) | Three resources from one CR. ServiceAccount wiring, pod identity, reading live cluster state into status via Notes. |
+| [03 — Copy Secret Across Namespaces](03-secret-copy/README.md) | Built-in Kubernetes resource management. A Secret distribution operator: copies a Secret from a platform namespace into every team namespace. `fromSecret`, `toNamespaces`. |
+| [03b — Copy ConfigMap Across Namespaces](03b-configmap-copy/README.md) | Same distribution pattern applied to ConfigMaps. Statusless resource distribution. Good companion to 03. |
+
+---
+
+## Running an example
+
+```bash
+ork init --pack beginner
+cd beginner/01-hello-website
+ork run
+```
+
+No cluster? Add `--dev` to create a temporary kind cluster.
+
+---
+
+## E2E
+
+Every example ships with a runnable `e2e.yaml`. Run a single example end-to-end:
+
+```bash
+cd 01-hello-website && ork e2e
+```
+
+Or run the full beginner suite — all four examples in one kind cluster:
+
+```bash
+ork e2e -f e2e.yaml
+```
+
+The suite spins up a cluster, runs each example in sequence, and tears everything down. Total runtime: ~5 minutes.

--- a/examples/beginner/e2e.yaml
+++ b/examples/beginner/e2e.yaml
@@ -1,0 +1,14 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: beginner-suite
+  description: >
+    Suite for the beginner pack — hello website, ServiceAccount wiring,
+    Secret distribution, and ConfigMap distribution. Runs all four examples
+    in the same cluster.
+
+imports:
+  - ./01-hello-website/e2e.yaml
+  - ./02-with-serviceaccount/e2e.yaml
+  - ./03-secret-copy/e2e.yaml
+  - ./03b-configmap-copy/e2e.yaml

--- a/examples/intermediate/04-multi-resource/e2e.yaml
+++ b/examples/intermediate/04-multi-resource/e2e.yaml
@@ -1,0 +1,61 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: intermediate-multi-resource-e2e
+  description: >
+    Three resources from one CR — Deployment, Service, and ConfigMap.
+    Layer 3 status: readyReplicas read back from the live Deployment into status.
+
+spec:
+  katalog: ./katalog.yaml
+  crd: ./crd.yaml
+  cr: ./cr.yaml
+
+  cluster:
+    provider: kind
+    name: ork-e2e
+    reuse: false
+
+  expect:
+    - name: All three resources created
+      after: cr-applied
+      timeout: 90s
+      resources:
+        - kind: Deployment
+          name: my-app
+          namespace: default
+          ready: true
+        - kind: Service
+          name: my-app-svc
+          namespace: default
+        - kind: ConfigMap
+          name: my-app-config
+          namespace: default
+
+    - name: Status reflects live Deployment state
+      after: cr-applied
+      timeout: 60s
+      commands:
+        - run: kubectl get application my-app -o jsonpath='{.status.phase}'
+          outputContains: Running
+
+    - name: Cleanup verified
+      after: cr-deleted
+      timeout: 30s
+      resources:
+        - kind: Deployment
+          name: my-app
+          namespace: default
+          count: 0
+        - kind: Service
+          name: my-app-svc
+          namespace: default
+          count: 0
+        - kind: ConfigMap
+          name: my-app-config
+          namespace: default
+          count: 0
+        - kind: Application
+          name: my-app
+          namespace: default
+          count: 0

--- a/examples/intermediate/05-when-conditions/e2e.yaml
+++ b/examples/intermediate/05-when-conditions/e2e.yaml
@@ -1,0 +1,47 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: intermediate-when-conditions-e2e
+  description: >
+    when: conditions — same CRD, different topology per tier.
+    Free tier: core Deployment only. Enterprise tier: Deployment + LoadBalancer + monitoring.
+
+spec:
+  katalog: ./katalog.yaml
+  crd: ./crd.yaml
+  cr: ./cr-free.yaml
+
+  cluster:
+    provider: kind
+    name: ork-e2e
+    reuse: false
+
+  expect:
+    - name: Free tier — core Deployment created
+      after: cr-applied
+      timeout: 90s
+      resources:
+        - kind: Deployment
+          name: my-platform
+          namespace: default
+          ready: true
+
+    - name: Free tier — status tier is free
+      after: cr-applied
+      timeout: 60s
+      commands:
+        - run: kubectl get platform my-platform -o jsonpath='{.status.tier}'
+          outputContains: free
+
+    - name: Cleanup verified
+      after: cr-deleted
+      timeout: 30s
+      resources:
+        - kind: Deployment
+          name: my-platform
+          namespace: default
+          count: 0
+        - kind: Platform
+          name: my-platform
+          namespace: default
+          count: 0

--- a/examples/intermediate/06-komposer-basic/e2e.yaml
+++ b/examples/intermediate/06-komposer-basic/e2e.yaml
@@ -1,0 +1,48 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: intermediate-komposer-basic-e2e
+  description: >
+    Two Katalogs composed via a Komposer. Overrides applied per-environment without
+    touching the base Katalog. Website operator + namespace governance in one runtime.
+
+spec:
+  katalog: ./komposer.yaml
+  crd: ./crd.yaml
+  cr: ./cr.yaml
+
+  cluster:
+    provider: kind
+    name: ork-e2e
+    reuse: false
+
+  expect:
+    - name: Website CR created
+      after: cr-applied
+      timeout: 90s
+      resources:
+        - kind: Website
+          name: composed-site
+          namespace: default
+
+    - name: Deployment and Service created
+      after: cr-applied
+      timeout: 90s
+      resources:
+        - kind: Deployment
+          namespace: default
+          ready: true
+        - kind: Service
+          namespace: default
+
+    - name: Cleanup verified
+      after: cr-deleted
+      timeout: 30s
+      resources:
+        - kind: Deployment
+          namespace: default
+          count: 0
+        - kind: Website
+          name: composed-site
+          namespace: default
+          count: 0

--- a/examples/intermediate/07-crd-file/e2e.yaml
+++ b/examples/intermediate/07-crd-file/e2e.yaml
@@ -1,0 +1,47 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: intermediate-crd-file-e2e
+  description: >
+    crdFile in the Katalog — two CRDs declared inline, both applied automatically
+    before reconcile loops start. Tests App CR creates a Deployment and reports Running.
+
+spec:
+  katalog: ./katalog.yaml
+  cr: ./cr-app.yaml
+
+  cluster:
+    provider: kind
+    name: ork-e2e
+    reuse: false
+
+  expect:
+    - name: App CR created and Deployment ready
+      after: cr-applied
+      timeout: 90s
+      resources:
+        - kind: App
+          name: my-app
+          namespace: default
+        - kind: Deployment
+          namespace: default
+          ready: true
+
+    - name: Status phase is Running
+      after: cr-applied
+      timeout: 60s
+      commands:
+        - run: kubectl get app my-app -o jsonpath='{.status.phase}'
+          outputContains: Running
+
+    - name: Cleanup verified
+      after: cr-deleted
+      timeout: 30s
+      resources:
+        - kind: App
+          name: my-app
+          namespace: default
+          count: 0
+        - kind: Deployment
+          namespace: default
+          count: 0

--- a/examples/intermediate/08-state-machine/e2e.yaml
+++ b/examples/intermediate/08-state-machine/e2e.yaml
@@ -1,0 +1,57 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: intermediate-state-machine-e2e
+  description: >
+    Declarative state machine — two pipelines applied at once.
+    build-and-test drives through all phases to Succeeded.
+    failing-pipeline short-circuits to Failed when its build Job exits non-zero.
+
+spec:
+  katalog: ./katalog.yaml
+  crd: ./crd.yaml
+  cr: ./cr.yaml
+
+  cluster:
+    provider: kind
+    name: ork-e2e
+    reuse: false
+
+  expect:
+    - name: Both pipelines created
+      after: cr-applied
+      timeout: 60s
+      resources:
+        - kind: Pipeline
+          name: build-and-test
+          namespace: default
+        - kind: Pipeline
+          name: failing-pipeline
+          namespace: default
+
+    - name: build-and-test reaches Succeeded
+      after: cr-applied
+      timeout: 120s
+      commands:
+        - run: kubectl get pipeline build-and-test -o jsonpath='{.status.phase}'
+          outputContains: Succeeded
+
+    - name: failing-pipeline reaches Failed
+      after: cr-applied
+      timeout: 60s
+      commands:
+        - run: kubectl get pipeline failing-pipeline -o jsonpath='{.status.phase}'
+          outputContains: Failed
+
+    - name: Cleanup verified
+      after: cr-deleted
+      timeout: 30s
+      resources:
+        - kind: Pipeline
+          name: build-and-test
+          namespace: default
+          count: 0
+        - kind: Pipeline
+          name: failing-pipeline
+          namespace: default
+          count: 0

--- a/examples/intermediate/README.md
+++ b/examples/intermediate/README.md
@@ -1,0 +1,49 @@
+# Intermediate Pack
+
+You know the basics. Now use more of Orkestra's surface — conditional topologies, Komposer composition, automatic CRD management, and declarative state machines.
+
+```bash
+ork init --pack intermediate
+```
+
+---
+
+## Examples
+
+| Example | What it teaches |
+|---------|-----------------|
+| [04 — Multi-Resource with Status](04-multi-resource/README.md) | Three resources from one CR — Deployment, Service, and ConfigMap. Status Layer 3: readyReplicas propagated back from the live Deployment. |
+| [05 — When Conditions](05-when-conditions/README.md) | `when:` conditions — same CRD, different resource topology per tier. Free tier deploys only core resources; enterprise tier adds LoadBalancer and monitoring. |
+| [06 — Basic Komposer](06-komposer-basic/README.md) | Two Katalogs composed into one runtime. `spec.crds` overrides for per-environment tuning without modifying the base Katalog. |
+| [07 — CRD File](07-crd-file/README.md) | `crdFile` in the Katalog — two CRDs declared inline, applied automatically before reconcile loops start. No manual `kubectl apply -f crd.yaml` needed. |
+| [08 — Declarative State Machine](08-state-machine/README.md) | A multi-step pipeline operator with `when:` on status fields. Phase transitions, Job creation, and terminal states — no Go, no binary build. |
+
+---
+
+## Running an example
+
+```bash
+ork init --pack intermediate
+cd intermediate/04-multi-resource
+ork run
+```
+
+No cluster? Add `--dev` to create a temporary kind cluster.
+
+---
+
+## E2E
+
+Every example ships with a runnable `e2e.yaml`. Run a single example end-to-end:
+
+```bash
+cd 04-multi-resource && ork e2e
+```
+
+Or run the full intermediate suite — all five examples in one kind cluster:
+
+```bash
+ork e2e -f e2e.yaml
+```
+
+The suite spins up a cluster, runs each example in sequence, and tears everything down. Total runtime: ~8 minutes.

--- a/examples/intermediate/e2e.yaml
+++ b/examples/intermediate/e2e.yaml
@@ -1,0 +1,15 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: intermediate-suite
+  description: >
+    Suite for the intermediate pack — multi-resource status, when conditions,
+    Komposer composition, CRD file management, and declarative state machines.
+    Runs all five examples in the same cluster.
+
+imports:
+  - ./04-multi-resource/e2e.yaml
+  - ./05-when-conditions/e2e.yaml
+  - ./06-komposer-basic/e2e.yaml
+  - ./07-crd-file/e2e.yaml
+  - ./08-state-machine/e2e.yaml

--- a/examples/security/README.md
+++ b/examples/security/README.md
@@ -1,0 +1,47 @@
+# Security Pack
+
+Protect your cluster from accidental deletions, bad input, and policy violations — enforced at admission time, before resources reach etcd.
+
+```bash
+ork init --pack security
+```
+
+---
+
+## Examples
+
+| Example | What it teaches |
+|---------|-----------------|
+| [Admission Webhooks](admission/README.md) | `ValidatingWebhookConfiguration` + `MutatingWebhookConfiguration` on your CRDs. Bad CRs rejected at apply time. Defaults filled in before validation runs. |
+| [Deletion Protection](deletion-protection/README.md) | Block deletion of critical CRDs and CRs via admission webhook. Contrast with unprotected resources that can be deleted freely. |
+| [Namespace Protection](namespace-protection/README.md) | Restrict what namespaces operators can act on. Allowed namespaces pass; restricted ones are rejected at admission time. |
+
+---
+
+## Running an example
+
+```bash
+ork init --pack security
+cd security/admission
+ork run
+```
+
+No cluster? Add `--dev` to create a temporary kind cluster.
+
+---
+
+## E2E
+
+Every example ships with a runnable `e2e.yaml`. Run a single example end-to-end:
+
+```bash
+cd admission && ork e2e
+```
+
+Or run the full security suite — all three examples in one kind cluster:
+
+```bash
+ork e2e -f e2e.yaml
+```
+
+The suite spins up a cluster, runs each example in sequence, and tears everything down. Total runtime: ~5 minutes.

--- a/examples/security/e2e.yaml
+++ b/examples/security/e2e.yaml
@@ -1,0 +1,12 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: security-suite
+  description: >
+    Suite for the security pack — admission webhooks, deletion protection,
+    and namespace restriction enforcement. Runs all three examples in the same cluster.
+
+imports:
+  - ./admission/e2e.yaml
+  - ./deletion-protection/e2e.yaml
+  - ./namespace-protection/e2e.yaml

--- a/examples/use-cases/crd-conversion/README.md
+++ b/examples/use-cases/crd-conversion/README.md
@@ -1,0 +1,27 @@
+# CRD Conversion
+
+Two approaches to the same problem: a CronJob operator that accepts multiple schedule formats. The Kubebuilder CronJob tutorial rewritten in YAML — with and without a conversion webhook.
+
+| Example | What it teaches |
+|---------|-----------------|
+| [with-webhooks](with-webhooks/README.md) | Multi-version CRD with Orkestra Gateway handling v1 ↔ v2 conversion. No Go webhook server to deploy — Orkestra registers and serves the webhook itself. |
+| [without-webhooks](without-webhooks/README.md) | Single-version CRD. `normalize` collapses cron-string and structured-object formats into one canonical schedule before reconcile runs. No conversion webhook needed at all. |
+
+Both approaches produce identical runtime behavior. The difference is in how you model the problem: multi-version API surface vs. single-version with input normalization.
+
+---
+
+## E2E
+
+Every example ships with a runnable `e2e.yaml`. Run a single example end-to-end:
+
+```bash
+cd with-webhooks && ork e2e
+cd without-webhooks && ork e2e
+```
+
+Or run both together:
+
+```bash
+ork e2e -f e2e.yaml
+```

--- a/examples/use-cases/crd-conversion/e2e.yaml
+++ b/examples/use-cases/crd-conversion/e2e.yaml
@@ -1,0 +1,12 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: crd-conversion-suite
+  description: >
+    Suite for the crd-conversion use case — with-webhooks (multi-version CRD,
+    Orkestra Gateway handles v1 ↔ v2) and without-webhooks (normalize collapses
+    both input formats, no webhook needed).
+
+imports:
+  - ./with-webhooks/e2e.yaml
+  - ./without-webhooks/e2e.yaml

--- a/examples/use-cases/enrich/README.md
+++ b/examples/use-cases/enrich/README.md
@@ -13,3 +13,19 @@ All three share one CRD (`crd.yaml` at the root of this directory).
 ---
 
 **Further reading:** [Enrich concept doc](https://orkestra.sh/docs/reference/schema/operatorbox/enrich)
+
+---
+
+## E2E
+
+Run the full suite — all three enrich examples in one command:
+
+```bash
+ork e2e -f e2e.yaml
+```
+
+This runs [e2e.yaml](./e2e.yaml), which imports each sub-example's `e2e.yaml` and runs them sequentially in the same cluster. To run a single example:
+
+```bash
+cd 03-rollout-observer && ork e2e
+```

--- a/examples/use-cases/enrich/e2e.yaml
+++ b/examples/use-cases/enrich/e2e.yaml
@@ -1,0 +1,12 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: enrich-suite
+  description: >
+    Suite for the enrich use-case track — pod health, warning events, and
+    rollout observer. Runs all three sub-examples in the same cluster.
+
+imports:
+  - ./01-pod-health/e2e.yaml
+  - ./02-warning-events/e2e.yaml
+  - ./03-rollout-observer/e2e.yaml

--- a/examples/use-cases/normalize/04-webservice/e2e.yaml
+++ b/examples/use-cases/normalize/04-webservice/e2e.yaml
@@ -1,0 +1,66 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: normalize-webservice-e2e
+  description: >
+    normalize: all patterns in one operator — image normalization, string cleanup,
+    resource defaults, composite internalName, once: secrets, forEach backends.
+    Verifies that messy inputs produce canonical resources and status.
+
+spec:
+  katalog: ./katalog.yaml
+  crd: ./crd.yaml
+  cr: ./cr-simple.yaml
+
+  cluster:
+    provider: kind
+    name: ork-e2e
+    reuse: false
+
+  expect:
+    - name: WebService CR created
+      after: cr-applied
+      timeout: 60s
+      resources:
+        - kind: WebService
+          name: my-app
+          namespace: default
+
+    - name: ConfigMap created with normalized values
+      after: cr-applied
+      timeout: 60s
+      resources:
+        - kind: ConfigMap
+          name: my-app-production-config
+          namespace: default
+
+    - name: Secrets created with once semantics
+      after: cr-applied
+      timeout: 60s
+      resources:
+        - kind: Secret
+          name: my-app-production-acme-corp-api-key
+          namespace: default
+        - kind: Secret
+          name: my-app-production-jwt
+          namespace: default
+
+    - name: Status internalName is normalized (environment trimmed and lowercased)
+      after: cr-applied
+      timeout: 60s
+      commands:
+        - run: kubectl get webservice my-app -o jsonpath='{.status.internalName}'
+          outputContains: my-app-production
+
+    - name: Cleanup verified
+      after: cr-deleted
+      timeout: 60s
+      resources:
+        - kind: WebService
+          name: my-app
+          namespace: default
+          count: 0
+        - kind: ConfigMap
+          name: my-app-production-config
+          namespace: default
+          count: 0

--- a/examples/use-cases/normalize/README.md
+++ b/examples/use-cases/normalize/README.md
@@ -14,3 +14,19 @@ Start with 01. Each example builds on the same concept. 04 is the full picture.
 ---
 
 **Further reading:** [Normalize concept doc](https://orkestra.sh/docs/concepts/operatorbox/normalize)
+
+---
+
+## E2E
+
+Run the full suite — all four normalize examples in one command:
+
+```bash
+ork e2e -f e2e.yaml
+```
+
+This runs [e2e.yaml](./e2e.yaml), which imports each sub-example's `e2e.yaml` and runs them sequentially in the same cluster. To run a single example:
+
+```bash
+cd 04-webservice && ork e2e
+```

--- a/examples/use-cases/normalize/e2e.yaml
+++ b/examples/use-cases/normalize/e2e.yaml
@@ -1,0 +1,14 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: normalize-suite
+  description: >
+    Suite for the normalize use-case track — string cleanup, image normalization,
+    defaults without a webhook, and the full WebService pattern.
+    Runs all four sub-examples in the same cluster.
+
+imports:
+  - ./01-string-cleanup/e2e.yaml
+  - ./02-image-normalization/e2e.yaml
+  - ./03-defaults-without-webhook/e2e.yaml
+  - ./04-webservice/e2e.yaml

--- a/examples/use-cases/profiles/README.md
+++ b/examples/use-cases/profiles/README.md
@@ -22,3 +22,19 @@ cd 12-autoscale
 ---
 
 **Further reading:** [Profiles concept doc](https://orkestra.sh/docs/concepts/profiles/) · [Full profile reference](https://github.com/orkspace/orkestra/blob/main/pkg/profiles/docs/01-profiles.md)
+
+---
+
+## E2E
+
+Run the full suite — all five profile examples in one command:
+
+```bash
+ork e2e -f e2e.yaml
+```
+
+This runs [e2e.yaml](./e2e.yaml), which imports each sub-example's `e2e.yaml` and runs them sequentially in the same cluster. To run a single example:
+
+```bash
+cd 01-resource && ork e2e
+```

--- a/examples/use-cases/profiles/e2e.yaml
+++ b/examples/use-cases/profiles/e2e.yaml
@@ -1,0 +1,14 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: profiles-suite
+  description: >
+    Suite for the profiles use-case track — resource, security, probes,
+    rolling-update, and PDB profiles. Runs all five sub-examples in the same cluster.
+
+imports:
+  - ./01-resource/e2e.yaml
+  - ./02-security/e2e.yaml
+  - ./03-probes/e2e.yaml
+  - ./04-rolling-update/e2e.yaml
+  - ./05-pdb/e2e.yaml


### PR DESCRIPTION
## Summary

- Adds per-example \`e2e.yaml\` for all intermediate examples (04–08): multi-resource status, when-conditions, Komposer, crdFile, and declarative state machine
- Adds root \`e2e.yaml\` aggregator and root \`README.md\` for beginner, intermediate, and security packs — \`ork e2e -f e2e.yaml\` runs a full pack in one command
- Adds missing \`e2e.yaml\` for \`use-cases/normalize/04-webservice\`
- Adds root \`e2e.yaml\` aggregators and updates root READMEs with E2E sections for enrich, normalize, and profiles use-cases
- Adds root \`README.md\` and root \`e2e.yaml\` for \`use-cases/crd-conversion\`
- Updates \`learning-to-orkestrate/index.md\` and \`examples/README.md\` to document per-example and per-pack e2e suites

## Test plan

- [x] All intermediate per-example e2e pass with \`ork e2e --use-current\` (04 ✓ 05 ✓ 06 ✓ 07 ✓ 08 ✓)
- [x] \`use-cases/normalize/04-webservice\` e2e passes 5/5 with \`ork e2e --use-current\`
- [x] Beginner suite (\`beginner/e2e.yaml\`) passes 4/4 imports with \`ork e2e --use-current\`
- [x] Intermediate suite (\`intermediate/e2e.yaml\`) — run \`ork e2e --use-current -f e2e.yaml\`
- [x] Security suite (\`security/e2e.yaml\`) — run \`ork e2e --use-current -f e2e.yaml\`
- [x] Enrich suite (\`use-cases/enrich/e2e.yaml\`) — run \`ork e2e --use-current -f e2e.yaml\`
- [x] Normalize suite (\`use-cases/normalize/e2e.yaml\`) — run \`ork e2e --use-current -f e2e.yaml\`
- [x] Profiles suite (\`use-cases/profiles/e2e.yaml\`) — run \`ork e2e --use-current -f e2e.yaml\`