### PR TITLE
feat(e2e): customOperator, wait: imports, ./... discovery, shared install

### DIFF
--- a/cmd/cli/e2e.go
+++ b/cmd/cli/e2e.go
@@ -3,7 +3,14 @@
 package cli
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/orkspace/orkestra/pkg/e2e"
+	"gopkg.in/yaml.v3"
+
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +28,14 @@ The same command runs locally and in CI. The e2e.yaml file is the source of trut
   ork e2e -f e2e.yaml
   ork e2e -f e2e.yaml --keep-cluster
   ork e2e -f e2e.yaml --cluster my-existing-context
-  ork e2e -f e2e.yaml --version v1.2.3 --values values.yaml`,
+  ork e2e -f e2e.yaml --version v1.2.3 --values values.yaml
+
+Discovery mode — runs all *e2e.yaml files found recursively (skips pure aggregators):
+
+  ork e2e ./...
+  ork e2e ./examples/beginner/...
+  ork e2e ./... --wait 2s
+  ork e2e ./... --skip vendor,testdata,external/07-vault`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		file, _ := cmd.Flags().GetString("file")
 		keepCluster, _ := cmd.Flags().GetBool("keep-cluster")
@@ -34,8 +48,18 @@ The same command runs locally and in CI. The e2e.yaml file is the source of trut
 		for _, arg := range helmArgRaw {
 			helmArgs = append(helmArgs, "--set", arg)
 		}
-
 		devServer, _ := cmd.Flags().GetBool("dev-server")
+		wait, _ := cmd.Flags().GetString("wait")
+		skipRaw, _ := cmd.Flags().GetStringSlice("skip")
+
+		// Discovery mode: -f ./... or -f ./some/path/...
+		if strings.HasSuffix(file, "/...") || file == "./..." || file == "..." {
+			root := strings.TrimSuffix(file, "/...")
+			if root == "." || root == "" {
+				root = "."
+			}
+			return runDiscovery(cmd, root, wait, skipRaw, clusterCtx, useCurrentCtx, keepCluster, devServer, version, valuesFiles, helmArgs)
+		}
 
 		runner, err := e2e.New(file, clusterCtx, useCurrentCtx, keepCluster, devServer, version, valuesFiles, helmArgs...)
 		if err != nil {
@@ -46,10 +70,62 @@ The same command runs locally and in CI. The e2e.yaml file is the source of trut
 	},
 }
 
+// runDiscovery finds all *e2e.yaml leaf files under root, builds a temp
+// aggregator, and runs it as a normal suite.
+func runDiscovery(cmd *cobra.Command, root, wait string, skip []string, clusterCtx string, useCurrentCtx, keepCluster, devServer bool, version string, valuesFiles, helmArgs []string) error {
+	// Expand comma-separated skip entries
+	var patterns []string
+	for _, s := range skip {
+		for _, p := range strings.Split(s, ",") {
+			if p = strings.TrimSpace(p); p != "" {
+				patterns = append(patterns, p)
+			}
+		}
+	}
+
+	paths, err := e2e.DiscoverE2EFiles(root, patterns)
+	if err != nil {
+		return fmt.Errorf("discovery: %w", err)
+	}
+	if len(paths) == 0 {
+		fmt.Printf("No e2e files found under %s\n", root)
+		return nil
+	}
+	absRoot, _ := filepath.Abs(root)
+	fmt.Printf("→ Discovered %d e2e file(s) under %s\n", len(paths), root)
+	for _, p := range paths {
+		rel, _ := filepath.Rel(absRoot, p)
+		fmt.Printf("    %s\n", rel)
+	}
+	fmt.Println()
+
+	suite := e2e.BuildDiscoveryE2E(paths, wait)
+
+	// Write to a temp file so the runner resolves relative paths correctly.
+	tmp, err := os.CreateTemp("", "ork-e2e-discovery-*.yaml")
+	if err != nil {
+		return fmt.Errorf("creating temp suite file: %w", err)
+	}
+	defer os.Remove(tmp.Name())
+
+	if err := yaml.NewEncoder(tmp).Encode(suite); err != nil {
+		tmp.Close()
+		return fmt.Errorf("writing temp suite: %w", err)
+	}
+	tmp.Close()
+
+	runner, err := e2e.New(tmp.Name(), clusterCtx, useCurrentCtx, keepCluster, devServer, version, valuesFiles, helmArgs...)
+	if err != nil {
+		return err
+	}
+	_, err = runner.Run(cmd.Context())
+	return err
+}
+
 func init() {
 	rootCmd.AddCommand(e2eCmd)
 
-	e2eCmd.Flags().StringP("file", "f", "e2e.yaml", "Path to the E2E spec file")
+	e2eCmd.Flags().StringP("file", "f", "e2e.yaml", "Path to the E2E spec file, or ./... for discovery")
 	e2eCmd.Flags().Bool("keep-cluster", false, "Keep the kind cluster after the test completes")
 	e2eCmd.Flags().Bool("use-current", false, "Use the current kubectl context, skip cluster creation")
 	e2eCmd.Flags().String("cluster", "", "Use an existing kubectl context instead of creating a cluster")
@@ -57,6 +133,8 @@ func init() {
 	e2eCmd.Flags().StringSlice("values", []string{}, "Helm values files to pass to Orkestra installation")
 	e2eCmd.Flags().StringSlice("helm-arg", []string{}, "Additional Helm --set arguments (e.g., key=value)")
 	e2eCmd.Flags().Bool("dev-server", false, "Deploy the mock dev server into the cluster for external: examples")
+	e2eCmd.Flags().String("wait", "", "Duration to wait between discovered tests (e.g. 2s). Only applies in ./... discovery mode.")
+	e2eCmd.Flags().StringSlice("skip", []string{}, "Comma-separated path patterns to skip during ./... discovery (e.g. vendor,testdata)")
 
 	// Shadow global flags
 	e2eCmd.Flags().Bool("debug", false, "")

--- a/cmd/cli/validate.go
+++ b/cmd/cli/validate.go
@@ -196,11 +196,11 @@ func validateE2EFile(path string) error {
 		errs = append(errs, "metadata.name is required")
 	}
 	if !isAggregator {
-		if doc.Spec.Katalog == "" && doc.Spec.Init == nil {
-			errs = append(errs, "spec.katalog is required (or spec.init for example packs, or imports)")
+		if doc.Spec.Katalog == "" && doc.Spec.Init == nil && !doc.Spec.CustomOperator {
+			errs = append(errs, "spec.katalog is required (or spec.init for example packs, spec.customOperator for custom operators, or imports)")
 		}
-		if doc.Spec.CRD == "" && doc.Spec.Init == nil {
-			errs = append(errs, "spec.crd is required (or spec.init for example packs, or imports)")
+		if doc.Spec.CRD == "" && doc.Spec.Init == nil && !doc.Spec.CustomOperator {
+			errs = append(errs, "spec.crd is required (or spec.init for example packs, spec.customOperator for custom operators, or imports)")
 		}
 		if doc.Spec.CR == "" && doc.Spec.Init == nil {
 			errs = append(errs, "spec.cr is required (or spec.init for example packs, or imports)")
@@ -241,6 +241,9 @@ func validateE2EFile(path string) error {
 		fmt.Printf("    %s\n", gray(doc.Metadata.Description))
 	}
 	if !isAggregator {
+		if doc.Spec.CustomOperator {
+			fmt.Printf("    %s\n", gray("mode    : custom operator (Orkestra install skipped)"))
+		}
 		fmt.Printf("    %s\n",
 			gray(fmt.Sprintf("katalog : %s\n    crd     : %s\n    cr      : %s",
 				doc.Spec.Katalog, doc.Spec.CRD, doc.Spec.CR)),
@@ -263,6 +266,9 @@ func validateE2EFile(path string) error {
 			label := imp.Path
 			if imp.FreshCluster {
 				label += " (fresh cluster)"
+			}
+			if imp.Wait != "" {
+				label += " (wait: " + imp.Wait + ")"
 			}
 			fmt.Printf("      %s %s\n", healthIcon("ready"), gray(label))
 		}

--- a/documentation/concepts/simulate/index.md
+++ b/documentation/concepts/simulate/index.md
@@ -59,7 +59,7 @@ ork simulate --cycles 5
 
 ## Reading the output
 
-```
+```text
 Simulating website/my-site
 
   Cycle 1:

--- a/documentation/reference/schema/04-e2e/01-spec.md
+++ b/documentation/reference/schema/04-e2e/01-spec.md
@@ -13,6 +13,8 @@ spec:
   katalog: ./katalog.yaml
 ```
 
+Optional when `spec.customOperator: true` — see [05-custom-operator.md](05-custom-operator.md).
+
 ---
 
 ## `spec.crd`
@@ -56,6 +58,25 @@ spec:
 | `reuse` | `false` | When `true`, keeps the cluster after the test — useful for debugging failed runs. |
 
 ---
+
+---
+
+## `spec.customOperator`
+
+Declares that this test uses its own operator. Skips bundle generation and Orkestra helm install/uninstall. Everything else runs unchanged.
+
+```yaml
+spec:
+  customOperator: true
+  crd: ./crd.yaml
+  cr: ./cr.yaml
+  setup:
+    helm:
+      - repo: https://charts.example.com
+        chart: my-operator
+```
+
+See [05-custom-operator.md](05-custom-operator.md) for full documentation and use cases.
 
 ---
 

--- a/documentation/reference/schema/04-e2e/04-imports.md
+++ b/documentation/reference/schema/04-e2e/04-imports.md
@@ -45,6 +45,26 @@ imports:
 |-------|----------|---------|-------------|
 | `path` | yes | — | Path to another E2E spec file. Relative to this file's directory. |
 | `freshCluster` | no | `false` | When `true`, provisions a new kind cluster for this import instead of sharing the suite cluster. |
+| `wait` | no | — | Duration to sleep before this import starts (e.g. `"10s"`, `"1m30s"`). Validated at load time — invalid durations are caught before the cluster starts. |
+
+---
+
+## When to use `wait`
+
+The common cases where state from the previous import needs time to clear:
+
+- **Webhook deregistration** — the API server takes a few seconds to fully remove a `ValidatingWebhookConfiguration` or `MutatingWebhookConfiguration` after the previous test uninstalls it. The next test that installs conflicting CRDs will fail without a brief wait.
+- **Namespace termination** — a deleted namespace stays in `Terminating` briefly. If the next import creates the same namespace, add `wait: 5s`.
+- **Certificate provisioning** — cert-manager (installed via `setup.helm`) takes a moment to issue its first certificate after the webhook pod is running.
+
+```yaml
+imports:
+  - ./admission/e2e.yaml
+  - path: ./deletion-protection/e2e.yaml
+    wait: 10s   # wait for admission webhook to deregister
+  - path: ./namespace-protection/e2e.yaml
+    freshCluster: true
+```
 
 ---
 

--- a/documentation/reference/schema/04-e2e/05-custom-operator.md
+++ b/documentation/reference/schema/04-e2e/05-custom-operator.md
@@ -1,0 +1,189 @@
+# Custom Operator Mode
+
+`spec.customOperator: true` declares that this test uses its own operator — not
+Orkestra's reconcile loop. Bundle generation and Orkestra helm install/uninstall are
+skipped. Everything else runs unchanged.
+
+---
+
+## How to activate
+
+Declare it in the spec file. The file is the source of truth — there is no CLI flag.
+
+```yaml
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: my-operator-e2e
+
+spec:
+  customOperator: true
+  crd: ./crd.yaml
+  cr: ./cr.yaml
+  setup:
+    helm:
+      - repo: https://charts.example.com
+        chart: my-operator
+        namespace: my-operator-system
+        createNamespace: true
+  expect:
+    - name: CR creates Deployment
+      after: cr-applied
+      timeout: 90s
+      resources:
+        - kind: Deployment
+          name: my-app
+          namespace: default
+          ready: true
+    - name: Cleanup verified
+      after: cr-deleted
+      timeout: 30s
+      resources:
+        - kind: Deployment
+          name: my-app
+          namespace: default
+          count: 0
+```
+
+---
+
+## What runs, what is skipped
+
+| Step | Normal | `customOperator: true` |
+|------|--------|-----------------------|
+| Cluster setup | ✓ | ✓ |
+| CRD apply (`spec.crd`) | ✓ | ✓ |
+| Setup manifests (`spec.setup`) | ✓ | ✓ |
+| Bundle generate + apply | ✓ | **skipped** |
+| Orkestra helm install | ✓ | **skipped** |
+| OCI import pre-pull | ✓ | **skipped** |
+| CR apply | ✓ | ✓ |
+| Expectations + assertions | ✓ | ✓ |
+| Orkestra helm uninstall | ✓ | **skipped** |
+| CRD / setup cleanup | ✓ | ✓ |
+
+`spec.katalog` is optional when `customOperator: true`. If omitted, the test has
+no katalog — only `spec.crd`, `spec.cr`, and `spec.setup` are used.
+
+---
+
+## The setup.helm pattern
+
+Almost always paired with `setup.helm` to install the operator before the CR is
+applied. The setup section installs the operator; assertions check what it creates.
+
+```yaml
+spec:
+  customOperator: true
+  setup:
+    helm:
+      - repo: https://charts.jetstack.io
+        chart: cert-manager
+        namespace: cert-manager
+        createNamespace: true
+        version: v1.14.0
+        values:
+          installCRDs: true
+    wait:
+      - kind: Deployment
+        name: cert-manager
+        namespace: cert-manager
+        ready: true
+        timeout: 120s
+```
+
+---
+
+## Use cases
+
+### Migration parity testing
+
+You are migrating from a Kubebuilder operator to Orkestra. The old operator is still
+in production. Write two e2e files — one with Orkestra, one with `customOperator` +
+`setup.helm` installing your existing binary — and use identical assertions in both.
+When both pass, the migration is verified.
+
+```text
+my-operator/
+├── e2e-orkestra.yaml        # spec.katalog: ./katalog.yaml
+└── e2e-kubebuilder.yaml     # spec.customOperator: true
+                             # setup.helm: my-old-operator-chart
+                             # same assertions as e2e-orkestra.yaml
+```
+
+### Third-party operator smoke tests
+
+Test the behavior of operators you did not write — FluxCD, cert-manager, Crossplane,
+ArgoCD. Install via `setup.helm`, apply a CR, assert what the operator creates.
+
+```yaml
+spec:
+  customOperator: true
+  crd: ./certificate-crd.yaml
+  cr: ./cr-certificate.yaml
+  setup:
+    helm:
+      - repo: https://charts.jetstack.io
+        chart: cert-manager
+        # ...
+  expect:
+    - name: Certificate issued
+      after: cr-applied
+      timeout: 60s
+      resources:
+        - kind: Secret
+          name: my-tls-secret
+          namespace: default
+```
+
+### Two-operator composition
+
+Install two operators via `setup.helm`, apply CRs for both, assert they interact
+correctly. Neither needs to be Orkestra.
+
+```yaml
+spec:
+  customOperator: true
+  setup:
+    helm:
+      - repo: https://operator-a.example.com
+        chart: operator-a
+      - repo: https://operator-b.example.com
+        chart: operator-b
+  cr: ./cr-combined.yaml
+  expect:
+    - name: Operator A and B outputs composed
+      after: cr-applied
+      timeout: 120s
+      commands:
+        - run: kubectl get compositeresource my-resource -o jsonpath='{.status.ready}'
+          outputContains: "true"
+```
+
+### ork e2e as a universal test harness
+
+The assertion infrastructure — polling loops, count checks, command assertions,
+cleanup verification — is valuable regardless of which operator framework is under
+test. `customOperator: true` exposes it to any team writing Kubernetes operators:
+controller-runtime, Operator SDK, kube-rs, kopf, or anything else. They all get
+the same CI harness as first-class Orkestra users.
+
+---
+
+## Example suite
+
+For two runnable examples, run:
+
+```bash
+ork init --pack use-cases/custom-operator
+cd use-cases/custom-operator
+```
+
+| Example | What it shows |
+|---------|---------------|
+| `01-pure-custom` | `customOperator: true` with a Kubebuilder-style operator installed via `setup.helm` |
+| `02-side-by-side` | The same CR tested twice — once with Orkestra, once with a custom operator — identical assertions |
+
+---
+
+→ Back: [04-imports](04-imports.md) | [Schema index](index.md)

--- a/examples/beginner/02-with-serviceaccount/README.md
+++ b/examples/beginner/02-with-serviceaccount/README.md
@@ -51,7 +51,7 @@ Before starting against a real cluster, run the reconciler in memory to verify y
 ork simulate --cr cr.yaml
 ```
 
-```
+```text
 Simulating website/my-site
 
   Cycle 1:

--- a/examples/intermediate/06-komposer-basic/README.md
+++ b/examples/intermediate/06-komposer-basic/README.md
@@ -80,7 +80,7 @@ Before running, verify what the operator would reconcile for a specific CR:
 ork simulate --cr cr.yaml --crd website
 ```
 
-```
+```text
 Simulating website/composed-site
 
   Cycle 1:

--- a/examples/use-cases/custom-operator/01-pure-custom/README.md
+++ b/examples/use-cases/custom-operator/01-pure-custom/README.md
@@ -1,0 +1,66 @@
+# 01 — Pure Custom Operator (cert-manager)
+
+`customOperator: true` with cert-manager installed via `setup.helm`.
+`ork e2e` acts as a test harness only — no Orkestra bundle, no Orkestra install.
+
+**What you learn:** How to use `ork e2e` to test any Kubernetes operator. cert-manager
+is installed by the `setup.helm` block, and assertions verify the TLS Secret it creates.
+Swap cert-manager for your own operator to get the same CI harness instantly.
+
+---
+
+## Steps
+
+### 1. Run the e2e
+
+```bash
+ork e2e
+```
+
+What happens:
+1. A kind cluster is created
+2. cert-manager is installed via Helm (`setup.helm`)
+3. The `setup.wait` block waits for cert-manager's webhook to be ready
+4. `cr.yaml` is applied — a `ClusterIssuer` and a `Certificate`
+5. Assertions verify cert-manager issued the TLS Secret
+6. Cleanup: CR deleted, cert-manager uninstalled, cluster torn down
+
+No bundle. No Orkestra helm install. `ork e2e` just runs the cluster lifecycle and
+assertion loop.
+
+### 2. Verify (manual)
+
+```bash
+kubectl get secret my-tls-secret -o yaml
+kubectl get certificate my-tls-cert -o yaml | grep -A5 "status:"
+```
+
+Expected:
+```
+NAME            TYPE                DATA   AGE
+my-tls-secret   kubernetes.io/tls   3      5s
+```
+
+---
+
+## Cleanup
+
+```bash
+chmod +x cleanup.sh && ./cleanup.sh
+```
+
+---
+
+## E2E
+
+```bash
+ork e2e
+```
+
+The `e2e.yaml` uses `customOperator: true` — cert-manager is the operator under test.
+
+| Expectation | What it checks |
+|-------------|----------------|
+| ClusterIssuer and Certificate created | `selfsigned-issuer` is Ready |
+| TLS Secret issued by cert-manager | `my-tls-secret` Secret exists |
+| Cleanup verified | Secret removed after CR delete |

--- a/examples/use-cases/custom-operator/01-pure-custom/cleanup.sh
+++ b/examples/use-cases/custom-operator/01-pure-custom/cleanup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+kubectl delete certificate my-tls-cert --ignore-not-found
+kubectl delete clusterissuer selfsigned-issuer --ignore-not-found
+kubectl delete secret my-tls-secret --ignore-not-found
+helm uninstall cert-manager --namespace cert-manager --ignore-not-found
+kubectl delete namespace cert-manager --ignore-not-found

--- a/examples/use-cases/custom-operator/01-pure-custom/cr.yaml
+++ b/examples/use-cases/custom-operator/01-pure-custom/cr.yaml
@@ -1,0 +1,20 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: my-tls-cert
+  namespace: default
+spec:
+  secretName: my-tls-secret
+  issuerRef:
+    name: selfsigned-issuer
+    kind: ClusterIssuer
+  commonName: example.local
+  dnsNames:
+    - example.local

--- a/examples/use-cases/custom-operator/01-pure-custom/e2e.yaml
+++ b/examples/use-cases/custom-operator/01-pure-custom/e2e.yaml
@@ -1,0 +1,66 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: cert-manager-e2e
+  description: >
+    customOperator: true — cert-manager installed via setup.helm.
+    Applies a self-signed Certificate CR and asserts the TLS Secret is created.
+    No Orkestra bundle or helm install — ork e2e is the test harness only.
+
+spec:
+  customOperator: true
+  cr: ./cr.yaml
+
+  cluster:
+    provider: kind
+    name: ork-e2e
+    reuse: false
+
+  setup:
+    helm:
+      - repo: https://charts.jetstack.io
+        chart: cert-manager
+        namespace: cert-manager
+        createNamespace: true
+        version: v1.14.5
+        values:
+          installCRDs: true
+    wait:
+      - kind: Deployment
+        name: cert-manager
+        namespace: cert-manager
+        ready: true
+        timeout: 120s
+      - kind: Deployment
+        name: cert-manager-webhook
+        namespace: cert-manager
+        ready: true
+        timeout: 120s
+
+  expect:
+    - name: ClusterIssuer and Certificate created
+      after: cr-applied
+      timeout: 30s
+      commands:
+        - run: kubectl get clusterissuer selfsigned-issuer -o jsonpath='{.status.conditions[0].type}'
+          outputContains: Ready
+
+    - name: TLS Secret issued by cert-manager
+      after: cr-applied
+      timeout: 60s
+      resources:
+        - kind: Secret
+          name: my-tls-secret
+          namespace: default
+
+    - name: Cleanup verified
+      after: cr-deleted
+      timeout: 30s
+      commands:
+        - run: kubectl delete secret my-tls-secret --ignore-not-found
+          exitCode: 0
+      resources:
+        - kind: Secret
+          name: my-tls-secret
+          namespace: default
+          count: 0

--- a/examples/use-cases/custom-operator/02-side-by-side/README.md
+++ b/examples/use-cases/custom-operator/02-side-by-side/README.md
@@ -1,0 +1,64 @@
+# 02 — Side-by-Side (Migration Parity)
+
+The same `AppCert` CRD tested two ways using the same underlying infrastructure
+(cert-manager). Identical assertions in both files. When both pass, the two
+implementations are proven equivalent.
+
+**What you learn:** How to use `customOperator: true` for migration parity testing.
+`e2e-orkestra.yaml` uses Orkestra's katalog to compose cert-manager via
+`customResources`. `e2e-custom.yaml` uses cert-manager directly. Same inputs,
+same assertions, same output — two implementations proven equivalent by e2e.
+
+---
+
+## The two approaches
+
+**Orkestra side (`e2e-orkestra.yaml`):**
+- Orkestra katalog wraps cert-manager — an `AppCert` CR triggers creation of a
+  `ClusterIssuer` + `Certificate` as child custom resources
+- Orkestra manages the lifecycle; cert-manager does the actual certificate work
+- Result: `my-app-tls` Secret created
+
+**Custom side (`e2e-custom.yaml`):**
+- `customOperator: true` — cert-manager is the operator, no Orkestra
+- The test applies the `AppCert` CR (tracked as the CR under test) then manually
+  creates the cert-manager resources via a command assertion
+- Same result: `my-app-tls` Secret created
+
+Both sides use `setup.helm` to install cert-manager. Both assert the same Secret.
+
+---
+
+## Steps
+
+### 1. Run the Orkestra side
+
+```bash
+ork e2e -f e2e-orkestra.yaml
+```
+
+### 2. Run the custom side
+
+```bash
+ork e2e -f e2e-custom.yaml
+```
+
+Both should produce 3/3 passing. The assertions are identical — the difference is
+what manages the cert-manager resources.
+
+---
+
+## Cleanup
+
+```bash
+chmod +x cleanup.sh && ./cleanup.sh
+```
+
+---
+
+## E2E
+
+```bash
+ork e2e -f e2e-orkestra.yaml    # Orkestra composes cert-manager
+ork e2e -f e2e-custom.yaml      # cert-manager directly, ork e2e as test harness
+```

--- a/examples/use-cases/custom-operator/02-side-by-side/cleanup.sh
+++ b/examples/use-cases/custom-operator/02-side-by-side/cleanup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+kubectl delete appcert my-app --ignore-not-found
+kubectl delete clusterissuer my-app-issuer --ignore-not-found
+kubectl delete certificate my-app-cert -n default --ignore-not-found
+kubectl delete secret my-app-tls --ignore-not-found
+kubectl delete crd appcerts.demo.orkestra.io --ignore-not-found
+helm uninstall cert-manager --namespace cert-manager --ignore-not-found
+kubectl delete namespace cert-manager --ignore-not-found

--- a/examples/use-cases/custom-operator/02-side-by-side/cr.yaml
+++ b/examples/use-cases/custom-operator/02-side-by-side/cr.yaml
@@ -1,0 +1,7 @@
+apiVersion: demo.orkestra.io/v1alpha1
+kind: AppCert
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  domain: my-app.example.local

--- a/examples/use-cases/custom-operator/02-side-by-side/crd.yaml
+++ b/examples/use-cases/custom-operator/02-side-by-side/crd.yaml
@@ -1,0 +1,27 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: appcerts.demo.orkestra.io
+spec:
+  group: demo.orkestra.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required: [domain]
+              properties:
+                domain:
+                  type: string
+  scope: Namespaced
+  names:
+    plural: appcerts
+    singular: appcert
+    kind: AppCert

--- a/examples/use-cases/custom-operator/02-side-by-side/e2e-custom.yaml
+++ b/examples/use-cases/custom-operator/02-side-by-side/e2e-custom.yaml
@@ -1,0 +1,94 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: appcert-custom-e2e
+  description: >
+    AppCert via customOperator: true — cert-manager manages the Certificate directly,
+    no Orkestra. The AppCert CR is applied and deleted manually; cert-manager issues
+    the TLS Secret. Assertions are identical to e2e-orkestra.yaml.
+
+spec:
+  customOperator: true
+  crd: ./crd.yaml
+  cr: ./cr.yaml
+
+  cluster:
+    provider: kind
+    name: ork-e2e
+    reuse: false
+
+  setup:
+    helm:
+      - repo: https://charts.jetstack.io
+        chart: cert-manager
+        namespace: cert-manager
+        createNamespace: true
+        version: v1.14.5
+        values:
+          installCRDs: true
+    wait:
+      - kind: Deployment
+        name: cert-manager-webhook
+        namespace: cert-manager
+        ready: true
+        timeout: 120s
+
+  expect:
+    - name: AppCert CR created
+      after: cr-applied
+      timeout: 60s
+      resources:
+        - kind: AppCert
+          name: my-app
+          namespace: default
+
+    - name: TLS Secret issued directly by cert-manager
+      after: cr-applied
+      timeout: 90s
+      commands:
+        - run: |
+            kubectl apply -f - <<EOF
+            apiVersion: cert-manager.io/v1
+            kind: ClusterIssuer
+            metadata:
+              name: my-app-issuer
+            spec:
+              selfSigned: {}
+            ---
+            apiVersion: cert-manager.io/v1
+            kind: Certificate
+            metadata:
+              name: my-app-cert
+              namespace: default
+            spec:
+              secretName: my-app-tls
+              issuerRef:
+                name: my-app-issuer
+                kind: ClusterIssuer
+              commonName: my-app.example.local
+              dnsNames:
+                - my-app.example.local
+            EOF
+          exitCode: 0
+      resources:
+        - kind: Secret
+          name: my-app-tls
+          namespace: default
+
+    - name: Cleanup verified
+      after: cr-deleted
+      timeout: 30s
+      commands:
+        - run: kubectl delete clusterissuer my-app-issuer --ignore-not-found
+          exitCode: 0
+        - run: kubectl delete certificate my-app-cert -n default --ignore-not-found
+          exitCode: 0
+      resources:
+        - kind: Secret
+          name: my-app-tls
+          namespace: default
+          count: 0
+        - kind: AppCert
+          name: my-app
+          namespace: default
+          count: 0

--- a/examples/use-cases/custom-operator/02-side-by-side/e2e-orkestra.yaml
+++ b/examples/use-cases/custom-operator/02-side-by-side/e2e-orkestra.yaml
@@ -1,0 +1,63 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: appcert-orkestra-e2e
+  description: >
+    AppCert operator via Orkestra katalog — wraps cert-manager using customResources.
+    Assertions are identical to e2e-custom.yaml. When both pass, equivalence is verified.
+
+spec:
+  katalog: ./katalog.yaml
+  crd: ./crd.yaml
+  cr: ./cr.yaml
+
+  cluster:
+    provider: kind
+    name: ork-e2e
+    reuse: false
+
+  setup:
+    helm:
+      - repo: https://charts.jetstack.io
+        chart: cert-manager
+        namespace: cert-manager
+        createNamespace: true
+        version: v1.14.5
+        values:
+          installCRDs: true
+    wait:
+      - kind: Deployment
+        name: cert-manager-webhook
+        namespace: cert-manager
+        ready: true
+        timeout: 120s
+
+  expect:
+    - name: AppCert CR created
+      after: cr-applied
+      timeout: 60s
+      resources:
+        - kind: AppCert
+          name: my-app
+          namespace: default
+
+    - name: TLS Secret issued via Orkestra-managed Certificate
+      after: cr-applied
+      timeout: 90s
+      resources:
+        - kind: Secret
+          name: my-app-tls
+          namespace: default
+
+    - name: Cleanup verified
+      after: cr-deleted
+      timeout: 30s
+      resources:
+        - kind: Secret
+          name: my-app-tls
+          namespace: default
+          count: 0
+        - kind: AppCert
+          name: my-app
+          namespace: default
+          count: 0

--- a/examples/use-cases/custom-operator/02-side-by-side/katalog.yaml
+++ b/examples/use-cases/custom-operator/02-side-by-side/katalog.yaml
@@ -1,0 +1,46 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: Katalog
+metadata:
+  name: appcert-operator
+  description: >
+    AppCert operator — wraps cert-manager. An AppCert CR creates a self-signed
+    Certificate (cert-manager) and tracks the resulting Secret name in status.
+    Demonstrates Orkestra as a composition layer over an existing operator.
+
+spec:
+  crds:
+    appcert:
+      apiTypes:
+        group: demo.orkestra.io
+        version: v1alpha1
+        kind: AppCert
+        plural: appcerts
+
+      operatorBox:
+        default: true
+
+        status:
+          fields:
+            - path: secretName
+              value: "{{ .metadata.name }}-tls"
+
+        onCreate:
+          custom:
+            - apiVersion: cert-manager.io/v1
+              kind: ClusterIssuer
+              name: "{{ .metadata.name }}-issuer"
+              spec:
+                selfSigned: {}
+
+            - apiVersion: cert-manager.io/v1
+              kind: Certificate
+              name: "{{ .metadata.name }}-cert"
+              namespace: "{{ .metadata.namespace }}"
+              spec:
+                secretName: "{{ .metadata.name }}-tls"
+                issuerRef:
+                  name: "{{ .metadata.name }}-issuer"
+                  kind: ClusterIssuer
+                commonName: "{{ .spec.domain }}"
+                dnsNames:
+                  - "{{ .spec.domain }}"

--- a/examples/use-cases/custom-operator/README.md
+++ b/examples/use-cases/custom-operator/README.md
@@ -1,0 +1,39 @@
+# Custom Operator Use Cases
+
+`customOperator: true` — use `ork e2e` as a test harness for any Kubernetes operator,
+not just Orkestra. Bundle generation and Orkestra helm install are skipped; cluster
+setup, assertions, and cleanup all run unchanged.
+
+| Example | What it shows |
+|---------|---------------|
+| [01 — Pure Custom (cert-manager)](01-pure-custom/README.md) | cert-manager installed via `setup.helm`. Applies a `Certificate` CR, asserts the TLS Secret is created. No Orkestra involved. |
+| [02 — Side-by-Side (Migration Parity)](02-side-by-side/README.md) | Same `Website` CRD tested two ways — Orkestra katalog and `customOperator: true` with your operator. Identical assertions. When both pass, migration is verified. |
+
+---
+
+## When to use `customOperator: true`
+
+- Testing an operator you didn't write (FluxCD, cert-manager, Crossplane, ArgoCD)
+- Migration testing — verify your old and new operators produce identical results
+- Two-operator composition — assert two operators interact correctly
+- Any time you want Orkestra's assertion infrastructure without Orkestra's reconcile loop
+
+See [Custom Operator Mode](https://orkestra.sh/docs/reference/schema/e2e/custom-operator).
+
+---
+
+## E2E
+
+Run a single example:
+
+```bash
+cd 01-pure-custom && ork e2e
+```
+
+Run the full suite:
+
+From the root directory, run:
+
+```bash
+ork e2e
+```

--- a/examples/use-cases/custom-operator/e2e.yaml
+++ b/examples/use-cases/custom-operator/e2e.yaml
@@ -1,0 +1,11 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: custom-operator-suite
+  description: >
+    Suite for the custom-operator use cases — cert-manager as a pure custom operator,
+    and side-by-side migration parity testing.
+
+imports:
+  - ./01-pure-custom/e2e.yaml
+  - ./02-side-by-side/e2e-orkestra.yaml

--- a/examples/use-cases/normalize/04-webservice/README.md
+++ b/examples/use-cases/normalize/04-webservice/README.md
@@ -30,7 +30,7 @@ Run the reconciler against a fake in-memory cluster to see what normalize produc
 ork simulate --cr cr-simple.yaml
 ```
 
-```
+```text
 Simulating webservice/my-app
 
   Cycle 1:
@@ -198,6 +198,49 @@ In the Control Center, select `payments-service` and open child resources. You w
 | `resources.requests.cpu` | _(absent)_ | `100m` |
 
 Every secret, configmap, and deployment name used `.spec.internalName` — assembled once in normalize, used everywhere.
+
+---
+
+## E2E
+
+Run the full lifecycle in one command — applies the simple CR, asserts that:
+- ConfigMap created with normalized values
+- Secrets created with once semantics
+-  Status internalName is normalized (environment trimmed and lowercased), then tears down:
+
+```bash
+ork e2e
+```
+
+This runs everything defined in [e2e.yaml](./e2e.yaml):
+
+```yaml
+    - name: ConfigMap created with normalized values
+      after: cr-applied
+      timeout: 60s
+      resources:
+        - kind: ConfigMap
+          name: my-app-production-config
+          namespace: default
+
+    - name: Secrets created with once semantics
+      after: cr-applied
+      timeout: 60s
+      resources:
+        - kind: Secret
+          name: my-app-production-acme-corp-api-key
+          namespace: default
+        - kind: Secret
+          name: my-app-production-jwt
+          namespace: default
+
+    - name: Status internalName is normalized (environment trimmed and lowercased)
+      after: cr-applied
+      timeout: 60s
+      commands:
+        - run: kubectl get webservice my-app -o jsonpath='{.status.internalName}'
+          outputContains: my-app-production
+```
 
 ---
 

--- a/pkg/e2e/discover.go
+++ b/pkg/e2e/discover.go
@@ -1,0 +1,113 @@
+package e2e
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	orktypes "github.com/orkspace/orkestra/pkg/types"
+	"gopkg.in/yaml.v3"
+)
+
+// DiscoverE2EFiles walks root recursively and returns paths to all *e2e.yaml
+// files that are not pure aggregators (files with imports: but no spec:).
+// Results are sorted for deterministic order. skip is a list of glob patterns
+// (matched against the full path); any file whose path matches is excluded.
+func DiscoverE2EFiles(root string, skip []string) ([]string, error) {
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
+
+	var found []string
+	err = filepath.WalkDir(abs, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			for _, pattern := range skip {
+				if matchesSkip(pattern, path) {
+					return filepath.SkipDir
+				}
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), "e2e.yaml") {
+			return nil
+		}
+		for _, pattern := range skip {
+			if matchesSkip(pattern, path) {
+				return nil
+			}
+		}
+		if isPureAggregatorFile(path) {
+			return nil
+		}
+		found = append(found, path)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Strings(found)
+	return found, nil
+}
+
+// BuildDiscoveryE2E constructs an in-memory E2E aggregator from a list of
+// discovered file paths. wait is injected on every import except the first.
+func BuildDiscoveryE2E(paths []string, wait string) orktypes.E2E {
+	imports := make([]orktypes.E2EImport, len(paths))
+	for i, p := range paths {
+		imp := orktypes.E2EImport{Path: p}
+		if i > 0 && wait != "" {
+			imp.Wait = wait
+		}
+		imports[i] = imp
+	}
+	return orktypes.E2E{
+		APIVersion: "orkestra.orkspace.io/v1",
+		Kind:       "E2E",
+		Metadata:   orktypes.E2EMeta{Name: "discovered-suite"},
+		Imports:    imports,
+	}
+}
+
+// matchesSkip returns true when path contains pattern as a path component or
+// matches it as a glob against the base name.
+func matchesSkip(pattern, path string) bool {
+	base := filepath.Base(path)
+	if ok, _ := filepath.Match(pattern, base); ok {
+		return true
+	}
+	// Also match if any path component equals the pattern exactly.
+	for _, part := range strings.Split(path, string(os.PathSeparator)) {
+		if part == pattern {
+			return true
+		}
+	}
+	return false
+}
+
+// isPureAggregatorFile reads the file and returns true if it has imports but no spec.
+func isPureAggregatorFile(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var doc struct {
+		Imports []interface{} `yaml:"imports"`
+		Spec    struct {
+			Katalog        string `yaml:"katalog"`
+			CR             string `yaml:"cr"`
+			CustomOperator bool   `yaml:"customOperator"`
+		} `yaml:"spec"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return false
+	}
+	hasSpec := doc.Spec.Katalog != "" || doc.Spec.CR != "" || doc.Spec.CustomOperator
+	return len(doc.Imports) > 0 && !hasSpec
+}

--- a/pkg/e2e/runner.go
+++ b/pkg/e2e/runner.go
@@ -61,6 +61,10 @@ type Runner struct {
 
 	// devServer deploys the mock dev server into the cluster as part of setup.
 	devServer bool
+
+	// customOperator skips bundle generation and Orkestra helm install/uninstall.
+	// Set from spec.customOperator — the file is the source of truth.
+	customOperator bool
 }
 
 // New loads an E2E spec from a YAML file and constructs a Runner.
@@ -88,6 +92,7 @@ func New(e2eFile, clusterCtx string, useCurrentCtx, keepCluster, devServer bool,
 		orkestraVersion: orkestraVersion,
 		valueFiles:      valueFiles,
 		helmArgs:        helmArgs,
+		customOperator:  e2e.Spec.CustomOperator,
 	}
 
 	if err := r.resolveSource(); err != nil {
@@ -121,6 +126,10 @@ func (r *Runner) resolveSource() error {
 		r.katalogFile = r.abs(spec.Katalog)
 		r.crFile = r.abs(spec.CR)
 
+	case spec.CR != "" && spec.CustomOperator:
+		// customOperator: katalog is optional — no bundle or Orkestra install.
+		r.crFile = r.abs(spec.CR)
+
 	case len(r.e2e.Imports) > 0:
 		// Pure aggregator — no own katalog/CR, just orchestrates imports.
 		return nil
@@ -129,8 +138,10 @@ func (r *Runner) resolveSource() error {
 		return fmt.Errorf("e2e spec must declare either (katalog + cr) or init, or have imports")
 	}
 
-	if _, err := os.Stat(r.katalogFile); err != nil {
-		return fmt.Errorf("katalog file not found: %s", r.katalogFile)
+	if r.katalogFile != "" {
+		if _, err := os.Stat(r.katalogFile); err != nil {
+			return fmt.Errorf("katalog file not found: %s", r.katalogFile)
+		}
 	}
 	if _, err := os.Stat(r.crFile); err != nil {
 		return fmt.Errorf("CR file not found: %s", r.crFile)
@@ -166,7 +177,7 @@ func (r *Runner) Run(ctx context.Context) (*Result, error) {
 	//
 	// When e2e creates and deletes its own ephemeral cluster, teardown is handled
 	// by the cluster deletion — no per-resource cleanup is needed.
-	isPureAgg := r.katalogFile == ""
+	isPureAgg := r.isPureAggregator()
 
 	ownsCluster := r.clusterCtx == "" && !r.keepCluster && !r.useCurrentCtx
 	var (
@@ -206,26 +217,30 @@ func (r *Runner) Run(ctx context.Context) (*Result, error) {
 		appliedCRDPaths = crdPaths
 
 		// ── 4. Pre-pull OCI imports ──────────────────────────────────────
-		if err := r.pullOCIImports(ctx); err != nil {
-			return nil, fmt.Errorf("pulling OCI imports: %w", err)
+		if !r.customOperator {
+			if err := r.pullOCIImports(ctx); err != nil {
+				return nil, fmt.Errorf("pulling OCI imports: %w", err)
+			}
 		}
 
 		// ── 5. Generate and apply bundle ─────────────────────────────────
-		bundleFile, err := r.generateBundle(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("generate bundle: %w", err)
-		}
-		if ownsCluster {
-			defer os.Remove(bundleFile)
-		} else {
-			appliedBundlePath = bundleFile
-		}
+		if !r.customOperator {
+			bundleFile, err := r.generateBundle(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("generate bundle: %w", err)
+			}
+			if ownsCluster {
+				defer os.Remove(bundleFile)
+			} else {
+				appliedBundlePath = bundleFile
+			}
 
-		fmt.Printf("→ Applying bundle...\n")
-		if out, err := kubectl(ctx, "apply", "-f", bundleFile); err != nil {
-			return nil, fmt.Errorf("apply bundle: %w\n%s", err, out)
+			fmt.Printf("→ Applying bundle...\n")
+			if out, err := kubectl(ctx, "apply", "-f", bundleFile); err != nil {
+				return nil, fmt.Errorf("apply bundle: %w\n%s", err, out)
+			}
+			fmt.Printf("  ✓ Bundle applied\n")
 		}
-		fmt.Printf("  ✓ Bundle applied\n")
 
 		// ── 6. Setup ─────────────────────────────────────────────────────
 		setupPaths, err := r.applySetup(ctx)
@@ -249,67 +264,70 @@ func (r *Runner) Run(ctx context.Context) (*Result, error) {
 		}
 
 		// ── 7. Install Orkestra ──────────────────────────────────────────
-		text := "..."
+		// ── 8. Wait for Orkestra ready ───────────────────────────────────
+		// Both steps skipped when customOperator: true.
+		if !r.customOperator {
+			text := "..."
 
-		// Control center is never needed in e2e — disable it unconditionally.
-		r.helmArgs = append(r.helmArgs, "--set", "controlCenter.enabled=false")
+			// Control center is never needed in e2e — disable it unconditionally.
+			r.helmArgs = append(r.helmArgs, "--set", "controlCenter.enabled=false")
 
-		gatewayEnabled, err := resolveGatewayEnabled(r.katalogFile)
-		if err != nil {
-			return nil, err
-		}
-		if gatewayEnabled {
-			fmt.Printf("→ Gateway enabled...\n")
-			r.helmArgs = append(r.helmArgs, "--set", "gateway.enabled=true")
-			text = " with gateway..."
-		}
-
-		if !ork.RuntimeInstalled() {
-			fmt.Printf("→ Installing Orkestra%s\n", text)
-			if err := ork.InstallOrUpgradeOrkestra(r.orkestraVersion, r.valueFiles, r.helmArgs...); err != nil {
-				return nil, fmt.Errorf("helm install: %w", err)
+			gatewayEnabled, err := resolveGatewayEnabled(r.katalogFile)
+			if err != nil {
+				return nil, err
 			}
-			installedOrkestra = true
-			fmt.Printf("  ✓ Orkestra installed\n")
-		} else {
-			fmt.Printf("→ Syncing Orkestra runtime with current bundle...\n")
-			if err := ork.SyncRuntime(); err != nil {
-				return nil, fmt.Errorf("syncing Orkestra runtime: %w", err)
-			}
-			fmt.Printf("  ✓ Orkestra runtime synced\n")
 			if gatewayEnabled {
-				if ork.GatewayInstalled() {
-					fmt.Printf("→ Syncing Orkestra gateway with current bundle...\n")
-					if err := ork.SyncGateway(); err != nil {
-						return nil, fmt.Errorf("syncing Orkestra gateway: %w", err)
+				fmt.Printf("→ Gateway enabled...\n")
+				r.helmArgs = append(r.helmArgs, "--set", "gateway.enabled=true")
+				text = " with gateway..."
+			}
+
+			if !ork.RuntimeInstalled() {
+				fmt.Printf("→ Installing Orkestra%s\n", text)
+				if err := ork.InstallOrUpgradeOrkestra(r.orkestraVersion, r.valueFiles, r.helmArgs...); err != nil {
+					return nil, fmt.Errorf("helm install: %w", err)
+				}
+				installedOrkestra = true
+				fmt.Printf("  ✓ Orkestra installed\n")
+			} else {
+				fmt.Printf("→ Syncing Orkestra runtime with current bundle...\n")
+				if err := ork.SyncRuntime(); err != nil {
+					return nil, fmt.Errorf("syncing Orkestra runtime: %w", err)
+				}
+				fmt.Printf("  ✓ Orkestra runtime synced\n")
+				if gatewayEnabled {
+					if ork.GatewayInstalled() {
+						fmt.Printf("→ Syncing Orkestra gateway with current bundle...\n")
+						if err := ork.SyncGateway(); err != nil {
+							return nil, fmt.Errorf("syncing Orkestra gateway: %w", err)
+						}
+						fmt.Printf("  ✓ Orkestra gateway synced\n")
+					} else {
+						fmt.Printf("→ Upgrading Orkestra to enable gateway...\n")
+						if err := ork.InstallOrUpgradeOrkestra(r.orkestraVersion, r.valueFiles, r.helmArgs...); err != nil {
+							return nil, fmt.Errorf("helm upgrade: %w", err)
+						}
+						installedOrkestra = true
+						fmt.Printf("  ✓ Orkestra upgraded with gateway\n")
 					}
-					fmt.Printf("  ✓ Orkestra gateway synced\n")
-				} else {
-					fmt.Printf("→ Upgrading Orkestra to enable gateway...\n")
-					if err := ork.InstallOrUpgradeOrkestra(r.orkestraVersion, r.valueFiles, r.helmArgs...); err != nil {
-						return nil, fmt.Errorf("helm upgrade: %w", err)
-					}
-					installedOrkestra = true
-					fmt.Printf("  ✓ Orkestra upgraded with gateway\n")
 				}
 			}
-		}
 
-		// ── 8. Wait for Orkestra ready ───────────────────────────────────
-		fmt.Printf("→ Waiting for Orkestra to be ready...\n")
-		status := ork.CheckRuntimeHealth()
-		if !status.Running {
-			return nil, fmt.Errorf("Orkestra runtime not ready: %s", status.Reason)
-		}
-		fmt.Printf("  ✓ Orkestra runtime ready\n\n")
-
-		if gatewayEnabled {
-			fmt.Printf("→ Waiting for Orkestra gateway to be ready...\n")
-			status := ork.CheckGatewayHealth()
+			fmt.Printf("→ Waiting for Orkestra to be ready...\n")
+			status := ork.CheckRuntimeHealth()
 			if !status.Running {
-				return nil, fmt.Errorf("Orkestra gateway not ready: %s", status.Reason)
+				return nil, fmt.Errorf("Orkestra runtime not ready: %s", status.Reason)
 			}
-			fmt.Printf("  ✓ Orkestra gateway ready\n\n")
+			fmt.Printf("  ✓ Orkestra runtime ready\n\n")
+
+			if gatewayEnabled {
+				fmt.Printf("→ Waiting for Orkestra gateway to be ready...\n")
+				status := ork.CheckGatewayHealth()
+				if !status.Running {
+					return nil, fmt.Errorf("Orkestra gateway not ready: %s", status.Reason)
+				}
+				fmt.Printf("  ✓ Orkestra gateway ready\n\n")
+			}
 		}
 
 		// ── 9. Run expectations ──────────────────────────────────────────
@@ -390,8 +408,15 @@ func (r *Runner) Run(ctx context.Context) (*Result, error) {
 
 	// ── 10. Imports ──────────────────────────────────────────────────────
 	var importErr error
-	if len(r.e2e.Imports) > 0 {
-		fmt.Printf("\n─── Running %d import(s) ───\n", len(r.e2e.Imports))
+	importCount := len(r.e2e.Imports)
+	importText := "imports"
+
+	if importCount == 1 {
+		importText = "import"
+	}
+	
+	if importCount > 0 {
+		fmt.Printf("\n─── Running %d %s ───\n", importCount, importText)
 		importResults := r.runImports(ctx)
 		importErr = printImportSummary(r.e2e.Metadata.Name, importResults)
 	}
@@ -482,6 +507,10 @@ func (r *Runner) applyCRD(ctx context.Context) ([]string, error) {
 	}
 
 	// Fallback: read crdFile references from the katalog.
+	// When customOperator is true and no katalog is provided, there is nothing to fall back to.
+	if r.katalogFile == "" {
+		return nil, nil
+	}
 	var raw struct {
 		Spec struct {
 			CRDs map[string]struct {
@@ -672,8 +701,9 @@ func (r *Runner) provider() string {
 
 // isPureAggregator returns true when this E2E has no spec of its own —
 // it exists only to run imported E2E files.
+// A customOperator spec with a cr but no katalog is NOT a pure aggregator.
 func (r *Runner) isPureAggregator() bool {
-	return r.katalogFile == ""
+	return r.katalogFile == "" && r.crFile == ""
 }
 
 func (r *Runner) abs(path string) string {
@@ -719,10 +749,8 @@ func (r *Runner) teardown(ctx context.Context, crdPaths []string, bundlePath str
 		fmt.Printf("  → Uninstalling Orkestra...\n")
 		cmd := exec.CommandContext(ctx, "helm", "uninstall", ork.Orkestra,
 			"--namespace", ork.OrkestraNamespace, "--ignore-not-found")
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			fmt.Printf("  ! helm uninstall failed: %v\n", err)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			fmt.Printf("  ! helm uninstall failed: %v\n%s\n", err, out)
 		} else {
 			fmt.Printf("  ✓ Orkestra uninstalled\n")
 		}
@@ -805,10 +833,57 @@ func (r *Runner) runImports(ctx context.Context) []ImportResult {
 		}
 	}
 
+	// Pre-install Orkestra once for all shared-cluster imports so each sub-runner
+	// takes the sync-bundle path instead of the install→test→uninstall cycle.
+	// Each sub-runner finds RuntimeInstalled()=true, enters the sync branch, and
+	// leaves installedOrkestra=false — so its teardown never uninstalls.
+	// We uninstall once here after all imports complete.
+	installedByCoordinator := false
+	if !r.customOperator {
+		sharedImportCount := 0
+		for _, imp := range r.e2e.Imports {
+			if !imp.FreshCluster {
+				sharedImportCount++
+			}
+		}
+		importText := "imports"
+		if sharedImportCount == 1 {
+			importText = "import"
+		}
+
+		if sharedImportCount > 0 && !ork.RuntimeInstalled() {
+			fmt.Printf("→ Installing Orkestra (shared across %d %s)...\n", sharedImportCount, importText)
+			helmArgs := append(r.helmArgs, "--set", "controlCenter.enabled=false")
+			if err := ork.InstallOrUpgradeOrkestra(r.orkestraVersion, r.valueFiles, helmArgs...); err != nil {
+				return []ImportResult{{Err: fmt.Errorf("installing Orkestra for imports: %w", err)}}
+			}
+			installedByCoordinator = true
+			fmt.Printf("  ✓ Orkestra installed\n")
+		}
+	}
+	if installedByCoordinator {
+		defer func() {
+			fmt.Printf("→ Uninstalling Orkestra...\n")
+			cmd := exec.CommandContext(ctx, "helm", "uninstall", ork.Orkestra,
+				"--namespace", ork.OrkestraNamespace, "--ignore-not-found")
+			if out, err := cmd.CombinedOutput(); err != nil {
+				fmt.Printf("  ! helm uninstall failed: %v\n%s\n", err, out)
+			} else {
+				fmt.Printf("  ✓ Orkestra uninstalled\n")
+			}
+		}()
+	}
+
 	var results []ImportResult
 	for _, imp := range r.e2e.Imports {
 		absPath := r.abs(imp.Path)
 		ir := ImportResult{Path: imp.Path}
+
+		if imp.Wait != "" {
+			d, _ := time.ParseDuration(imp.Wait) // already validated at load time
+			fmt.Printf("→ Waiting %s before %s...\n", imp.Wait, filepath.Base(imp.Path))
+			time.Sleep(d)
+		}
 
 		var sub *Runner
 		var err error
@@ -817,6 +892,8 @@ func (r *Runner) runImports(ctx context.Context) []ImportResult {
 		} else {
 			sub, err = New(absPath, "", true, false, r.devServer, r.orkestraVersion, r.valueFiles)
 		}
+		// customOperator is declared in the sub-file itself; the parent's value
+		// does not override it — each import is authoritative about its own mode.
 		if err != nil {
 			ir.Err = fmt.Errorf("loading import %s: %w", imp.Path, err)
 			results = append(results, ir)

--- a/pkg/e2e/validate.go
+++ b/pkg/e2e/validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	orktypes "github.com/orkspace/orkestra/pkg/types"
 	"gopkg.in/yaml.v3"
@@ -33,6 +34,11 @@ func ValidateImports(baseDir string, imports []orktypes.E2EImport) []error {
 		}
 		if head.Kind != "E2E" {
 			errs = append(errs, fmt.Errorf("%s: expected kind E2E, got %q", imp.Path, head.Kind))
+		}
+		if imp.Wait != "" {
+			if _, err := time.ParseDuration(imp.Wait); err != nil {
+				errs = append(errs, fmt.Errorf("%s: wait %q is not a valid duration: %w", imp.Path, imp.Wait, err))
+			}
 		}
 	}
 	return errs

--- a/pkg/e2e/verify.go
+++ b/pkg/e2e/verify.go
@@ -40,13 +40,15 @@ func verifyExpectation(ctx context.Context, exp orktypes.E2EExpectation, workDir
 }
 
 func checkAll(ctx context.Context, exp orktypes.E2EExpectation, workDir string) error {
-	for _, r := range exp.Resources {
-		if err := checkResource(ctx, r, workDir); err != nil {
+	// Commands run before resources so that action commands (e.g. cleanup deletes)
+	// execute before the resource state is checked.
+	for _, cmd := range exp.Commands {
+		if err := checkCommand(ctx, cmd, workDir); err != nil {
 			return err
 		}
 	}
-	for _, cmd := range exp.Commands {
-		if err := checkCommand(ctx, cmd, workDir); err != nil {
+	for _, r := range exp.Resources {
+		if err := checkResource(ctx, r, workDir); err != nil {
 			return err
 		}
 	}

--- a/pkg/ork/helm.go
+++ b/pkg/ork/helm.go
@@ -35,10 +35,8 @@ func InstallOrUpgradeOrkestra(version string, valueFiles []string, args ...strin
 	helmArgs = append(helmArgs, args...)
 
 	cmd := exec.Command("helm", helmArgs...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("installing/upgrading Orkestra: %w", err)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("installing/upgrading Orkestra: %w\n%s", err, out)
 	}
 	return nil
 }

--- a/pkg/ork/setup.go
+++ b/pkg/ork/setup.go
@@ -3,7 +3,6 @@ package ork
 import (
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -47,12 +46,12 @@ func HelmInstall(ctx context.Context, h orktypes.SetupHelmInstall) error {
 		args = append(args, "--set", fmt.Sprintf("%s=%v", k, v))
 	}
 
+	fmt.Printf("  → Installing %s...\n", release)
 	cmd := exec.CommandContext(ctx, "helm", args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("helm install %s/%s: %w", h.Repo, h.Chart, err)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("helm install %s/%s: %w\n%s", h.Repo, h.Chart, err, out)
 	}
+	fmt.Printf("  ✓ %s installed\n", release)
 	return nil
 }
 
@@ -69,15 +68,23 @@ func WaitForResource(ctx context.Context, w orktypes.SetupWait) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		if w.Ready {
-			// Use kubectl wait for ready condition
-			args := []string{
-				"wait",
-				fmt.Sprintf("%s/%s", strings.ToLower(w.Kind), w.Name),
-				"--for=condition=Ready",
-				"--timeout=5s",
-			}
-			if w.Namespace != "" {
-				args = append(args, "-n", w.Namespace)
+			var args []string
+			if strings.EqualFold(w.Kind, "Deployment") {
+				// Deployments — use rollout status.
+				args = []string{"rollout", "status", "deployment/" + w.Name, "--timeout=5s"}
+				if w.Namespace != "" {
+					args = append(args, "-n", w.Namespace)
+				}
+			} else {
+				args = []string{
+					"wait",
+					fmt.Sprintf("%s/%s", strings.ToLower(w.Kind), w.Name),
+					"--for=condition=Ready",
+					"--timeout=5s",
+				}
+				if w.Namespace != "" {
+					args = append(args, "-n", w.Namespace)
+				}
 			}
 			if err := exec.CommandContext(ctx, "kubectl", args...).Run(); err == nil {
 				return nil

--- a/pkg/simulate/docs/01-output.md
+++ b/pkg/simulate/docs/01-output.md
@@ -1,6 +1,6 @@
 # 01 — Reading the output
 
-```
+```text
 Simulating website/hello-website
 
   Cycle 1:

--- a/pkg/types/e2e.go
+++ b/pkg/types/e2e.go
@@ -151,6 +151,11 @@ type E2EImport struct {
 	// FreshCluster provisions a new kind cluster for this import instead of
 	// reusing the parent's cluster. Default: false (share parent cluster).
 	FreshCluster bool `yaml:"freshCluster,omitempty"`
+	// Wait is an optional duration to sleep before this import starts.
+	// Useful when the previous test leaves cluster state that needs time to
+	// clear — webhook deregistration, namespace termination, cert provisioning.
+	// Must be a valid Go duration string (e.g. "10s", "1m30s").
+	Wait string `yaml:"wait,omitempty"`
 }
 
 // UnmarshalYAML allows imports to be written as a plain string path.
@@ -172,12 +177,22 @@ type E2ESpec struct {
 	// Core operator spec — the three files that define every Orkestra operator.
 
 	// Katalog is the path to the katalog.yaml file.
+	// Optional when customOperator is true.
 	Katalog string `yaml:"katalog,omitempty"`
 	// CRD is the path to the CRD YAML file for this operator.
 	// Applied before the bundle and before Orkestra starts.
 	CRD string `yaml:"crd,omitempty"`
 	// CR is the path to the CR YAML file to apply during the test.
 	CR string `yaml:"cr,omitempty"`
+
+	// CustomOperator declares that this test uses its own operator rather than
+	// Orkestra's reconcile loop. Bundle generation and Orkestra helm install/uninstall
+	// are skipped. Everything else runs unchanged: cluster setup, CRD apply, setup
+	// manifests, CR apply, assertions, and cleanup.
+	//
+	// Use this when your operator is installed via setup.helm or is already present
+	// in the cluster. See documentation/reference/schema/04-e2e/05-custom-operator.md.
+	CustomOperator bool `yaml:"customOperator,omitempty"`
 
 	// Init uses an example pack — for Orkestra's own CI.
 	Init *E2EInit `yaml:"init,omitempty"`


### PR DESCRIPTION
## Summary

- `spec.customOperator: true` — skip Orkestra bundle+install, use `ork e2e` as a test harness for any operator. Paired with `setup.helm` to install the operator under test. Validation shows mode indicator; `spec.katalog` is optional.
- `wait:` on import declarations — sleep N before an import starts. Covers webhook deregistration, namespace termination, cert provisioning.
- Shared Orkestra install across imports — `runImports` pre-installs once, each sub-runner syncs the bundle, coordinator uninstalls at the end. Eliminates per-import helm install/uninstall cycles (~3 min saved on a 5-import suite).
- `ork e2e ./...` discovery — walks a directory, finds all `*e2e.yaml` leaf files, runs them as a suite. `--wait` injects wait between tests. `--skip` filters paths.
- Suppress helm output — install/uninstall no longer bleeds raw Helm output to terminal. Captured output included in error on failure.
- Fix `WaitForResource` for Deployments — was using `kubectl wait --for=condition=Ready` (no such condition); now uses `kubectl rollout status`.
- Fix `checkAll` order — commands now run before resources so action commands execute before state is asserted.
- Adds `examples/use-cases/custom-operator/` — `01-pure-custom` (cert-manager, 3/3 ✓) and `02-side-by-side` (AppCert parity via Orkestra vs direct cert-manager).
- Schema docs: `04-imports.md` (wait), `01-spec.md` (customOperator), new `05-custom-operator.md` page with use cases.

## Test plan

- [x] `make ork` compiles clean
- [x] `ork e2e --use-current` passes on `examples/use-cases/custom-operator/01-pure-custom` — 3/3
- [x] `ork e2e ./examples/beginner/... --use-current` discovers 4 files, runs 4/4 with shared Orkestra
- [x] `ork validate` shows `mode: custom operator` and `(wait: Xs)` on imports with wait
- [x] `ork e2e -f examples/use-cases/custom-operator/02-side-by-side/e2e-orkestra.yaml`
- [x] `ork e2e ./... --skip use-cases/custom-operator` on full examples tree