### PR TITLE
fix(e2e): shared Orkestra, silent sync, --dry-run, positional ./...

### DIFF
--- a/cmd/cli/e2e.go
+++ b/cmd/cli/e2e.go
@@ -38,6 +38,10 @@ Discovery mode — runs all *e2e.yaml files found recursively (skips pure aggreg
   ork e2e ./... --skip vendor,testdata,external/07-vault`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		file, _ := cmd.Flags().GetString("file")
+		// Allow positional argument: ork e2e ./... (like go test ./...)
+		if len(args) > 0 {
+			file = args[0]
+		}
 		keepCluster, _ := cmd.Flags().GetBool("keep-cluster")
 		useCurrentCtx, _ := cmd.Flags().GetBool("use-current")
 		clusterCtx, _ := cmd.Flags().GetString("cluster")
@@ -51,6 +55,7 @@ Discovery mode — runs all *e2e.yaml files found recursively (skips pure aggreg
 		devServer, _ := cmd.Flags().GetBool("dev-server")
 		wait, _ := cmd.Flags().GetString("wait")
 		skipRaw, _ := cmd.Flags().GetStringSlice("skip")
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
 
 		// Discovery mode: -f ./... or -f ./some/path/...
 		if strings.HasSuffix(file, "/...") || file == "./..." || file == "..." {
@@ -58,7 +63,14 @@ Discovery mode — runs all *e2e.yaml files found recursively (skips pure aggreg
 			if root == "." || root == "" {
 				root = "."
 			}
+			if dryRun {
+				return dryRunDiscovery(root, skipRaw)
+			}
 			return runDiscovery(cmd, root, wait, skipRaw, clusterCtx, useCurrentCtx, keepCluster, devServer, version, valuesFiles, helmArgs)
+		}
+
+		if dryRun {
+			return validateE2EFile(file)
 		}
 
 		runner, err := e2e.New(file, clusterCtx, useCurrentCtx, keepCluster, devServer, version, valuesFiles, helmArgs...)
@@ -68,6 +80,40 @@ Discovery mode — runs all *e2e.yaml files found recursively (skips pure aggreg
 		_, err = runner.Run(cmd.Context())
 		return err
 	},
+}
+
+// dryRunDiscovery lists the files that would be discovered without running them.
+func dryRunDiscovery(root string, skip []string) error {
+	var patterns []string
+	for _, s := range skip {
+		for _, p := range strings.Split(s, ",") {
+			if p = strings.TrimSpace(p); p != "" {
+				patterns = append(patterns, p)
+			}
+		}
+	}
+
+	paths, err := e2e.DiscoverE2EFiles(root, patterns)
+	if err != nil {
+		return fmt.Errorf("discovery: %w", err)
+	}
+	if len(paths) == 0 {
+		fmt.Printf("No e2e files found under %s\n", root)
+		return nil
+	}
+
+	absRoot, _ := filepath.Abs(root)
+	const maxShow = 10
+	fmt.Printf("→ Would run %d e2e file(s) under %s\n\n", len(paths), root)
+	for i, p := range paths {
+		if i >= maxShow {
+			fmt.Printf("  ... %d more\n", len(paths)-maxShow)
+			break
+		}
+		rel, _ := filepath.Rel(absRoot, p)
+		fmt.Printf("  %s\n", rel)
+	}
+	return nil
 }
 
 // runDiscovery finds all *e2e.yaml leaf files under root, builds a temp
@@ -135,6 +181,7 @@ func init() {
 	e2eCmd.Flags().Bool("dev-server", false, "Deploy the mock dev server into the cluster for external: examples")
 	e2eCmd.Flags().String("wait", "", "Duration to wait between discovered tests (e.g. 2s). Only applies in ./... discovery mode.")
 	e2eCmd.Flags().StringSlice("skip", []string{}, "Comma-separated path patterns to skip during ./... discovery (e.g. vendor,testdata)")
+	e2eCmd.Flags().Bool("dry-run", false, "Print what would run without executing. Single file: runs validate. ./...: lists discovered files.")
 
 	// Shadow global flags
 	e2eCmd.Flags().Bool("debug", false, "")

--- a/documentation/reference/schema/04-e2e/06-discovery.md
+++ b/documentation/reference/schema/04-e2e/06-discovery.md
@@ -1,0 +1,80 @@
+# Discovery Mode and Dry Run
+
+## `ork e2e ./...`
+
+Recursively walks a directory, finds all `*e2e.yaml` leaf files, and runs them as a suite — the same pattern as `go test ./...`. No root `e2e.yaml` file needed.
+
+```bash
+ork e2e ./...                                   # all *e2e.yaml files from cwd down
+ork e2e ./examples/beginner/...                 # scoped to a subtree
+ork e2e ./... --wait 2s                         # 2s between each discovered test
+ork e2e ./... --skip vendor,testdata            # exclude matching paths
+```
+
+### Discovery rules
+
+- Finds all files whose name ends with `e2e.yaml` — e.g. `operator-e2e.yaml`, `e2e.yaml`
+- **Skips pure aggregators** — files that have `imports:` but no `spec:`. Those exist for explicit suite runs. Discovery runs leaf tests only to avoid running the same test twice.
+- Sorted by full path for deterministic order
+
+### `--wait`
+
+Sleeps for the given duration before each discovered test (except the first). Use when tests leave cluster state that needs time to clear — webhook deregistration, namespace termination, cert provisioning:
+
+```bash
+ork e2e ./... --wait 5s
+```
+
+### `--skip`
+
+Comma-separated path patterns. Matched against the full file path — either as a path component or as a glob against the file name. Skip slow suites, infrastructure-heavy tests, or vendor directories:
+
+```bash
+ork e2e ./... --skip cr-e2e.yaml,vendor,testdata,external/07-vault
+```
+
+`--skip` is necessary in practice. Without it, `./...` will sweep in tests that require special infrastructure or that are intentionally slow.
+
+---
+
+## `--dry-run`
+
+Shows what would run without executing any tests or touching any cluster.
+
+**Single file:**
+
+```bash
+ork e2e -f e2e.yaml --dry-run
+```
+
+Runs `ork validate` on the file and prints the structured validation output — field summary, setup, expectations. Identical to `ork validate -f e2e.yaml`.
+
+**Discovery mode:**
+
+```bash
+ork e2e ./... --dry-run
+```
+
+Lists the files that would be discovered:
+
+```
+→ Would run 12 e2e file(s) under .
+
+  examples/beginner/01-hello-website/e2e.yaml
+  examples/beginner/02-with-serviceaccount/e2e.yaml
+  examples/beginner/03-secret-copy/e2e.yaml
+  examples/beginner/03b-configmap-copy/e2e.yaml
+  examples/intermediate/04-multi-resource/e2e.yaml
+  examples/intermediate/05-when-conditions/e2e.yaml
+  examples/intermediate/06-komposer-basic/e2e.yaml
+  examples/intermediate/07-crd-file/e2e.yaml
+  examples/intermediate/08-state-machine/e2e.yaml
+  examples/use-cases/enrich/01-pod-health/e2e.yaml
+  ... 2 more
+```
+
+No cluster is created. No tests are run.
+
+---
+
+→ Back: [05-custom-operator.md](05-custom-operator.md) | [Schema index](index.md)

--- a/documentation/reference/schema/04-e2e/index.md
+++ b/documentation/reference/schema/04-e2e/index.md
@@ -125,16 +125,41 @@ To keep the cluster for inspection after the test:
 ork e2e --keep-cluster
 ```
 
+### Run a full pack
+
+Every example pack ships with a root `e2e.yaml`. Run the full suite in one command:
+
+```bash
+ork e2e -f examples/beginner/e2e.yaml --use-current
+ork e2e -f examples/intermediate/e2e.yaml --use-current
+```
+
+Orkestra installs once before the suite, each test updates the bundle in place, Orkestra uninstalls once at the end.
+
+### Discover and run without a root file
+
+`./...` finds every leaf test automatically — no root `e2e.yaml` needed:
+
+```bash
+ork e2e ./examples/beginner/...          # all beginner tests
+ork e2e ./... --skip external            # everything except external gate tests
+ork e2e ./... --dry-run                  # list what would run, no cluster created
+```
+
+See [06-discovery.md](06-discovery.md).
+
 ---
 
 ## Where to go
 
 | Page | Covers |
 |------|--------|
-| [01-spec.md](01-spec.md) | `katalog`, `crd`, `cr`, `cluster` |
+| [01-spec.md](01-spec.md) | `katalog`, `crd`, `cr`, `cluster`, `customOperator` |
 | [02-setup.md](02-setup.md) | `setup.apply`, `setup.helm`, `setup.wait` |
 | [03-expect.md](03-expect.md) | `expect` — resources, commands, after, timeout |
-| [04-imports.md](04-imports.md) | `imports` — test suites, cluster strategy, pure aggregators |
+| [04-imports.md](04-imports.md) | `imports` — test suites, `wait:`, cluster strategy, pure aggregators |
+| [05-custom-operator.md](05-custom-operator.md) | `customOperator: true` — test any operator without Orkestra |
+| [06-discovery.md](06-discovery.md) | `./...` discovery, `--wait`, `--skip`, `--dry-run` |
 
 ---
 

--- a/examples/use-cases/custom-operator/e2e.yaml
+++ b/examples/use-cases/custom-operator/e2e.yaml
@@ -8,4 +8,5 @@ metadata:
 
 imports:
   - ./01-pure-custom/e2e.yaml
-  - ./02-side-by-side/e2e-orkestra.yaml
+  - path: ./02-side-by-side/e2e-orkestra.yaml
+    wait: 10s

--- a/pkg/e2e/README.md
+++ b/pkg/e2e/README.md
@@ -4,6 +4,8 @@
 
 ```bash
 ork e2e -f e2e.yaml
+ork e2e ./...                    # discover and run all *e2e.yaml files recursively
+ork e2e ./examples/beginner/...  # scoped discovery
 ```
 
 ## Developer documentation
@@ -13,4 +15,7 @@ ork e2e -f e2e.yaml
 | Understand the spec file format and all fields | [docs/01-spec.md](docs/01-spec.md) |
 | Understand how expectations are evaluated (resources, commands, polling) | [docs/02-expectations.md](docs/02-expectations.md) |
 | Understand the full run pipeline (what happens in order) | [docs/03-pipeline.md](docs/03-pipeline.md) |
-| Understand cluster lifecycle (kind, reuse, context restore) | [docs/04-cluster.md](docs/04-cluster.md) |
+| Understand cluster lifecycle (kind, reuse, context restore, shared Orkestra) | [docs/04-cluster.md](docs/04-cluster.md) |
+| Compose test suites with imports and the `wait:` field | [docs/05-imports.md](docs/05-imports.md) |
+| Use `./...` discovery mode, `--wait`, `--skip`, `--dry-run` | [docs/06-discovery.md](docs/06-discovery.md) |
+| Test any operator without Orkestra (`customOperator: true`) | [docs/07-custom-operator.md](docs/07-custom-operator.md) |

--- a/pkg/e2e/docs/01-spec.md
+++ b/pkg/e2e/docs/01-spec.md
@@ -10,9 +10,11 @@ metadata:
   description: What this test verifies
 
 spec:
-  katalog: ./katalog.yaml   # required
+  katalog: ./katalog.yaml   # required (optional when customOperator: true)
   crd: ./crd.yaml           # required — the operator's CRD
   cr: ./cr.yaml             # required — the CR to apply
+
+  customOperator: false     # true = skip bundle + Orkestra install (see below)
 
   cluster:
     provider: kind           # only "kind" is supported
@@ -20,7 +22,19 @@ spec:
     reuse: false             # false = delete and recreate if exists
 
   setup:                     # optional — applied before CR, in order
-    - ./setup.yaml
+    apply:
+      - ./setup.yaml
+    helm:
+      - repo: https://charts.example.com
+        chart: my-prereq
+        namespace: my-prereq-system
+        createNamespace: true
+    wait:
+      - kind: Deployment
+        name: my-prereq
+        namespace: my-prereq-system
+        ready: true
+        timeout: 120s
 
   expect:
     - name: CR created
@@ -45,28 +59,104 @@ spec:
 ### `spec.katalog`
 Path to the Katalog (or Komposer) file. The runner resolves `crdFile` entries in it and embeds them in the bundle so the in-cluster runtime doesn't need local file access.
 
+Optional when `spec.customOperator: true`.
+
 ### `spec.crd`
 Path to the CRD YAML to apply before the operator starts. If omitted, the runner falls back to `crdFile` entries in the Katalog.
 
 ### `spec.cr`
 Path to the CR to apply. Applied when the first `after: cr-applied` expectation is reached, deleted when the first `after: cr-deleted` expectation is reached.
 
+### `spec.customOperator`
+When `true`, skips bundle generation and Orkestra helm install/uninstall. Use when your operator is installed via `setup.helm` or is already present in the cluster. `spec.katalog` is optional. Everything else (CRD apply, setup, CR apply, assertions, cleanup) runs unchanged.
+
+See [05-custom-operator.md](05-custom-operator.md).
+
 ### `spec.setup`
-List of YAML files applied after the cluster is ready but before the CR. Use for namespaces, Secrets, or fixture CRDs the test depends on.
+Prerequisites applied after the cluster is ready but before the CR. Shorthand (plain list of strings) applies each file:
+
+```yaml
+setup:
+  - ./namespaces.yaml
+  - ./secret.yaml
+```
+
+Struct form adds Helm chart installation and resource waiting:
+
+```yaml
+setup:
+  apply:
+    - ./namespaces.yaml
+  helm:
+    - repo: https://charts.jetstack.io
+      chart: cert-manager
+      namespace: cert-manager
+      createNamespace: true
+      version: v1.14.5
+      values:
+        installCRDs: true
+  wait:
+    - kind: Deployment
+      name: cert-manager-webhook
+      namespace: cert-manager
+      ready: true
+      timeout: 120s
+```
+
+`setup.wait` uses `kubectl rollout status` for Deployments and `kubectl wait --for=condition=Ready` for other kinds.
 
 ### `spec.cluster.reuse`
 When `true`, the runner reuses an existing kind cluster with the same name instead of deleting and recreating it. Useful for iterating locally without waiting for cluster creation each time.
 
-## Using an existing cluster
+## Imports (suite composition)
 
-Pass `--cluster` to skip cluster creation entirely:
+`imports` is a top-level field (alongside `spec:`) that lists other E2E files to run after the current one:
+
+```yaml
+imports:
+  - ./01-basic/e2e.yaml
+  - path: ./02-advanced/e2e.yaml
+    wait: 10s          # sleep before this import starts
+  - path: ./03-infra/e2e.yaml
+    freshCluster: true # provision a new cluster for this import
+```
+
+See [05-imports.md](05-imports.md).
+
+## Using an existing cluster
 
 ```bash
 ork e2e -f e2e.yaml --cluster my-existing-context
+ork e2e -f e2e.yaml --use-current
 ```
+
+## Discovery mode
+
+```bash
+ork e2e ./...                          # all *e2e.yaml files recursively
+ork e2e ./examples/beginner/...        # scoped to a subtree
+ork e2e ./... --wait 2s --skip vendor,cr-e2e.yaml
+```
+
+See [06-discovery.md](06-discovery.md).
+
+## Dev server (external gate examples)
+
+```bash
+ork e2e -f e2e.yaml --dev-server
+```
+
+Deploys `ghcr.io/orkspace/orkestra-dev-server:latest` as a Deployment+Service into `orkestra-system` before Orkestra installs. CRs in `use-cases/external` use `orkestra-dev-server.orkestra-system.svc:9999` as the gate endpoint instead of `localhost:9999`, so they work from inside the cluster without host networking.
 
 ## Keeping the cluster after the test
 
 ```bash
 ork e2e -f e2e.yaml --keep-cluster
+```
+
+## Dry run
+
+```bash
+ork e2e -f e2e.yaml --dry-run          # runs ork validate on the file
+ork e2e ./... --dry-run                # lists files that would be discovered
 ```

--- a/pkg/e2e/docs/02-expectations.md
+++ b/pkg/e2e/docs/02-expectations.md
@@ -59,10 +59,32 @@ Run arbitrary shell commands and assert exit code or output:
 
 ```yaml
 commands:
+  - run: kubectl get pipeline build-and-test -o jsonpath='{.status.phase}'
+    outputContains: Succeeded
   - run: kubectl delete crd apps.security.orkestra.io
     exitCode: 1
     outputContains: "denied the request"
 ```
+
+Commands also serve as **action commands** — imperative steps that run before resource state is checked. This is the pattern for cleanup that requires an explicit delete:
+
+```yaml
+- name: Cleanup verified
+  after: cr-deleted
+  timeout: 30s
+  commands:
+    - run: kubectl delete secret my-tls-secret --ignore-not-found
+      exitCode: 0
+  resources:
+    - kind: Secret
+      name: my-tls-secret
+      namespace: default
+      count: 0
+```
+
+## Evaluation order
+
+Within each polling iteration: **commands run first, then resources**. This ensures action commands (like a delete) execute before the resource state assertion checks the result.
 
 ## Polling
 

--- a/pkg/e2e/docs/03-pipeline.md
+++ b/pkg/e2e/docs/03-pipeline.md
@@ -3,29 +3,52 @@
 `runner.Run` executes these steps in order. Each step must succeed before the next begins.
 
 ```
-1. Capture original kubectl context  (restored via defer on any exit)
-2. Ensure cluster                    (create kind cluster, or use --cluster)
-3. Check dependencies                (kubectl, helm, kind available)
-4. Apply CRD                         (from spec.crd or katalog crdFile entries)
-5. Generate bundle                   (ork generate bundle → resolves crdFile inline)
-6. Apply bundle                      (kubectl apply — RBAC, ServiceAccounts, ConfigMap)
-7. Apply setup files                 (spec.setup, in order)
-8. Install Orkestra                  (helm install, skipped if already installed)
-9. Wait for Orkestra ready           (health check)
-10. Run expectations                 (cr-applied / cr-deleted, in order)
-11. Print results
-12. Delete cluster                   (unless --keep-cluster or --cluster was used)
-13. Restore kubectl context          (defer — always runs)
+ 1. Capture original kubectl context  (restored via defer on any exit)
+ 2. Ensure cluster                    (create kind cluster, or use --cluster / --use-current)
+ 3. Check dependencies                (kubectl, helm, kind available)
+ 4. Apply CRD                         (from spec.crd or katalog crdFile entries)
+ 5. Pre-pull OCI imports              (skipped when customOperator: true)
+ 6. Generate + apply bundle           (skipped when customOperator: true)
+ 7. Apply setup files                 (spec.setup.apply, in order)
+ 8. Install setup Helm charts         (spec.setup.helm, in order)
+ 9. Wait for setup resources          (spec.setup.wait, in order)
+10. Install or sync Orkestra          (skipped when customOperator: true — see below)
+11. Run expectations                  (cr-applied / cr-deleted, in order)
+12. Print results
+13. Run imports                       (if any — see imports.md)
+14. Delete cluster                    (unless --keep-cluster or --cluster was used)
+15. Restore kubectl context           (defer — always runs)
 ```
+
+## Orkestra install / sync (step 10)
+
+**Fresh install** (Orkestra not present):
+```
+→ Installing Orkestra...
+  ✓ Orkestra installed
+→ Waiting for Orkestra to be ready...
+  ✓ Orkestra runtime ready
+```
+
+**Already installed** (bundle update only — silent):
+The runtime is restarted silently to pick up the new bundle. No messages are printed. The health check still runs to ensure the runtime is ready before the CR is applied.
+
+**customOperator: true** — step 10 is skipped entirely. Your operator is responsible for reconciling the CR.
+
+## Teardown
+
+For non-owned clusters (--use-current, --cluster, --keep-cluster), teardown reverses every applied resource in order:
+
+```
+CR delete → Orkestra uninstall → bundle delete → setup (reverse) → CRDs
+```
+
+When running as a shared import (suite mode), the bundle is NOT deleted from the cluster — the next import will update it in place with its own bundle. The coordinator uninstalls Orkestra once after all imports complete.
 
 ## Bundle generation
 
 The runner resolves `crdFile` references in the Katalog before generating the bundle. This embeds the CRD type information directly into the ConfigMap so the in-cluster Orkestra runtime doesn't need access to local files.
 
-## Orkestra install
-
-If Orkestra is already installed in the cluster (`doctor.OrkestraInstalled()` returns true), the install step is skipped. This makes `--keep-cluster` + `reuse: true` fast for local iteration.
-
 ## Context restore
 
-The original `kubectl` context is captured at the start of `Run` and restored via `defer` — so it's always restored regardless of whether the test passes, fails, or panics. This prevents the kind cluster context from stranding your terminal after the cluster is deleted.
+The original `kubectl` context is captured at the start of `Run` and restored via `defer` — so it's always restored regardless of whether the test passes, fails, or panics.

--- a/pkg/e2e/docs/04-cluster.md
+++ b/pkg/e2e/docs/04-cluster.md
@@ -15,18 +15,37 @@ cluster:
   reuse: true
 ```
 
-Combined with `--keep-cluster`, this makes local iteration fast — the cluster stays up, Orkestra stays installed, and only the CR lifecycle is re-run.
+Combined with `--keep-cluster`, this makes local iteration fast — the cluster stays up, the bundle is updated in place, and only the CR lifecycle is re-run.
 
 ## Using an existing cluster
 
 ```bash
 ork e2e -f e2e.yaml --cluster my-context
+ork e2e -f e2e.yaml --use-current
 ```
 
-The runner switches to `my-context` and skips cluster creation entirely. The cluster is never deleted at the end. The original context is still restored via defer.
+The runner switches to the given context and skips cluster creation entirely. The cluster is never deleted at the end. The original context is still restored via defer.
+
+## Suite mode — shared cluster across imports
+
+When a root e2e file has `imports:`, all non-`freshCluster` imports share the same cluster. Orkestra is installed **once** by the coordinator before the import loop, then each import:
+
+1. Applies its own bundle (updates the ConfigMap in place via `kubectl apply`)
+2. Syncs the runtime silently
+3. Runs its test
+4. Cleans up CRDs and setup — but does **not** delete the bundle or uninstall Orkestra
+
+After all imports complete, the coordinator uninstalls Orkestra once. This means a suite of 5 imports shows exactly one `→ Installing Orkestra...` and one `→ Uninstalling Orkestra...`, regardless of how many imports it contains.
+
+For imports that need full isolation, set `freshCluster: true`:
+
+```yaml
+imports:
+  - ./01-basic/e2e.yaml
+  - path: ./02-needs-isolation/e2e.yaml
+    freshCluster: true
+```
 
 ## Context restore
 
 The runner captures `kubectl config current-context` before any context switch and restores it at the end via `defer` — so cleanup errors, test failures, and early returns all restore the context correctly.
-
-Before this fix, deleting the kind cluster left `kubectl` pointing at the deleted cluster. Any subsequent `kubectl` command would fail with "the server could not find the requested resource" until the context was switched manually.

--- a/pkg/e2e/docs/05-imports.md
+++ b/pkg/e2e/docs/05-imports.md
@@ -1,0 +1,67 @@
+# Imports and Suite Composition
+
+`imports` is a top-level field (alongside `spec:`) that lists other E2E files to run after the current one completes. It is the building block for test suites.
+
+## Wire format
+
+```yaml
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: beginner-suite
+
+imports:
+  - ./01-hello-website/e2e.yaml
+  - path: ./02-with-serviceaccount/e2e.yaml
+    wait: 10s
+  - path: ./03-infra/e2e.yaml
+    freshCluster: true
+```
+
+## Fields
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `path` | — | Path to another E2E spec file. Relative to this file's directory. |
+| `wait` | — | Duration to sleep before this import starts (e.g. `10s`, `1m30s`). Validated at load time. |
+| `freshCluster` | `false` | When `true`, provisions a new kind cluster for this import instead of sharing the suite cluster. |
+
+### `wait:` — why you need it
+
+State from the previous import sometimes needs time to clear before the next one starts:
+
+- **Webhook deregistration**: the API server takes ~2–5s to fully remove a `ValidatingWebhookConfiguration` after the previous test uninstalled it. The next test that installs conflicting CRDs will fail without a wait.
+- **Namespace termination**: a deleted namespace stays `Terminating` briefly. If the next import creates the same namespace, add `wait: 5s`.
+- **Cert provisioning**: cert-manager (installed via `setup.helm`) takes a moment to issue its first certificate after the webhook pod is ready.
+
+## Pure aggregator
+
+An E2E file with `imports:` but no `spec:` is a pure aggregator — it exists only to run a suite:
+
+```yaml
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: beginner-suite
+
+imports:
+  - ./01-hello-website/e2e.yaml
+  - ./02-with-serviceaccount/e2e.yaml
+  - ./03-secret-copy/e2e.yaml
+  - ./03b-configmap-copy/e2e.yaml
+```
+
+## Shared Orkestra (default)
+
+For non-`freshCluster` imports, the coordinator installs Orkestra **once** before the import loop. Each import updates the bundle in place and syncs the runtime silently. After all imports complete, the coordinator uninstalls once.
+
+A suite of 10 imports produces exactly one `→ Installing Orkestra...` and one `→ Uninstalling Orkestra...`.
+
+## Validation
+
+`ork validate` and `ork e2e` both check every import file before the test runs:
+- The file must exist at the resolved path
+- The file must declare `kind: E2E`
+- Any `wait:` value must be a valid Go duration string
+
+A missing file, wrong kind, or invalid duration is a validation error — the run does not start.

--- a/pkg/e2e/docs/06-discovery.md
+++ b/pkg/e2e/docs/06-discovery.md
@@ -1,0 +1,61 @@
+# Discovery Mode — `ork e2e ./...`
+
+`ork e2e ./...` recursively walks a directory, finds all `*e2e.yaml` leaf files, and runs them as a suite — the same pattern as `go test ./...`.
+
+```bash
+ork e2e ./...                               # all e2e files from cwd down
+ork e2e ./examples/beginner/...             # scoped to a subtree
+ork e2e ./... --wait 2s                     # 2s between each discovered test
+ork e2e ./... --skip vendor,testdata        # exclude paths matching patterns
+ork e2e ./... --dry-run                     # list files without running
+```
+
+## Discovery rules
+
+- Finds all files whose name ends with `e2e.yaml` (e.g. `my-e2e.yaml`, `operator-e2e.yaml`)
+- **Skips pure aggregators** — files with `imports:` but no `spec:`. They exist for explicit suite runs; discovery runs leaf tests only to avoid double-running
+- Sorts by full path for deterministic order
+- Skips paths matching any `--skip` pattern (matched against the full path as a component or glob)
+
+## `--wait`
+
+Injects `wait: <d>` on every import except the first. Use when tests leave cluster state that needs time to clear between runs:
+
+```bash
+ork e2e ./... --wait 5s
+```
+
+## `--skip`
+
+Comma-separated patterns. Each pattern is matched against path components and the file's base name:
+
+```bash
+ork e2e ./... --skip vendor,testdata,external/07-vault
+```
+
+`--skip` is necessary in practice. Without it, `./...` will sweep in slow suites, vendor directories, and tests that require special infrastructure.
+
+## `--dry-run`
+
+Lists the files that would be discovered without running any tests:
+
+```bash
+$ ork e2e ./... --dry-run
+→ Would run 12 e2e file(s) under .
+
+  examples/beginner/01-hello-website/e2e.yaml
+  examples/beginner/02-with-serviceaccount/e2e.yaml
+  examples/beginner/03-secret-copy/e2e.yaml
+  examples/beginner/03b-configmap-copy/e2e.yaml
+  examples/intermediate/04-multi-resource/e2e.yaml
+  examples/intermediate/05-when-conditions/e2e.yaml
+  examples/intermediate/06-komposer-basic/e2e.yaml
+  examples/intermediate/07-crd-file/e2e.yaml
+  examples/intermediate/08-state-machine/e2e.yaml
+  examples/use-cases/enrich/01-pod-health/e2e.yaml
+  ... 2 more
+```
+
+## How it works
+
+The CLI builds a synthetic in-memory aggregator (`kind: E2E` with the discovered paths as imports), writes it to a temp file, and passes it to the normal runner. Everything after that is identical to running a hand-written root `e2e.yaml`.

--- a/pkg/e2e/docs/07-custom-operator.md
+++ b/pkg/e2e/docs/07-custom-operator.md
@@ -1,0 +1,70 @@
+# Custom Operator Mode
+
+`spec.customOperator: true` declares that this test uses its own operator — not Orkestra's reconcile loop. Bundle generation and Orkestra helm install/uninstall are skipped. Everything else runs unchanged.
+
+## Activation
+
+Declare it in the spec file — the file is the source of truth, there is no CLI flag:
+
+```yaml
+spec:
+  customOperator: true
+  crd: ./crd.yaml
+  cr: ./cr.yaml
+  setup:
+    helm:
+      - repo: https://charts.example.com
+        chart: my-operator
+        namespace: my-operator-system
+        createNamespace: true
+```
+
+## What is skipped
+
+| Step | Normal | `customOperator: true` |
+|------|--------|-----------------------|
+| Bundle generate + apply | ✓ | skipped |
+| OCI import pre-pull | ✓ | skipped |
+| Orkestra helm install | ✓ | skipped |
+| Orkestra helm uninstall | ✓ | skipped |
+| Everything else | ✓ | ✓ |
+
+`spec.katalog` is optional when `customOperator: true`. The spec only needs `spec.cr` at minimum.
+
+## Use cases
+
+### Third-party operator smoke tests
+Install cert-manager, FluxCD, Crossplane via `setup.helm`, apply a CR, assert what it creates:
+
+```yaml
+spec:
+  customOperator: true
+  cr: ./cr-certificate.yaml
+  setup:
+    helm:
+      - repo: https://charts.jetstack.io
+        chart: cert-manager
+        values:
+          installCRDs: true
+    wait:
+      - kind: Deployment
+        name: cert-manager-webhook
+        namespace: cert-manager
+        ready: true
+        timeout: 120s
+```
+
+### Migration parity testing
+Two e2e files, same CRD, same assertions — one via Orkestra katalog, one via `customOperator`. When both pass, the implementations are equivalent:
+
+```
+my-operator/
+├── e2e-orkestra.yaml   # spec.katalog: ./katalog.yaml
+└── e2e-custom.yaml     # spec.customOperator: true + setup.helm: my-old-operator
+```
+
+### Universal test harness
+`customOperator: true` exposes `ork e2e`'s assertion infrastructure — polling loops, count checks, command assertions, cleanup verification — to any operator framework: controller-runtime, Operator SDK, kube-rs, kopf.
+
+## Example
+See [`examples/use-cases/custom-operator/`](../../../examples/use-cases/custom-operator/README.md) for two runnable examples.

--- a/pkg/e2e/runner.go
+++ b/pkg/e2e/runner.go
@@ -65,6 +65,13 @@ type Runner struct {
 	// customOperator skips bundle generation and Orkestra helm install/uninstall.
 	// Set from spec.customOperator — the file is the source of truth.
 	customOperator bool
+
+	// sharedOrkestra means Orkestra is managed by the parent runImports coordinator.
+	// The sub-runner must not delete the bundle from the cluster (the bundle contains
+	// the orkestra-system namespace; deleting it cascades to the Orkestra deployment).
+	// It also suppresses all sync/health-check output — only the coordinator's single
+	// install and uninstall messages are visible.
+	sharedOrkestra bool
 }
 
 // New loads an E2E spec from a YAML file and constructs a Runner.
@@ -290,18 +297,15 @@ func (r *Runner) Run(ctx context.Context) (*Result, error) {
 				installedOrkestra = true
 				fmt.Printf("  ✓ Orkestra installed\n")
 			} else {
-				fmt.Printf("→ Syncing Orkestra runtime with current bundle...\n")
+				// Orkestra already running — sync bundle silently.
 				if err := ork.SyncRuntime(); err != nil {
 					return nil, fmt.Errorf("syncing Orkestra runtime: %w", err)
 				}
-				fmt.Printf("  ✓ Orkestra runtime synced\n")
 				if gatewayEnabled {
 					if ork.GatewayInstalled() {
-						fmt.Printf("→ Syncing Orkestra gateway with current bundle...\n")
 						if err := ork.SyncGateway(); err != nil {
 							return nil, fmt.Errorf("syncing Orkestra gateway: %w", err)
 						}
-						fmt.Printf("  ✓ Orkestra gateway synced\n")
 					} else {
 						fmt.Printf("→ Upgrading Orkestra to enable gateway...\n")
 						if err := ork.InstallOrUpgradeOrkestra(r.orkestraVersion, r.valueFiles, r.helmArgs...); err != nil {
@@ -311,22 +315,33 @@ func (r *Runner) Run(ctx context.Context) (*Result, error) {
 						fmt.Printf("  ✓ Orkestra upgraded with gateway\n")
 					}
 				}
-			}
-
-			fmt.Printf("→ Waiting for Orkestra to be ready...\n")
-			status := ork.CheckRuntimeHealth()
-			if !status.Running {
-				return nil, fmt.Errorf("Orkestra runtime not ready: %s", status.Reason)
-			}
-			fmt.Printf("  ✓ Orkestra runtime ready\n\n")
-
-			if gatewayEnabled {
-				fmt.Printf("→ Waiting for Orkestra gateway to be ready...\n")
-				status := ork.CheckGatewayHealth()
-				if !status.Running {
-					return nil, fmt.Errorf("Orkestra gateway not ready: %s", status.Reason)
+				// Health check — silent, still blocks until ready.
+				if status := ork.CheckRuntimeHealth(); !status.Running {
+					return nil, fmt.Errorf("Orkestra runtime not ready after sync: %s", status.Reason)
 				}
-				fmt.Printf("  ✓ Orkestra gateway ready\n\n")
+				if gatewayEnabled {
+					if status := ork.CheckGatewayHealth(); !status.Running {
+						return nil, fmt.Errorf("Orkestra gateway not ready after sync: %s", status.Reason)
+					}
+				}
+			}
+
+			if installedOrkestra {
+				fmt.Printf("→ Waiting for Orkestra to be ready...\n")
+				status := ork.CheckRuntimeHealth()
+				if !status.Running {
+					return nil, fmt.Errorf("Orkestra runtime not ready: %s", status.Reason)
+				}
+				fmt.Printf("  ✓ Orkestra runtime ready\n\n")
+
+				if gatewayEnabled {
+					fmt.Printf("→ Waiting for Orkestra gateway to be ready...\n")
+					status := ork.CheckGatewayHealth()
+					if !status.Running {
+						return nil, fmt.Errorf("Orkestra gateway not ready: %s", status.Reason)
+					}
+					fmt.Printf("  ✓ Orkestra gateway ready\n\n")
+				}
 			}
 		}
 
@@ -414,7 +429,7 @@ func (r *Runner) Run(ctx context.Context) (*Result, error) {
 	if importCount == 1 {
 		importText = "import"
 	}
-	
+
 	if importCount > 0 {
 		fmt.Printf("\n─── Running %d %s ───\n", importCount, importText)
 		importResults := r.runImports(ctx)
@@ -757,12 +772,17 @@ func (r *Runner) teardown(ctx context.Context, crdPaths []string, bundlePath str
 	}
 
 	// Bundle (RBAC, ConfigMap, Namespace created by ork generate bundle).
+	// sharedOrkestra: skip kubectl delete — the bundle contains orkestra-system namespace;
+	// deleting it cascades to the Orkestra deployment managed by the coordinator.
+	// The temp file is still removed.
 	if bundlePath != "" {
-		fmt.Printf("  → Deleting bundle resources...\n")
-		if out, err := kubectl(ctx, "delete", "-f", bundlePath, "--ignore-not-found"); err != nil {
-			fmt.Printf("  ! bundle delete failed: %v\n%s\n", err, out)
-		} else {
-			fmt.Printf("  ✓ Bundle resources deleted\n")
+		if !r.sharedOrkestra {
+			fmt.Printf("  → Deleting bundle resources...\n")
+			if out, err := kubectl(ctx, "delete", "-f", bundlePath, "--ignore-not-found"); err != nil {
+				fmt.Printf("  ! bundle delete failed: %v\n%s\n", err, out)
+			} else {
+				fmt.Printf("  ✓ Bundle resources deleted\n")
+			}
 		}
 		os.Remove(bundlePath)
 	}
@@ -891,6 +911,9 @@ func (r *Runner) runImports(ctx context.Context) []ImportResult {
 			sub, err = New(absPath, "", false, r.keepCluster, r.devServer, r.orkestraVersion, r.valueFiles)
 		} else {
 			sub, err = New(absPath, "", true, false, r.devServer, r.orkestraVersion, r.valueFiles)
+			if err == nil {
+				sub.sharedOrkestra = true
+			}
 		}
 		// customOperator is declared in the sub-file itself; the parent's value
 		// does not override it — each import is authoritative about its own mode.

--- a/pkg/ork/helper.go
+++ b/pkg/ork/helper.go
@@ -31,22 +31,14 @@ func SyncDeployment(deploymentName, namespace string, timeout time.Duration) err
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	// Restart the deployment
-	restart := exec.CommandContext(ctx, "kubectl", "rollout", "restart",
-		"deploy/"+deploymentName, "-n", namespace)
-	restart.Stdout = os.Stdout
-	restart.Stderr = os.Stderr
-	if err := restart.Run(); err != nil {
-		return fmt.Errorf("restarting deployment %s/%s: %w", namespace, deploymentName, err)
+	if out, err := exec.CommandContext(ctx, "kubectl", "rollout", "restart",
+		"deploy/"+deploymentName, "-n", namespace).CombinedOutput(); err != nil {
+		return fmt.Errorf("restarting deployment %s/%s: %w\n%s", namespace, deploymentName, err, out)
 	}
 
-	// Wait for rollout to complete
-	wait := exec.CommandContext(ctx, "kubectl", "rollout", "status",
-		"deploy/"+deploymentName, "-n", namespace)
-	wait.Stdout = os.Stdout
-	wait.Stderr = os.Stderr
-	if err := wait.Run(); err != nil {
-		return fmt.Errorf("waiting for rollout of %s/%s: %w", namespace, deploymentName, err)
+	if out, err := exec.CommandContext(ctx, "kubectl", "rollout", "status",
+		"deploy/"+deploymentName, "-n", namespace).CombinedOutput(); err != nil {
+		return fmt.Errorf("waiting for rollout of %s/%s: %w\n%s", namespace, deploymentName, err, out)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- **One install, one uninstall per suite** — root cause was bundle deletion cascading to `orkestra-system` namespace, which deleted the Orkestra deployment between imports. Fixed with `sharedOrkestra` on sub-runners: teardown skips `kubectl delete` on the bundle (next sub-runner's `kubectl apply` updates it in place). `SyncDeployment` output suppressed. Sync branch in `Run()` is fully silent. A suite of N imports shows exactly one `→ Installing Orkestra...` and one `→ Uninstalling Orkestra...`.
- **`--dry-run`** — single file: runs `ork validate`; `./...`: lists files with count + first 10 + `... N more`.
- **Positional `./...`** — `ork e2e ./...` now works without `-f`, matching `go test ./...` convention.
- **`pkg/e2e` docs** — all four existing pages rewritten; three new pages: `05-imports.md`, `06-discovery.md`, `07-custom-operator.md`.

## Test plan

- [x] `make ork` compiles clean
- [x] `ork e2e ./examples/beginner/... --dry-run` — lists 4 files, no cluster created
- [x] `ork e2e -f examples/beginner/01-hello-website/e2e.yaml --dry-run` — runs validate output
- [x] Suite run shows single install + single uninstall (no sync messages)
- [x] Full beginner suite 4/4 with `--use-current`
- [x] `ork e2e ./... --skip use-cases/custom-operator,external` on full examples tree