### PR TITLE
fix(init): strip //go:build ignore and restore go.mod on typed example extraction

### DIFF
--- a/cmd/cli/init_helper.go
+++ b/cmd/cli/init_helper.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"fmt"
 	"io"
@@ -60,6 +61,13 @@ func extractEmbeddedPack(root, pack string) error {
 		data, err := examples.FS.ReadFile(path)
 		if err != nil {
 			return err
+		}
+
+		// Strip //go:build ignore added at embed time to keep go vet clean.
+		// The tag is only meaningful inside the parent module; the user's
+		// extracted project has its own go.mod and must compile normally.
+		if filepath.Ext(dst) == ".go" {
+			data = bytes.TrimPrefix(data, []byte("//go:build ignore\n\n"))
 		}
 
 		return os.WriteFile(dst, data, 0644)

--- a/examples/advanced/09-hooks/Makefile
+++ b/examples/advanced/09-hooks/Makefile
@@ -23,6 +23,7 @@ ORK_LDFLAGS := -X github.com/orkspace/orkestra/pkg/version.Version=$(GIT_VERSION
 registry:
 	@[ -f go.mod.txt ] && mv go.mod.txt go.mod || true
 	@[ -f go.sum.txt ] && mv go.sum.txt go.sum || true
+	@find . -name "*.go" | xargs grep -l "^//go:build ignore$$" 2>/dev/null | while read f; do tail -n +3 "$$f" > "$$f.tmp" && mv "$$f.tmp" "$$f"; done || true
 	ork generate registry --file $(KATALOG)
 
 # ── build ─────────────────────────────────────────────────────────────────────
@@ -30,6 +31,7 @@ registry:
 build:
 	@[ -f go.mod.txt ] && mv go.mod.txt go.mod || true
 	@[ -f go.sum.txt ] && mv go.sum.txt go.sum || true
+	@find . -name "*.go" | xargs grep -l "^//go:build ignore$$" 2>/dev/null | while read f; do tail -n +3 "$$f" > "$$f.tmp" && mv "$$f.tmp" "$$f"; done || true
 	@mkdir -p $(OUTPUT_DIR)
 	go mod tidy
 	gofmt -w . && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build \

--- a/examples/advanced/10-constructor/Makefile
+++ b/examples/advanced/10-constructor/Makefile
@@ -23,6 +23,7 @@ ORK_LDFLAGS := -X github.com/orkspace/orkestra/pkg/version.Version=$(GIT_VERSION
 registry:
 	@[ -f go.mod.txt ] && mv go.mod.txt go.mod || true
 	@[ -f go.sum.txt ] && mv go.sum.txt go.sum || true
+	@find . -name "*.go" | xargs grep -l "^//go:build ignore$$" 2>/dev/null | while read f; do tail -n +3 "$$f" > "$$f.tmp" && mv "$$f.tmp" "$$f"; done || true
 	ork generate registry --file $(KATALOG)
 
 # ── build ─────────────────────────────────────────────────────────────────────
@@ -30,6 +31,7 @@ registry:
 build:
 	@[ -f go.mod.txt ] && mv go.mod.txt go.mod || true
 	@[ -f go.sum.txt ] && mv go.sum.txt go.sum || true
+	@find . -name "*.go" | xargs grep -l "^//go:build ignore$$" 2>/dev/null | while read f; do tail -n +3 "$$f" > "$$f.tmp" && mv "$$f.tmp" "$$f"; done || true
 	@mkdir -p $(OUTPUT_DIR)
 	go mod tidy
 	gofmt -w . && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build \

--- a/examples/advanced/11-mixed-operator-pattern/Makefile
+++ b/examples/advanced/11-mixed-operator-pattern/Makefile
@@ -23,6 +23,7 @@ ORK_LDFLAGS := -X github.com/orkspace/orkestra/pkg/version.Version=$(GIT_VERSION
 registry:
 	@[ -f go.mod.txt ] && mv go.mod.txt go.mod || true
 	@[ -f go.sum.txt ] && mv go.sum.txt go.sum || true
+	@find . -name "*.go" | xargs grep -l "^//go:build ignore$$" 2>/dev/null | while read f; do tail -n +3 "$$f" > "$$f.tmp" && mv "$$f.tmp" "$$f"; done || true
 	ork generate registry --file $(KATALOG)
 
 # ── build ─────────────────────────────────────────────────────────────────────
@@ -30,6 +31,7 @@ registry:
 build:
 	@[ -f go.mod.txt ] && mv go.mod.txt go.mod || true
 	@[ -f go.sum.txt ] && mv go.sum.txt go.sum || true
+	@find . -name "*.go" | xargs grep -l "^//go:build ignore$$" 2>/dev/null | while read f; do tail -n +3 "$$f" > "$$f.tmp" && mv "$$f.tmp" "$$f"; done || true
 	@mkdir -p $(OUTPUT_DIR)
 	go mod tidy
 	gofmt -w . && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build \


### PR DESCRIPTION
## Summary

- `cmd/cli/init_helper.go`: `extractEmbeddedPack` now strips `//go:build ignore\n\n` from the top of any `.go` file it writes. The tag is added at embed time to keep `go vet` clean (the parent module can't compile files that import non-existent demo packages); once extracted into the user's own project the tag must be gone so the code compiles normally.
- `examples/advanced/09-hooks/Makefile`, `10-constructor/Makefile`, `11-mixed-operator-pattern/Makefile`: same strip added to `make registry` and `make build` as a safety net for users who clone the repo directly rather than using `ork init`.

## Test plan

- [x] `ork init --pack advanced` — extracted `.go` files in 09-hooks and 10-constructor have no `//go:build ignore` line
- [x] `make registry` inside an extracted typed example strips the tag before running `ork generate registry`
- [x] `go build ./...` succeeds inside an extracted typed example after `make registry`
- [x] `go vet ./...` on the orkestra repo itself still passes (tag still present in source)