### PR TITLE
docs: documentation update — --set flag, typed examples UX, first-motif guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ example-crds/
 ork-amd64
 orkcc-amd64
 orkcc
+ork
 orkestra-demo
 orkestra-action
 ork.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ This release ships the first public early-access build of Orkestra. It focuses o
 
 - **`examples/use-cases/full-stack-app`** — all six sub-katalogs switched from inline `apiTypes:` to `crdFile:`; manual `kubectl apply -f crd.yaml` pre-step eliminated from every walkthrough. `03-cross-crd/crd.yaml` split into `crd-managed-database.yaml` + `crd-database-backed-app.yaml`. `06-full-stack` uses a `setup:` block to pull in the managed-database dependency.
 - **Advanced typed examples** — `09-hooks` (typed Go hooks), `10-constructor` (custom reconciler), and `11-mixed-operator-pattern` (dynamic + hooks + constructor together) fully implemented, documented, and e2e-ready.
-- **Typed e2e documented** — READMEs for typed examples now explain `--helm-arg runtime.image.repository` / `--helm-arg runtime.image.tag` so `ork e2e` deploys the user's custom image (which contains the generated type registry) instead of the default Orkestra image.
+- **Typed e2e documented** — READMEs for typed examples now explain `--set runtime.image.repository` / `--set runtime.image.tag` so `ork e2e` deploys the user's custom image (which contains the generated type registry) instead of the default Orkestra image.
 
 ### Documentation
 

--- a/cmd/cli/e2e.go
+++ b/cmd/cli/e2e.go
@@ -47,7 +47,7 @@ Discovery mode — runs all *e2e.yaml files found recursively (skips pure aggreg
 		clusterCtx, _ := cmd.Flags().GetString("cluster")
 		version, _ := cmd.Flags().GetString("version")
 		valuesFiles, _ := cmd.Flags().GetStringSlice("values")
-		helmArgRaw, _ := cmd.Flags().GetStringSlice("helm-arg")
+		helmArgRaw, _ := cmd.Flags().GetStringSlice("set")
 		var helmArgs []string
 		for _, arg := range helmArgRaw {
 			helmArgs = append(helmArgs, "--set", arg)
@@ -177,7 +177,7 @@ func init() {
 	e2eCmd.Flags().String("cluster", "", "Use an existing kubectl context instead of creating a cluster")
 	e2eCmd.Flags().String("version", "", "Orkestra version to install (e.g., v1.2.3)")
 	e2eCmd.Flags().StringSlice("values", []string{}, "Helm values files to pass to Orkestra installation")
-	e2eCmd.Flags().StringSlice("helm-arg", []string{}, "Additional Helm --set arguments (e.g., key=value)")
+	e2eCmd.Flags().StringSlice("set", []string{}, "Additional Helm --set arguments (e.g., key=value)")
 	e2eCmd.Flags().Bool("dev-server", false, "Deploy the mock dev server into the cluster for external: examples")
 	e2eCmd.Flags().String("wait", "", "Duration to wait between discovered tests (e.g. 2s). Only applies in ./... discovery mode.")
 	e2eCmd.Flags().StringSlice("skip", []string{}, "Comma-separated path patterns to skip during ./... discovery (e.g. vendor,testdata)")

--- a/cmd/cli/run_dev_apply.go
+++ b/cmd/cli/run_dev_apply.go
@@ -46,13 +46,11 @@ func ensureClusterReady(dev bool) error {
 			return fmt.Errorf("installing dependencies: %w", err)
 		}
 
-		if !orkpkg.ClusterReachable() {
-			fmt.Println("\n  Cannot reach Kubernetes cluster.")
-			fmt.Printf("  Creating local Kind cluster '%s'...\n", orkpkg.KindClusterName)
+		fmt.Println("\n  Cannot reach Kubernetes cluster.")
+		fmt.Printf("  Creating local Kind cluster '%s'...\n", orkpkg.KindClusterName)
 
-			if err := orkpkg.EnsureKindCluster(orkpkg.KindClusterName); err != nil {
-				return fmt.Errorf("setting up kind cluster: %w", err)
-			}
+		if err := orkpkg.EnsureKindCluster(orkpkg.KindClusterName); err != nil {
+			return fmt.Errorf("setting up kind cluster: %w", err)
 		}
 
 		return nil

--- a/cmd/controlcenter/cc/assets/static/css/style.css
+++ b/cmd/controlcenter/cc/assets/static/css/style.css
@@ -373,10 +373,9 @@ code, .mono {
   box-shadow: none;
   background: var(--bg-elevated);
 }
-/* Name + badge + pills: fixed left section, does not expand */
+/* Name + badge + stats: expands to fill remaining row space */
 .cc-card-grid.list-view .cc-card-body {
-  flex: none;
-  min-width: 260px;
+  flex: 1;
   display: flex;
   align-items: center;
   gap: 12px;
@@ -393,12 +392,9 @@ code, .mono {
   overflow: hidden;
   text-overflow: ellipsis;
 }
-/* Footer: takes remaining space, lays stats + button in a row */
+/* Footer (View Details button): always visible, pushed right */
 .cc-card-grid.list-view .cc-card-footer {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  gap: 24px;
+  flex-shrink: 0;
   padding: 0;
   border: none;
   background: none;
@@ -434,12 +430,11 @@ code, .mono {
 .cc-card-grid.list-view .cc-card-body > .font-mono {
   display: none;
 }
-/* Button: stays compact, never shrinks */
+/* Button: stays compact */
 .cc-card-grid.list-view .cc-card-footer .cc-btn {
   width: auto;
-  flex-shrink: 0;
   font-size: 12px;
-  padding: 5px 14px;
+  padding: 5px 10px;
 }
 
 /* ── Grid view for resource table (cr_list.html) ───────────── */

--- a/documentation/concepts/e2e/01-how-it-works.md
+++ b/documentation/concepts/e2e/01-how-it-works.md
@@ -96,11 +96,11 @@ For owned kind clusters, the cluster deletion handles all of this in one shot.
 
 `ork e2e` always passes `--set controlCenter.enabled=false` to Helm. The Control Center is not needed in automated tests and adds startup time.
 
-Additional flags are passed with `--helm-arg`:
+Additional flags are passed with `--set`:
 
 ```bash
-# Each --helm-arg becomes --set key=value
-ork e2e --helm-arg "runtime.image.tag=dev" --helm-arg "gateway.replicas=3"
+# Each --set becomes --set key=value
+ork e2e --set "runtime.image.tag=dev" --set "gateway.replicas=3"
 ```
 
 When the Katalog declares a `gateway:` block, `--set gateway.enabled=true` is appended automatically.

--- a/documentation/getting-started/02-writing-your-first-motif.md
+++ b/documentation/getting-started/02-writing-your-first-motif.md
@@ -30,28 +30,37 @@ inputs:
   - name: image
     description: Redis image tag
     default: "redis:7-alpine"
+  
+  - name: replicas
+    description: Number of replicas
+    default: "1"
 
   - name: password
     description: Redis password (leave empty to disable auth)
     default: ""
+  
+  - name: rotateAfter
+    description: How long before the password is rotated
+    default: 30d
 
 resources:
   onCreate:
     secrets:
-      - name: "{{ .metadata.name }}-redis-creds"
+      - name: "{{ .inputs.name }}-redis-creds"
         once: true
+        rotateAfter: "{{ .inputs.rotateAfter }}"
         data:
           password: "{{ .inputs.password }}"
 
   deployments:
-    - name: "{{ .metadata.name }}-redis"
+    - name: "{{ .inputs.name }}-redis"
       image: "{{ .inputs.image }}"
-      replicas: "1"
+      replicas: "{{ .inputs.replicas }}"
       port: "6379"
       reconcile: true
 
   services:
-    - name: "{{ .metadata.name }}-redis"
+    - name: "{{ .inputs.name }}-redis"
       port: "6379"
       targetPort: "6379"
       reconcile: true
@@ -62,7 +71,7 @@ status:
       value: "{{ replicasReady .children.deployment }}"
 ```
 
-The template context is the CR being reconciled — `.metadata.name` is the CR's name, not the Motif's name. The Motif does not know which CRD will import it.
+The template context is the CR being reconciled — `.inputs.name` is the CR's name, not the Motif's name. The Motif does not know which CRD will import it.
 
 ---
 
@@ -102,8 +111,9 @@ spec:
       imports:
         - motif: ./motif.yaml
           with:
-            image: "{{ .spec.redisImage | default \"redis:7-alpine\" }}"
-            password: "{{ .spec.redisPassword }}"
+            image: '{{ .spec.redisImage | default "redis:7-alpine" }}'
+            replicas: "{{ .spec.replicas }}"
+            password: "{{ randomBase64 32 }}"       # Orkestra random note
 
       operatorBox:
         deployments:
@@ -152,7 +162,7 @@ CR spec                              Motif
 Once the Motif works locally, push it:
 
 ```bash
-ork registry push ./motif.yaml --registry oci://ghcr.io/myorg/patterns/redis --tag v0.1.0
+ork registry push ./<motif-dir> --registry oci://ghcr.io/myorg/patterns/redis
 ```
 
 Other Katalogs can then import it by OCI reference:
@@ -172,10 +182,10 @@ imports:
 ```text
 redis/
   motif.yaml          # the Motif
-  example/
+  example/            # (optional)
     katalog.yaml      # example Katalog importing this Motif
-    crd.yaml
-    cr.yaml
+    crd.yaml          # CRD definition
+    cr.yaml           # CR definition
 ```
 
 ---

--- a/documentation/getting-started/index.md
+++ b/documentation/getting-started/index.md
@@ -165,9 +165,9 @@ Ctrl+C
 |---------|-------------|
 | `ork init` | Scaffold a new operator project in the current directory |
 | `ork run -f <path>` | Start the operator runtime. `<path>` is optional if `katalog.yaml` or `komposer.yaml` is in the current directory |
-| `ork run --dev -f` | Start the operator, create kind cluster if needed |
-| `ork validate -f` | Validate a Katalog without starting |
-| `ork template -f` | Preview the merged, resolved Katalog |
+| `ork run --dev` | Start the operator, create kind cluster if needed |
+| `ork validate` | Validate a Katalog without starting |
+| `ork template` | Preview the merged, resolved Katalog |
 | `ork control` | Start the Control Center at localhost:8081 |
 | `ork version` | Print version |
 

--- a/examples/advanced/09-hooks/Makefile
+++ b/examples/advanced/09-hooks/Makefile
@@ -1,6 +1,7 @@
 # ── Typed Orkestra Operator — Hooks ───────────────────────────────────────────
 BINARY_NAME ?= ork
-OUTPUT_DIR  ?= $(HOME)/.orkestra/bin
+DEV_OUTPUT_DIR  ?= $(HOME)/.orkestra/bin
+PROD_OUTPUT_DIR ?= $(HOME)/.orkestra/bin/runtime
 KATALOG     ?= katalog.yaml
 
 IMAGE_REPO  ?= myorg/my-operator
@@ -26,33 +27,65 @@ registry:
 	@find . -name "*.go" | xargs grep -l "^//go:build ignore$$" 2>/dev/null | while read f; do tail -n +3 "$$f" > "$$f.tmp" && mv "$$f.tmp" "$$f"; done || true
 	ork generate registry --file $(KATALOG)
 
-# ── build ─────────────────────────────────────────────────────────────────────
+# ── build (development) ───────────────────────────────────────────────────────
+# Builds the full CLI with all commands (validate, e2e, simulate, run, etc.)
 .PHONY: build
 build:
 	@[ -f go.mod.txt ] && mv go.mod.txt go.mod || true
 	@[ -f go.sum.txt ] && mv go.sum.txt go.sum || true
 	@find . -name "*.go" | xargs grep -l "^//go:build ignore$$" 2>/dev/null | while read f; do tail -n +3 "$$f" > "$$f.tmp" && mv "$$f.tmp" "$$f"; done || true
-	@mkdir -p $(OUTPUT_DIR)
+	@mkdir -p $(DEV_OUTPUT_DIR)
 	go mod tidy
-	gofmt -w . && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build \
-		-tags "$(BUILD_TAGS)" \
+	gofmt -w .
+	go build \
 		-ldflags "$(ORK_LDFLAGS)" \
-		-o $(OUTPUT_DIR)/$(BINARY_NAME) ./cmd/orkestra
-	@echo "✅ $(OUTPUT_DIR)/$(BINARY_NAME)"
+		-o $(DEV_OUTPUT_DIR)/$(BINARY_NAME) ./cmd/orkestra
+	@echo "✅ Development build: $(DEV_OUTPUT_DIR)/$(BINARY_NAME)"
+
+# ── build-runtime (production) ────────────────────────────────────────────────
+# Builds a production binary with ONLY the `run` command (no validate, e2e, etc.)
+# This is what runs in your cluster — smaller attack surface, focused responsibility.
+.PHONY: build-runtime
+build-runtime:
+	@[ -f go.mod.txt ] && mv go.mod.txt go.mod || true
+	@[ -f go.sum.txt ] && mv go.sum.txt go.sum || true
+	@find . -name "*.go" | xargs grep -l "^//go:build ignore$$" 2>/dev/null | while read f; do tail -n +3 "$$f" > "$$f.tmp" && mv "$$f.tmp" "$$f"; done || true
+	@mkdir -p $(PROD_OUTPUT_DIR)
+	go mod tidy
+	gofmt -w .
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build \
+		-tags "runtime" \
+		-ldflags "$(ORK_LDFLAGS)" \
+		-o $(PROD_OUTPUT_DIR)/$(BINARY_NAME) ./cmd/orkestra
+	@echo "✅ Production runtime build: $(PROD_OUTPUT_DIR)/$(BINARY_NAME)"
+	@echo "   This binary only supports 'ork run' — perfect for production."
 
 # ── validate ──────────────────────────────────────────────────────────────────
 .PHONY: validate
 validate:
-	$(OUTPUT_DIR)/$(BINARY_NAME) validate -f $(KATALOG)
+	$(DEV_OUTPUT_DIR)/$(BINARY_NAME) validate -f $(KATALOG)
+
+# ── e2e ───────────────────────────────────────────────────────────────────────
+.PHONY: e2e
+e2e:
+	$(DEV_OUTPUT_DIR)/$(BINARY_NAME) e2e
 
 # ── docker / push / release ───────────────────────────────────────────────────
+# Builds the production runtime binary, copies it to the current directory for
+# Docker build, then restores the development binary (if it exists) or leaves
+# a clean state. This round‑trip is required because the Docker image should
+# contain ONLY the production binary (runtime tag), not the full CLI.
 .PHONY: docker
-docker:
-	$(MAKE) build BUILD_TAGS=runtime
-	@cp $(OUTPUT_DIR)/$(BINARY_NAME) ./$(BINARY_NAME)
+docker: build-runtime
+	@echo "📦 Preparing production binary for Docker image..."
+	@cp $(PROD_OUTPUT_DIR)/$(BINARY_NAME) ./$(BINARY_NAME)
 	docker build -t $(IMAGE) .
 	@rm -f ./$(BINARY_NAME)
-	@echo "✅ $(IMAGE)"
+	@if [ -f $(DEV_OUTPUT_DIR)/$(BINARY_NAME) ]; then \
+		cp $(DEV_OUTPUT_DIR)/$(BINARY_NAME) ./$(BINARY_NAME); \
+		echo "🔧 Restored development binary to ./$(BINARY_NAME)"; \
+	fi
+	@echo "✅ Docker image built: $(IMAGE)"
 
 .PHONY: push
 push:
@@ -62,17 +95,21 @@ push:
 release: docker push
 
 # ── clean ─────────────────────────────────────────────────────────────────────
-# Removes the local typed binary only. The standard ork CLI is unaffected.
 .PHONY: clean
 clean:
-	@rm -f $(OUTPUT_DIR)/$(BINARY_NAME)
-	@echo "✅ removed $(OUTPUT_DIR)/$(BINARY_NAME)"
+	@rm -f $(DEV_OUTPUT_DIR)/$(BINARY_NAME)
+	@rm -rf $(PROD_OUTPUT_DIR)
+	@echo "✅ Removed all local builds"
 
 # ── help ──────────────────────────────────────────────────────────────────────
 .PHONY: help
 help:
-	@echo "  registry   generate pkg/typeregistry/zz_generated_typeregistry.go"
-	@echo "  build      compile the typed operator binary"
-	@echo "  validate   run katalog validation with your binary"
-	@echo "  release    build + push  IMAGE=repo/name:tag"
-	@echo "  clean      remove local binary (standard ork unaffected)"
+	@echo "  registry       generate type registry from Katalog"
+	@echo "  build          compile full development CLI (all commands)"
+	@echo "  build-runtime  compile production binary (only 'ork run')"
+	@echo "  validate       run katalog validation (using development binary)"
+	@echo "  e2e            run end‑to‑end tests (using development binary)"
+	@echo "  docker         build-runtime + copy into Docker image"
+	@echo "  push           push Docker image to registry"
+	@echo "  release        docker + push"
+	@echo "  clean          remove all local builds"

--- a/examples/advanced/09-hooks/README.md
+++ b/examples/advanced/09-hooks/README.md
@@ -242,17 +242,35 @@ Typed operators require your own published image — `ork e2e` installs Orkestra
 make docker push IMAGE_REPO=yourregistry/database-operator IMAGE_TAG=latest
 ```
 
+
+**Important notes: (build-time security)**
+
+- `make docker` builds a production‑only binary (tags `runtime`) – it cannot run developer commands like `validate` or `e2e`
+- The binary is copied from `~/.orkestra/bin/runtime/ork` into the current directory for `docker build`, then removed
+- Your local `./ork` (development CLI) is restored after the build – it remains unchanged and fully featured
+- This round‑trip ensures your container image contains only the secure runtime, while your local environment keeps all developer tools
+
+#### Try running a developer command
+It will fail (as intended), only `ork run` succeeds.
+
+```bash
+~/.orkestra/bin/runtime/ork validate
+# unknown command "validate" for "ork"
+```
+
+---
+
 **Step 2 — run e2e with your image:**
 
 ```bash
 ork e2e \
-  --helm-arg runtime.image.repository=yourregistry/database-operator \
-  --helm-arg runtime.image.tag=latest
+  --set runtime.image.repository=yourregistry/database-operator \
+  --set runtime.image.tag=latest
 ```
 
-The `--helm-arg` flags are forwarded as `--set` values to the Helm install (`runtime.image.repository` / `runtime.image.tag` in `charts/orkestra/values.yaml`), so the cluster runs your image instead of the default Orkestra image.
+The `--set` flags are are used by `ork e2e`, so the cluster runs your image instead of the default Orkestra image.
 
-This spins up a kind cluster, deploys your operator, applies the CR, asserts your Go hooks fired and the expected resources exist, then tears down.
+This spins up a kind cluster, deploys your custom Orkestra runtime, applies the CR, asserts your Go hooks fired and the expected resources exist, then tears down.
 
 This runs everything defined in [e2e.yaml](./e2e.yaml):
 

--- a/examples/advanced/09-hooks/e2e.yaml
+++ b/examples/advanced/09-hooks/e2e.yaml
@@ -15,18 +15,25 @@ spec:
     reuse: false
 
   expect:
-    - name: Database deployment created
+    - name: Database statefulSet and Cronjob created
       after: cr-applied
       timeout: 90s
       resources:
-        - kind: Deployment
+        - kind: StatefulSet
           namespace: default
           ready: true
+        - kind: Cronjob
+          name: my-db-backup
+          namespace: default
 
-    - name: Deployment removed on delete
+    - name: Deployment and Cronjob removed on delete
       after: cr-deleted
       timeout: 30s
       resources:
-        - kind: Deployment
+        - kind: StatefulSet
           namespace: default
+          count: 0
+        - kind: Cronjob
+          namespace: default
+          name: my-db-backup
           count: 0

--- a/examples/advanced/09-hooks/go.mod.txt
+++ b/examples/advanced/09-hooks/go.mod.txt
@@ -3,7 +3,7 @@ module github.com/orkspace/orkestra-hooks-demo
 go 1.26.3
 
 require (
-	github.com/orkspace/orkestra v0.7.1
+	github.com/orkspace/orkestra v0.7.2
 	k8s.io/apimachinery v0.36.1
 )
 

--- a/examples/advanced/10-constructor/Makefile
+++ b/examples/advanced/10-constructor/Makefile
@@ -1,6 +1,7 @@
 # ── Typed Orkestra Operator — Hooks ───────────────────────────────────────────
 BINARY_NAME ?= ork
-OUTPUT_DIR  ?= $(HOME)/.orkestra/bin
+DEV_OUTPUT_DIR  ?= $(HOME)/.orkestra/bin
+PROD_OUTPUT_DIR ?= $(HOME)/.orkestra/bin/runtime
 KATALOG     ?= katalog.yaml
 
 IMAGE_REPO  ?= myorg/my-operator
@@ -26,33 +27,65 @@ registry:
 	@find . -name "*.go" | xargs grep -l "^//go:build ignore$$" 2>/dev/null | while read f; do tail -n +3 "$$f" > "$$f.tmp" && mv "$$f.tmp" "$$f"; done || true
 	ork generate registry --file $(KATALOG)
 
-# ── build ─────────────────────────────────────────────────────────────────────
+# ── build (development) ───────────────────────────────────────────────────────
+# Builds the full CLI with all commands (validate, e2e, simulate, run, etc.)
 .PHONY: build
 build:
 	@[ -f go.mod.txt ] && mv go.mod.txt go.mod || true
 	@[ -f go.sum.txt ] && mv go.sum.txt go.sum || true
 	@find . -name "*.go" | xargs grep -l "^//go:build ignore$$" 2>/dev/null | while read f; do tail -n +3 "$$f" > "$$f.tmp" && mv "$$f.tmp" "$$f"; done || true
-	@mkdir -p $(OUTPUT_DIR)
+	@mkdir -p $(DEV_OUTPUT_DIR)
 	go mod tidy
-	gofmt -w . && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build \
-		-tags "$(BUILD_TAGS)" \
+	gofmt -w .
+	go build \
 		-ldflags "$(ORK_LDFLAGS)" \
-		-o $(OUTPUT_DIR)/$(BINARY_NAME) ./cmd/orkestra
-	@echo "✅ $(OUTPUT_DIR)/$(BINARY_NAME)"
+		-o $(DEV_OUTPUT_DIR)/$(BINARY_NAME) ./cmd/orkestra
+	@echo "✅ Development build: $(DEV_OUTPUT_DIR)/$(BINARY_NAME)"
+
+# ── build-runtime (production) ────────────────────────────────────────────────
+# Builds a production binary with ONLY the `run` command (no validate, e2e, etc.)
+# This is what runs in your cluster — smaller attack surface, focused responsibility.
+.PHONY: build-runtime
+build-runtime:
+	@[ -f go.mod.txt ] && mv go.mod.txt go.mod || true
+	@[ -f go.sum.txt ] && mv go.sum.txt go.sum || true
+	@find . -name "*.go" | xargs grep -l "^//go:build ignore$$" 2>/dev/null | while read f; do tail -n +3 "$$f" > "$$f.tmp" && mv "$$f.tmp" "$$f"; done || true
+	@mkdir -p $(PROD_OUTPUT_DIR)
+	go mod tidy
+	gofmt -w .
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build \
+		-tags "runtime" \
+		-ldflags "$(ORK_LDFLAGS)" \
+		-o $(PROD_OUTPUT_DIR)/$(BINARY_NAME) ./cmd/orkestra
+	@echo "✅ Production runtime build: $(PROD_OUTPUT_DIR)/$(BINARY_NAME)"
+	@echo "   This binary only supports 'ork run' — perfect for production."
 
 # ── validate ──────────────────────────────────────────────────────────────────
 .PHONY: validate
 validate:
-	$(OUTPUT_DIR)/$(BINARY_NAME) validate -f $(KATALOG)
+	$(DEV_OUTPUT_DIR)/$(BINARY_NAME) validate -f $(KATALOG)
+
+# ── e2e ───────────────────────────────────────────────────────────────────────
+.PHONY: e2e
+e2e:
+	$(DEV_OUTPUT_DIR)/$(BINARY_NAME) e2e
 
 # ── docker / push / release ───────────────────────────────────────────────────
+# Builds the production runtime binary, copies it to the current directory for
+# Docker build, then restores the development binary (if it exists) or leaves
+# a clean state. This round‑trip is required because the Docker image should
+# contain ONLY the production binary (runtime tag), not the full CLI.
 .PHONY: docker
-docker:
-	$(MAKE) build BUILD_TAGS=runtime
-	@cp $(OUTPUT_DIR)/$(BINARY_NAME) ./$(BINARY_NAME)
+docker: build-runtime
+	@echo "📦 Preparing production binary for Docker image..."
+	@cp $(PROD_OUTPUT_DIR)/$(BINARY_NAME) ./$(BINARY_NAME)
 	docker build -t $(IMAGE) .
 	@rm -f ./$(BINARY_NAME)
-	@echo "✅ $(IMAGE)"
+	@if [ -f $(DEV_OUTPUT_DIR)/$(BINARY_NAME) ]; then \
+		cp $(DEV_OUTPUT_DIR)/$(BINARY_NAME) ./$(BINARY_NAME); \
+		echo "🔧 Restored development binary to ./$(BINARY_NAME)"; \
+	fi
+	@echo "✅ Docker image built: $(IMAGE)"
 
 .PHONY: push
 push:
@@ -62,17 +95,21 @@ push:
 release: docker push
 
 # ── clean ─────────────────────────────────────────────────────────────────────
-# Removes the local typed binary only. The standard ork CLI is unaffected.
 .PHONY: clean
 clean:
-	@rm -f $(OUTPUT_DIR)/$(BINARY_NAME)
-	@echo "✅ removed $(OUTPUT_DIR)/$(BINARY_NAME)"
+	@rm -f $(DEV_OUTPUT_DIR)/$(BINARY_NAME)
+	@rm -rf $(PROD_OUTPUT_DIR)
+	@echo "✅ Removed all local builds"
 
 # ── help ──────────────────────────────────────────────────────────────────────
 .PHONY: help
 help:
-	@echo "  registry   generate pkg/typeregistry/zz_generated_typeregistry.go"
-	@echo "  build      compile the typed operator binary"
-	@echo "  validate   run katalog validation with your binary"
-	@echo "  release    build + push  IMAGE=repo/name:tag"
-	@echo "  clean      remove local binary (standard ork unaffected)"
+	@echo "  registry       generate type registry from Katalog"
+	@echo "  build          compile full development CLI (all commands)"
+	@echo "  build-runtime  compile production binary (only 'ork run')"
+	@echo "  validate       run katalog validation (using development binary)"
+	@echo "  e2e            run end‑to‑end tests (using development binary)"
+	@echo "  docker         build-runtime + copy into Docker image"
+	@echo "  push           push Docker image to registry"
+	@echo "  release        docker + push"
+	@echo "  clean          remove all local builds"

--- a/examples/advanced/10-constructor/README.md
+++ b/examples/advanced/10-constructor/README.md
@@ -122,7 +122,7 @@ First, see the expected error with the standard `ork` CLI:
 
 ```bash
 ork validate
-# error: no reconciler constructor registered for Kind=Pipeline
+# CRD "pipeline": no constructor registered — check reconciler.constructor in Katalog and re-run ork generate registry
 ```
 
 Now build your own binary:
@@ -198,17 +198,35 @@ Typed operators require your own published image — `ork e2e` installs Orkestra
 make docker push IMAGE_REPO=yourregistry/pipeline-operator IMAGE_TAG=latest
 ```
 
+
+**Important notes: (build-time security)**
+
+- `make docker` builds a production‑only binary (tags `runtime`) – it cannot run developer commands like `validate` or `e2e`
+- The binary is copied from `~/.orkestra/bin/runtime/ork` into the current directory for `docker build`, then removed
+- Your local `./ork` (development CLI) is restored after the build – it remains unchanged and fully featured
+- This round‑trip ensures your container image contains only the secure runtime, while your local environment keeps all developer tools
+
+#### Try running a developer command
+It will fail (as intended), only `ork run` succeeds.
+
+```bash
+~/.orkestra/bin/runtime/ork validate
+# unknown command "validate" for "ork"
+```
+
+---
+
 **Step 2 — run e2e with your image:**
 
 ```bash
 ork e2e \
-  --helm-arg runtime.image.repository=yourregistry/pipeline-operator \
-  --helm-arg runtime.image.tag=latest
+  --set runtime.image.repository=yourregistry/pipeline-operator \
+  --set runtime.image.tag=latest
 ```
 
-The `--helm-arg` flags are forwarded as `--set` values to the Helm install (`runtime.image.repository` / `runtime.image.tag` in `charts/orkestra/values.yaml`), so the cluster runs your image instead of the default Orkestra image.
+The `--set` flags are are used by `ork e2e`, so the cluster runs your image instead of the default Orkestra image.
 
-This spins up a kind cluster, deploys your operator, applies the CR, asserts the state machine ran to completion, then tears down.
+This spins up a kind cluster, deploys your custom Orkestra runtime, applies the CR, asserts the state machine ran to completion, then tears down.
 
 This runs everything defined in [e2e.yaml](./e2e.yaml):
 

--- a/examples/advanced/10-constructor/e2e.yaml
+++ b/examples/advanced/10-constructor/e2e.yaml
@@ -15,18 +15,33 @@ spec:
     reuse: false
 
   expect:
-    - name: Pipeline deployment created
+    - name: Pipeline jobs created
       after: cr-applied
       timeout: 90s
       resources:
-        - kind: Deployment
+        - kind: Job
           namespace: default
-          ready: true
+          name: build-and-test-build
+        - kind: Job
+          namespace: default
+          name: build-and-test-notify
+        - kind: Job
+          namespace: default
+          name: build-and-test-test
 
-    - name: Deployment removed on delete
+    - name: Jobs removed on delete
       after: cr-deleted
       timeout: 30s
       resources:
-        - kind: Deployment
+        - kind: Job
           namespace: default
+          name: build-and-test-build
+          count: 0
+        - kind: Job
+          namespace: default
+          name: build-and-test-notify
+          count: 0
+        - kind: Job
+          namespace: default
+          name: build-and-test-test
           count: 0

--- a/examples/advanced/10-constructor/go.mod.txt
+++ b/examples/advanced/10-constructor/go.mod.txt
@@ -3,7 +3,7 @@ module github.com/orkspace/orkestra-constructor-demo
 go 1.26.3
 
 require (
-	github.com/orkspace/orkestra v0.7.1
+	github.com/orkspace/orkestra v0.7.2
 	k8s.io/api v0.36.1
 	k8s.io/apimachinery v0.36.1
 	k8s.io/client-go v0.36.1

--- a/examples/advanced/11-mixed-operator-pattern/01-hello-website/e2e.yaml
+++ b/examples/advanced/11-mixed-operator-pattern/01-hello-website/e2e.yaml
@@ -1,0 +1,51 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: hello-website-e2e
+  description: Deploy a single nginx website and verify the deployment and service comes up and are cleaned up on delete
+
+spec:
+  katalog: ./katalog.yaml
+  crd: ./crd.yaml
+  cr: ./cr.yaml
+
+  cluster:
+    provider: kind
+    name: ork-e2e
+    reuse: false
+
+  expect:
+    - name: CR created
+      after: cr-applied
+      timeout: 60s
+      resources:
+        - kind: Website
+          name: hello-website
+          namespace: default
+
+    - name: Deployment created
+      after: cr-applied
+      timeout: 60s
+      resources:
+        - kind: Deployment
+          namespace: default
+          ready: true
+        - kind: Service
+          namespace: default
+
+    - name: Cleanup verified
+      after: cr-deleted
+      timeout: 30s
+      resources:
+        - kind: Deployment
+          name: hello-website
+          namespace: default
+          count: 0
+        - kind: Service
+          name: hello-website-svc
+          namespace: default
+          count: 0
+        - kind: Website
+          name: hello-website
+          namespace: default
+          count: 0

--- a/examples/advanced/11-mixed-operator-pattern/09-hooks/e2e.yaml
+++ b/examples/advanced/11-mixed-operator-pattern/09-hooks/e2e.yaml
@@ -1,0 +1,39 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: hooks-e2e
+  description: Exercise typed Go hooks — verify pre/post reconcile hooks fire and the operator deployment comes up
+
+spec:
+  katalog: ./katalog.yaml
+  crd: ./crd.yaml
+  cr: ./cr.yaml
+
+  cluster:
+    provider: kind
+    name: ork-e2e
+    reuse: false
+
+  expect:
+    - name: Database statefulSet and Cronjob created
+      after: cr-applied
+      timeout: 90s
+      resources:
+        - kind: StatefulSet
+          namespace: default
+          ready: true
+        - kind: Cronjob
+          name: my-db-backup
+          namespace: default
+
+    - name: Deployment and Cronjob removed on delete
+      after: cr-deleted
+      timeout: 30s
+      resources:
+        - kind: StatefulSet
+          namespace: default
+          count: 0
+        - kind: Cronjob
+          namespace: default
+          name: my-db-backup
+          count: 0

--- a/examples/advanced/11-mixed-operator-pattern/09-hooks/hooks/database_hooks.go
+++ b/examples/advanced/11-mixed-operator-pattern/09-hooks/hooks/database_hooks.go
@@ -1,4 +1,5 @@
 //go:build ignore
+
 // hooks/database_hooks.go
 //
 // Typed Go hooks for the Database CRD.
@@ -16,6 +17,7 @@
 //   - Type-safe struct access (obj.Spec.Engine, not unstructured map navigation)
 //   - The business logic that cannot be expressed in templates
 //   - OrkestraRegistry calls for Kubernetes child resources
+//
 package hooks
 
 import (

--- a/examples/advanced/11-mixed-operator-pattern/10-constructor/e2e.yaml
+++ b/examples/advanced/11-mixed-operator-pattern/10-constructor/e2e.yaml
@@ -1,0 +1,47 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: constructor-e2e
+  description: Verify the constructor pattern — operator builds pipeline jobs from a typed Go constructor and they run to completion
+
+spec:
+  katalog: ./katalog.yaml
+  crd: ./crd.yaml
+  cr: ./cr.yaml
+
+  cluster:
+    provider: kind
+    name: ork-e2e
+    reuse: false
+
+  expect:
+    - name: Pipeline jobs created
+      after: cr-applied
+      timeout: 90s
+      resources:
+        - kind: Job
+          namespace: default
+          name: build-and-test-build
+        - kind: Job
+          namespace: default
+          name: build-and-test-notify
+        - kind: Job
+          namespace: default
+          name: build-and-test-test
+
+    - name: Jobs removed on delete
+      after: cr-deleted
+      timeout: 30s
+      resources:
+        - kind: Job
+          namespace: default
+          name: build-and-test-build
+          count: 0
+        - kind: Job
+          namespace: default
+          name: build-and-test-notify
+          count: 0
+        - kind: Job
+          namespace: default
+          name: build-and-test-test
+          count: 0

--- a/examples/advanced/11-mixed-operator-pattern/10-constructor/reconciler/pipeline_reconciler.go
+++ b/examples/advanced/11-mixed-operator-pattern/10-constructor/reconciler/pipeline_reconciler.go
@@ -1,4 +1,5 @@
 //go:build ignore
+
 // reconciler/pipeline_reconciler.go
 //
 // A custom reconciler for the Pipeline CRD. This implements domain.Reconciler
@@ -23,6 +24,7 @@
 //   - Kubernetes events
 //   - Status updates
 //   - All reconcile and delete logic
+//
 package reconciler
 
 import (

--- a/examples/advanced/11-mixed-operator-pattern/Makefile
+++ b/examples/advanced/11-mixed-operator-pattern/Makefile
@@ -1,6 +1,7 @@
 # ── Typed Orkestra Operator — Hooks ───────────────────────────────────────────
 BINARY_NAME ?= ork
-OUTPUT_DIR  ?= $(HOME)/.orkestra/bin
+DEV_OUTPUT_DIR  ?= $(HOME)/.orkestra/bin
+PROD_OUTPUT_DIR ?= $(HOME)/.orkestra/bin/runtime
 KATALOG     ?= komposer.yaml
 
 IMAGE_REPO  ?= myorg/my-operator
@@ -26,33 +27,65 @@ registry:
 	@find . -name "*.go" | xargs grep -l "^//go:build ignore$$" 2>/dev/null | while read f; do tail -n +3 "$$f" > "$$f.tmp" && mv "$$f.tmp" "$$f"; done || true
 	ork generate registry --file $(KATALOG)
 
-# ── build ─────────────────────────────────────────────────────────────────────
+# ── build (development) ───────────────────────────────────────────────────────
+# Builds the full CLI with all commands (validate, e2e, simulate, run, etc.)
 .PHONY: build
 build:
 	@[ -f go.mod.txt ] && mv go.mod.txt go.mod || true
 	@[ -f go.sum.txt ] && mv go.sum.txt go.sum || true
 	@find . -name "*.go" | xargs grep -l "^//go:build ignore$$" 2>/dev/null | while read f; do tail -n +3 "$$f" > "$$f.tmp" && mv "$$f.tmp" "$$f"; done || true
-	@mkdir -p $(OUTPUT_DIR)
+	@mkdir -p $(DEV_OUTPUT_DIR)
 	go mod tidy
-	gofmt -w . && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build \
-		-tags "$(BUILD_TAGS)" \
+	gofmt -w .
+	go build \
 		-ldflags "$(ORK_LDFLAGS)" \
-		-o $(OUTPUT_DIR)/$(BINARY_NAME) ./cmd/orkestra
-	@echo "✅ $(OUTPUT_DIR)/$(BINARY_NAME)"
+		-o $(DEV_OUTPUT_DIR)/$(BINARY_NAME) ./cmd/orkestra
+	@echo "✅ Development build: $(DEV_OUTPUT_DIR)/$(BINARY_NAME)"
+
+# ── build-runtime (production) ────────────────────────────────────────────────
+# Builds a production binary with ONLY the `run` command (no validate, e2e, etc.)
+# This is what runs in your cluster — smaller attack surface, focused responsibility.
+.PHONY: build-runtime
+build-runtime:
+	@[ -f go.mod.txt ] && mv go.mod.txt go.mod || true
+	@[ -f go.sum.txt ] && mv go.sum.txt go.sum || true
+	@find . -name "*.go" | xargs grep -l "^//go:build ignore$$" 2>/dev/null | while read f; do tail -n +3 "$$f" > "$$f.tmp" && mv "$$f.tmp" "$$f"; done || true
+	@mkdir -p $(PROD_OUTPUT_DIR)
+	go mod tidy
+	gofmt -w .
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build \
+		-tags "runtime" \
+		-ldflags "$(ORK_LDFLAGS)" \
+		-o $(PROD_OUTPUT_DIR)/$(BINARY_NAME) ./cmd/orkestra
+	@echo "✅ Production runtime build: $(PROD_OUTPUT_DIR)/$(BINARY_NAME)"
+	@echo "   This binary only supports 'ork run' — perfect for production."
 
 # ── validate ──────────────────────────────────────────────────────────────────
 .PHONY: validate
 validate:
-	$(OUTPUT_DIR)/$(BINARY_NAME) validate -f $(KATALOG)
+	$(DEV_OUTPUT_DIR)/$(BINARY_NAME) validate -f $(KATALOG)
+
+# ── e2e ───────────────────────────────────────────────────────────────────────
+.PHONY: e2e
+e2e:
+	$(DEV_OUTPUT_DIR)/$(BINARY_NAME) e2e
 
 # ── docker / push / release ───────────────────────────────────────────────────
+# Builds the production runtime binary, copies it to the current directory for
+# Docker build, then restores the development binary (if it exists) or leaves
+# a clean state. This round‑trip is required because the Docker image should
+# contain ONLY the production binary (runtime tag), not the full CLI.
 .PHONY: docker
-docker:
-	$(MAKE) build BUILD_TAGS=runtime
-	@cp $(OUTPUT_DIR)/$(BINARY_NAME) ./$(BINARY_NAME)
+docker: build-runtime
+	@echo "📦 Preparing production binary for Docker image..."
+	@cp $(PROD_OUTPUT_DIR)/$(BINARY_NAME) ./$(BINARY_NAME)
 	docker build -t $(IMAGE) .
 	@rm -f ./$(BINARY_NAME)
-	@echo "✅ $(IMAGE)"
+	@if [ -f $(DEV_OUTPUT_DIR)/$(BINARY_NAME) ]; then \
+		cp $(DEV_OUTPUT_DIR)/$(BINARY_NAME) ./$(BINARY_NAME); \
+		echo "🔧 Restored development binary to ./$(BINARY_NAME)"; \
+	fi
+	@echo "✅ Docker image built: $(IMAGE)"
 
 .PHONY: push
 push:
@@ -62,17 +95,21 @@ push:
 release: docker push
 
 # ── clean ─────────────────────────────────────────────────────────────────────
-# Removes the local typed binary only. The standard ork CLI is unaffected.
 .PHONY: clean
 clean:
-	@rm -f $(OUTPUT_DIR)/$(BINARY_NAME)
-	@echo "✅ removed $(OUTPUT_DIR)/$(BINARY_NAME)"
+	@rm -f $(DEV_OUTPUT_DIR)/$(BINARY_NAME)
+	@rm -rf $(PROD_OUTPUT_DIR)
+	@echo "✅ Removed all local builds"
 
 # ── help ──────────────────────────────────────────────────────────────────────
 .PHONY: help
 help:
-	@echo "  registry   generate pkg/typeregistry/zz_generated_typeregistry.go"
-	@echo "  build      compile the typed operator binary"
-	@echo "  validate   run katalog validation with your binary"
-	@echo "  release    build + push  IMAGE=repo/name:tag"
-	@echo "  clean      remove local binary (standard ork unaffected)"
+	@echo "  registry       generate type registry from Katalog"
+	@echo "  build          compile full development CLI (all commands)"
+	@echo "  build-runtime  compile production binary (only 'ork run')"
+	@echo "  validate       run katalog validation (using development binary)"
+	@echo "  e2e            run end-to-end tests (using development binary)"
+	@echo "  docker         build-runtime + copy into Docker image"
+	@echo "  push           push Docker image to registry"
+	@echo "  release        docker + push"
+	@echo "  clean          remove all local builds"

--- a/examples/advanced/11-mixed-operator-pattern/README.md
+++ b/examples/advanced/11-mixed-operator-pattern/README.md
@@ -353,7 +353,8 @@ imports:
   files:
   - ./01-hello-website/e2e.yaml
   - ./09-hooks/e2e.yaml
-  - ./10-constructor/e2e.yaml
+  - path: 10-constructor/e2e.yaml
+    wait: 30s     # let the cluster settle after hooks teardown before constructor starts
 ```
 
 ---

--- a/examples/advanced/11-mixed-operator-pattern/README.md
+++ b/examples/advanced/11-mixed-operator-pattern/README.md
@@ -317,15 +317,44 @@ This example contains typed operators (hooks + constructor) so e2e requires your
 make docker push IMAGE_REPO=yourregistry/mixed-operator IMAGE_TAG=latest
 ```
 
+**Important notes: (build-time security)**
+
+- `make docker` builds a production‑only binary (tags `runtime`) – it cannot run developer commands like `validate` or `e2e`
+- The binary is copied from `~/.orkestra/bin/runtime/ork` into the current directory for `docker build`, then removed
+- Your local `./ork` (development CLI) is restored after the build – it remains unchanged and fully featured
+- This round‑trip ensures your container image contains only the secure runtime, while your local environment keeps all developer tools
+
+#### Try running a developer command
+It will fail (as intended), only `ork run` succeeds.
+
+```bash
+~/.orkestra/bin/runtime/ork validate
+# unknown command "validate" for "ork"
+```
+
+---
+
 **Step 2 — run e2e with your image:**
 
 ```bash
 ork e2e \
-  --helm-arg runtime.image.repository=yourregistry/mixed-operator \
-  --helm-arg runtime.image.tag=latest
+  --set runtime.image.repository=yourregistry/mixed-operator \
+  --set runtime.image.tag=latest
 ```
 
-The `--helm-arg` flags become `--set` values on the Helm install so the cluster runs your image (with the type registry for all three CRDs) instead of the default Orkestra image.
+The `--set` flags are are used by `ork e2e`, so the cluster runs your image instead of the default Orkestra image.
+
+This spins up a kind cluster, deploys your custom Orkestra runtime, runs the e2e tests for each operator, then tears down.
+
+This runs everything defined in [e2e.yaml](./e2e.yaml):
+
+```yaml
+imports:
+  files:
+  - ./01-hello-website/e2e.yaml
+  - ./09-hooks/e2e.yaml
+  - ./10-constructor/e2e.yaml
+```
 
 ---
 

--- a/examples/advanced/11-mixed-operator-pattern/e2e.yaml
+++ b/examples/advanced/11-mixed-operator-pattern/e2e.yaml
@@ -1,0 +1,13 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: mixed-operator-pattern-suite
+  description: >
+    Suite for the mixed operator pattern — Declarative, Go hooks, and Go
+    constructor. Runs all three examples in the same cluster.
+
+imports:
+  - ./01-hello-website/e2e.yaml
+  - ./09-hooks/e2e.yaml
+  - path: 10-constructor/e2e.yaml
+    wait: 30s

--- a/examples/advanced/11-mixed-operator-pattern/go.mod.txt
+++ b/examples/advanced/11-mixed-operator-pattern/go.mod.txt
@@ -3,7 +3,7 @@ module github.com/orkspace/orkestra-mixed-operator-pattern
 go 1.26.3
 
 require (
-	github.com/orkspace/orkestra v0.7.1
+	github.com/orkspace/orkestra v0.7.2
 	k8s.io/api v0.36.1
 	k8s.io/apimachinery v0.36.1
 	k8s.io/client-go v0.36.1

--- a/pkg/katalog/validation_methods.go
+++ b/pkg/katalog/validation_methods.go
@@ -690,7 +690,7 @@ func (k *Katalog) validateTeams() error {
 		return nil
 	}
 
-	for name, _ := range k.enabledCRDs {
+	for name := range k.enabledCRDs {
 		if _, ok := k.Notification.Teams[name]; !ok {
 			return fmt.Errorf("%s team not found", name)
 		}

--- a/templates/motif.yaml
+++ b/templates/motif.yaml
@@ -42,4 +42,4 @@ resources:
 # status:
 #   fields:
 #     - path: ready
-#       value: "{{ replicasReady .children.deployment }}"
+#       value: "{{ allReplicasReady .children.deployment }}"


### PR DESCRIPTION
## Summary

- **`--helm-arg → --set`** — `ork e2e` flag renamed to match standard helm CLI convention; docs and CHANGELOG updated.
- **Typed example READMEs** — `--set` flag documented, build-time security section added explaining the dev/runtime binary split.
- **Typed e2e.yaml expectations** — `09-hooks` now expects `StatefulSet` + `CronJob` (not `Deployment`); `10-constructor` expects `Job` resources.
- **`11-mixed-operator-pattern` e2e suite** — new per-operator `e2e.yaml` files + top-level aggregator that imports all three sub-specs.
- **Getting-started motif guide** — adds `replicas` and `rotateAfter` inputs, `randomBase64 32` for password, switches from `.metadata.name` to `.inputs.name`; fixes CLI reference table flags.
- **Control Center** — revert list-view footer `flex:1` regression; View Details button stays compact at the right.
- **Minor** — `run_dev_apply.go` removes redundant `ClusterReachable()` guard in dev branch; Go file formatting fixes in mixed-operator; `.gitignore` adds `ork` binary; motif template uses `allReplicasReady`.

## Test plan

- [ ] `ork e2e --set runtime.image.tag=dev` — flag accepted, forwarded as `--set` to Helm
- [ ] `ork e2e --helm-arg ...` — should now error (old flag removed)
- [ ] `ork e2e -f examples/advanced/09-hooks/e2e.yaml --use-current` — StatefulSet + CronJob expectations pass
- [ ] `ork e2e -f examples/advanced/10-constructor/e2e.yaml --use-current` — Job expectations pass
- [ ] `ork e2e -f examples/advanced/11-mixed-operator-pattern/e2e.yaml --use-current` — aggregator runs all three sub-specs
- [ ] Control Center list view — View Details button compact at right, not stretched