### PR TITLE
bump typed examples to v0.7.3 in preparation for release. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.7.2 Simulate: standalone operation
+## v0.7.3 Simulate: standalone operation
 
 `ork simulate` is now a self-contained command. Key changes:
 

--- a/examples/advanced/09-hooks/go.mod.txt
+++ b/examples/advanced/09-hooks/go.mod.txt
@@ -3,7 +3,7 @@ module github.com/orkspace/orkestra-hooks-demo
 go 1.26.3
 
 require (
-	github.com/orkspace/orkestra v0.7.2
+	github.com/orkspace/orkestra v0.7.3
 	k8s.io/apimachinery v0.36.1
 )
 

--- a/examples/advanced/10-constructor/go.mod.txt
+++ b/examples/advanced/10-constructor/go.mod.txt
@@ -3,7 +3,7 @@ module github.com/orkspace/orkestra-constructor-demo
 go 1.26.3
 
 require (
-	github.com/orkspace/orkestra v0.7.2
+	github.com/orkspace/orkestra v0.7.3
 	k8s.io/api v0.36.1
 	k8s.io/apimachinery v0.36.1
 	k8s.io/client-go v0.36.1

--- a/examples/advanced/11-mixed-operator-pattern/go.mod.txt
+++ b/examples/advanced/11-mixed-operator-pattern/go.mod.txt
@@ -3,7 +3,7 @@ module github.com/orkspace/orkestra-mixed-operator-pattern
 go 1.26.3
 
 require (
-	github.com/orkspace/orkestra v0.7.2
+	github.com/orkspace/orkestra v0.7.3
 	k8s.io/api v0.36.1
 	k8s.io/apimachinery v0.36.1
 	k8s.io/client-go v0.36.1


### PR DESCRIPTION
This enables the new simulate aggregator to work with the examples, while maintaining backward compatibility