### PR TITLE
docs: introduce Orkestra Patterns concept and rename document terminology

### DIFF
--- a/documentation/concepts/index.md
+++ b/documentation/concepts/index.md
@@ -4,6 +4,14 @@ Concepts are the building blocks that make Orkestra expressive without being ver
 
 ---
 
+## Orkestra Patterns
+
+Every file you write in Orkestra — `katalog.yaml`, `simulate.yaml`, `komposer.yaml` — is an **Orkestra Pattern**: a versioned, distributable artifact with a specific kind and a specific job. The name reflects something real: these files don't just describe resources, they encode solutions to recurring problems in the operator world.
+
+→ [Read: Orkestra Patterns](patterns/)
+
+---
+
 ## Profiles
 
 [Profiles](profiles/) are named presets that expand into fully-formed configuration at Katalog load time. They cover resources, autoscaling, probes, and security. A profile is a decision made once by someone who thought it through, shared with everyone who shouldn't have to.

--- a/documentation/concepts/patterns/index.md
+++ b/documentation/concepts/patterns/index.md
@@ -1,0 +1,51 @@
+# Orkestra Patterns
+
+Operators are not unique. Across hundreds of teams building Kubernetes operators, the same problems appear repeatedly: gate a Deployment on an upstream health check, inject live config from an external service, enforce ordered deletion, propagate CRD status from child resource state, compose operators across teams without coupling them.
+
+These are not one-off requirements. They are **patterns** — recurring solutions to recurring problems in the operator world.
+
+Orkestra formalizes this. Every file you write — `katalog.yaml`, `komposer.yaml`, `simulate.yaml` — is an Orkestra Pattern: a versioned, named, distributable artifact with a specific kind and a specific job.
+
+---
+
+## The Pattern kinds
+
+| Kind | File | Job |
+|------|------|-----|
+| **Katalog** | `katalog.yaml` | Declares a CRD and its full operator behavior — resources, status, admission, lifecycle |
+| **Motif** | `motif.yaml` | A reusable resource blueprint imported by Katalogs — security posture, RBAC, probes, retry policy |
+| **Komposer** | `komposer.yaml` | Wires multiple Katalogs from registry, file, or Helm sources into a running platform |
+| **E2E** | `e2e.yaml` | Verifies operator behavior against a real cluster — declarative, no test framework |
+| **Simulate** | `simulate.yaml` | Verifies reconciler behavior in memory — no cluster, sub-second |
+
+Each kind solves one problem. You compose them as needed.
+
+---
+
+## How they relate
+
+Motifs are imported by Katalogs. Katalogs are imported by Komposers. E2E and Simulate are the testing layer — they reference Katalogs and CRs, and they compose into suites with `imports:`.
+
+A small platform might be one Katalog. A large one might be a Komposer pulling three Katalogs from the registry, each built from shared Motifs, with a Simulate suite for CI and an E2E suite for pre-deploy verification.
+
+---
+
+## Patterns are portable
+
+A Pattern is not tied to the team that wrote it. It is an OCI artifact, versioned and distributable:
+
+```
+ghcr.io/orkspace/orkestra-registry/patterns/katalogs/postgres:v1.0.0
+```
+
+A team publishes a Katalog that knows how to manage PostgreSQL. Another team imports it in a Komposer, overrides the parts specific to their environment, and runs it. The behavior travels with the artifact — not with a binary, not with a Helm chart, not with tribal knowledge.
+
+This is the same shift containers made for applications. Patterns make operator behavior portable.
+
+---
+
+## Why not "document"?
+
+YAML files are documents. Patterns are something more specific: they encode a solution to a named problem that recurs in the operator world. The name reflects intent — not format.
+
+→ See the [Pattern kinds in the registry](../../orkestra-registry/index.md) — examples of Katalogs, Motifs, and Komposers in practice.

--- a/documentation/concepts/simulate/03-init.md
+++ b/documentation/concepts/simulate/03-init.md
@@ -60,7 +60,7 @@ Output:
 
 ## What it generates
 
-`ork simulate init` produces a `Simulate` document pre-filled with the observed cycle-1 create operations as `expect:` rules:
+`ork simulate init` produces a `Simulate` Pattern pre-filled with the observed cycle-1 create operations as `expect:` rules:
 
 ```yaml
 apiVersion: orkestra.orkspace.io/v1

--- a/documentation/orkestra-registry/03-komposers.md
+++ b/documentation/orkestra-registry/03-komposers.md
@@ -1,6 +1,6 @@
 # Komposers
 
-A Komposer is the **composition plane**: it declares where to pull operator patterns from and how to compose them into a running platform. Komposers are the only document type with a top-level `imports` block (registry, file, and Helm sources). Katalogs import only Motifs, and only at the CRD level — they cannot pull other Katalogs or Komposers.
+A Komposer is the **composition plane**: it declares where to pull operator patterns from and how to compose them into a running platform. Komposers are the only Pattern with a top-level `imports` block (registry, file, and Helm sources). Katalogs import only Motifs, and only at the CRD level — they cannot pull other Katalogs or Komposers.
 
 ---
 

--- a/documentation/reference/index.md
+++ b/documentation/reference/index.md
@@ -6,9 +6,9 @@ Technical reference for the Orkestra runtime, schemas, and CLI.
 
 ## Schema
 
-Complete field reference for every Orkestra document type.
+Complete field reference for every Orkestra Pattern.
 
-| Document | Description |
+| Pattern | Description |
 |----------|-------------|
 | [Katalog](./schema/katalog.md) | Top-level operator definition |
 | [Komposer](./schema/komposer.md) | Multi-source composition |
@@ -38,6 +38,6 @@ Complete field reference for every Orkestra document type.
 
 ## Where to go next
 
-- **[Schema Reference](./schema/katalog.md)** — every field in every document type
+- **[Schema Reference](./schema/motif.md)** — every field in every Pattern
 - **[CLI Reference](./cli/run.md)** — full flag reference for every command
 - **[Typed Operators](../concepts/typed-operators/index.md)** — hooks, constructors, and mixed patterns

--- a/documentation/reference/schema/05-simulate/index.md
+++ b/documentation/reference/schema/05-simulate/index.md
@@ -1,0 +1,160 @@
+# Simulate
+
+!!! note "Simulate is not a Kubernetes CRD"
+    `kubectl apply` will not work. Orkestra kinds are consumed by the `ork` CLI and runtime — not by the Kubernetes API server. [Your CRD is enough](../../../blog/02-your-crd-is-enough.md).
+
+A `Simulate` Pattern declares what your operator should produce — which resources, in which cycle — and verifies it by running the reconciler against a fake in-memory cluster. No Kubernetes. No Docker. Sub-second.
+
+```text
+Motif     — smallest reusable unit
+    ↓
+Katalog   — operator declaration
+    ↓
+Komposer  — platform declaration
+    ↓
+Simulate  — in-memory reconciler verification
+```
+
+`ork validate` checks the structure. `ork simulate` runs it.
+
+---
+
+## Wire format
+
+### With `expect:` — assert mode
+
+```yaml
+apiVersion: orkestra.orkspace.io/v1
+kind: Simulate
+
+metadata:
+  name: my-operator-sim
+  description: Verify Deployment and Service created in cycle 1
+
+spec:
+  katalog: ./katalog.yaml
+  cr: ./cr.yaml
+  cycles: 5
+  skipExternal: false
+
+  expect:
+    noErrors: true
+    ops:
+      - cycle: 1
+        verb: create
+        resource: deployments
+        name: my-app
+    # absent:   # ops that must NOT appear — fill in for failure-path coverage
+    #   - cycle: 1
+    #     verb: create
+    #     resource: deployments
+    steady: true
+
+```
+
+### Without `expect:` — op-print mode
+
+Same spec, no `expect:` block. Runs the reconciler, prints every op recorded per cycle, always exits 0. Used for exploration before you know the expected sequence.
+
+### Aggregator form
+
+```yaml
+apiVersion: orkestra.orkspace.io/v1
+kind: Simulate
+
+metadata:
+  name: my-suite
+
+imports:
+  - ./01-basic/simulate.yaml
+  - ./02-with-hooks/simulate.yaml
+```
+
+No `spec:`. Each imported file runs independently. The suite fails if any file fails.
+
+---
+
+## Field reference
+
+### `metadata`
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | yes | Name of this simulate run — used in output headers |
+| `description` | no | Free-text description shown in output and registry |
+
+### `spec`
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `katalog` | yes | | Path to the `katalog.yaml` (or `komposer.yaml`) |
+| `cr` | yes | | Path to the CR YAML file. Multi-doc YAML supported — each doc matched to its CRD by `kind` |
+| `cycles` | no | `10` | Maximum number of reconcile cycles to run |
+| `skipExternal` | no | `false` | Stub all `external:` HTTP calls with an empty 200 response instead of hitting the real network |
+
+### `spec.expect`
+
+Optional. When omitted the run is in op-print mode — no assertions, always exits 0.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `steady` | bool | Reconciler must reach steady state within `cycles` |
+| `steadyAt` | int | Steady state must be reached by this cycle number (≤ value) |
+| `noErrors` | bool | Any reconcile error fails the run |
+| `ops` | `[]OpRule` | Ops that must appear — see below |
+| `absent` | `[]OpRule` | Ops that must NOT appear — use for failure-path assertions |
+| `crds` | `map[string]expect` | Per-CRD overrides for multi-CRD Katalogs. Top-level fields are defaults; a named entry overrides for that CRD only |
+
+### `OpRule`
+
+Used in both `ops` and `absent`.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `cycle` | yes | Reconcile cycle the op must (or must not) occur in |
+| `verb` | yes | `create`, `update`, `delete`, or `patch` |
+| `resource` | yes | Kubernetes resource type: `deployments`, `statefulsets`, `configmaps`, … |
+| `name` | no | Assert a specific resource name |
+| `count` | no | Minimum number of matching ops (default: ≥1). Ignored in `absent` |
+
+---
+
+## Validation
+
+```bash
+ork validate -f simulate.yaml
+```
+
+Catches: missing required fields, verbs outside the four allowed values, `imports` paths that don't resolve on disk.
+
+---
+
+## Scaffold with `ork simulate init`
+
+`ork simulate init` runs the reconciler once, captures the cycle-1 create ops, and writes a `simulate.yaml` pre-filled with `expect:` rules — including a commented `absent:` block seeded with the first observed resource type.
+
+```bash
+ork simulate init           # writes simulate.yaml
+ork simulate init --dry-run # prints to stdout, nothing written
+ork simulate init --force   # overwrites existing simulate.yaml
+```
+
+→ [Scaffolding Tests](../../../concepts/simulate/03-init.md)
+
+---
+
+## Try it
+
+```bash
+ork init --pack beginner
+cd beginner/02-with-serviceaccount
+ork simulate
+```
+
+---
+
+## See also
+
+- [Katalog schema](../02-katalog/01-top-level.md) — the Katalog under simulation
+- [simulate concept docs](../../../concepts/simulate/index.md) — how simulate works, aggregators, hooks and constructors
+- [ork simulate CLI reference](../../cli/05-simulate.md)

--- a/documentation/reference/schema/index.md
+++ b/documentation/reference/schema/index.md
@@ -8,6 +8,7 @@ The schema is organised by kind. Each kind has its own subfolder.
 | [Katalog](02-katalog/) | `02-katalog/` | Operator declaration. Defines CRDs, resources, status, and admission rules. |
 | [Komposer](03-komposer/) | `03-komposer/` | Compose multiple Katalogs from files, Helm, or OCI registries. |
 | [E2E](04-e2e/) | `04-e2e/` | Declarative end-to-end test for a Katalog. [spec](04-e2e/01-spec.md) · [setup](04-e2e/02-setup.md) · [expect](04-e2e/03-expect.md) |
+| [Simulate](05-simulate/) | `05-simulate/` | In-memory reconciler verification — no cluster. [field reference](05-simulate/index.md) |
 
 ---
 
@@ -15,7 +16,7 @@ The schema is organised by kind. Each kind has its own subfolder.
 
 All fields that live inside a Katalog `spec.crds.<name>` entry:
 
-| Document | Covers |
+| Pattern | Covers |
 |----------|--------|
 | [01-top-level.md](02-katalog/01-top-level.md) | Top-level Katalog structure |
 | [02-crd-entry.md](02-katalog/02-crd-entry.md) | Fields inside `spec.crds.<name>` |

--- a/documentation/security/06-validation-pipeline.md
+++ b/documentation/security/06-validation-pipeline.md
@@ -1,6 +1,6 @@
 # Validation pipeline
 
-Every Orkestra document goes through a strict validation pipeline before anything runs. The whole pipeline runs entirely offline — no cluster required.
+Every Orkestra Pattern goes through a strict validation pipeline before anything runs. The whole pipeline runs entirely offline — no cluster required.
 
 ---
 
@@ -12,13 +12,13 @@ Orkestra uses strict YAML unmarshaling. Unknown fields produce an immediate erro
 error: unknown field "reconcileMode" in operatorBox — did you mean "reconcile"?
 ```
 
-This applies to every document type: Katalog, Komposer, Motif, E2E spec.
+This applies to every Pattern: Katalog, Komposer, Motif, E2E, Simulate.
 
 ---
 
 ## `ork validate`
 
-Validates an Orkestra document fully without touching a cluster.
+Validates an Orkestra Pattern fully without touching a cluster.
 
 ```bash
 ork validate
@@ -100,7 +100,7 @@ The following commands require no cluster connection:
 | Command | What it does |
 |---------|-------------|
 | `ork init` | Scaffold a new operator project |
-| `ork validate` | Full document validation |
+| `ork validate` | Full Pattern validation |
 | `ork template` | Render the merged, resolved Katalog |
 | `ork simulate` | Reconcile against a fake in-memory cluster |
 | `ork notes` | Browse and search template expression library |
@@ -132,7 +132,7 @@ Validation runs at multiple points independently:
 4. **Admission webhooks** — the Gateway rejects invalid CRs at CREATE/UPDATE time, before etcd storage
 5. **Reconcile time** — the runtime re-checks rules on every reconcile as a backstop
 
-A document that passes `ork validate` and `ork simulate` is very unlikely to fail at runtime — the same validation logic runs in all five stages.
+A Pattern that passes `ork validate` and `ork simulate` is very unlikely to fail at runtime — the same validation logic runs in all five stages.
 
 ---
 

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -23,7 +23,7 @@ enableGitInfo = true
   [params.algolia]
     appId = "IDBZPZV9Q6"
     searchKey = "6eadbb67e7c72aaaa5309e17c4e1e9ad"
-    indexName = "Orkestra Documentaion"
+    indexName = "Orkestra Documentation"
 
 
 [menu]


### PR DESCRIPTION
## Summary

- **New concept page** — `concepts/patterns/index.md` explains what an Orkestra Pattern is, why the word "pattern" (recurring solutions to recurring operator problems), the five kinds and how they compose, and OCI-based portability. Added as the first entry in the concepts index.
- **Terminology rename** — "Orkestra document" → "Orkestra Pattern" across all doc files: reference index, validation pipeline, registry komposers doc, and simulate init doc. Simulate is also added to the Pattern kinds list in the validation pipeline (it was missing alongside E2E).
- Go strings (`validate.go`, `main.go`, `konfig/ork.go`) are out of scope — left for a code-facing PR.

## Test plan

- [x] `concepts/patterns/index.md` renders correctly in Hugo
- [x] All internal links in the new pages resolve
- [x] `reference/schema/` shows Simulate alongside E2E, Motif, Katalog, Komposer
- [x] No remaining "Orkestra document" references in `documentation/` (excluding generic uses like "This document describes…")