### PR TITLE
docs(faqs): ArgoCD + Kubebuilder comparisons, testing FAQ, usage rename

### DIFF
--- a/documentation/faqs/01-concepts.md
+++ b/documentation/faqs/01-concepts.md
@@ -1,7 +1,5 @@
 # Concepts
 
----
-
 ## What is Orkestra?
 
 Orkestra is a declarative operator runtime for Kubernetes. It turns CRDs into
@@ -218,5 +216,5 @@ declared alongside reconcile templates:
 ## Next
 
 - **[Running](./02-running.md)** — setup, configuration, and operations
-- **[Patterns](./03-patterns.md)** — validation, mutation, built-in kinds
+- **[Usage](./03-usage.md)** — validation, mutation, built-in kinds
 - **[Ecosystem](./04-ecosystem.md)** — comparisons and the Kubernetes roadmap

--- a/documentation/faqs/02-running.md
+++ b/documentation/faqs/02-running.md
@@ -1,7 +1,5 @@
 # Running Orkestra
 
----
-
 ## Can Orkestra manage multiple CRDs?
 
 Yes — any number. This is the point.
@@ -206,6 +204,6 @@ failure mode, what it means, and how Orkestra handles it.
 
 ## Next
 
-- **[Patterns](./03-patterns.md)** — validation, mutation, built-in kinds
+- **[Usage](./03-usage.md)** — validation, mutation, built-in kinds
 - **[Ecosystem](./04-ecosystem.md)** — comparisons and the Kubernetes roadmap
 - **[Deploying](../deploying.md)** — full cluster setup

--- a/documentation/faqs/03-usage.md
+++ b/documentation/faqs/03-usage.md
@@ -1,6 +1,4 @@
-# Patterns
-
----
+# Usage
 
 ## Can Orkestra manage built-in Kubernetes resources?
 

--- a/documentation/faqs/04-ecosystem.md
+++ b/documentation/faqs/04-ecosystem.md
@@ -1,5 +1,52 @@
 # Ecosystem
 
+## How does Orkestra compare to ArgoCD?
+
+ArgoCD does manage drift. That's a fair starting point.
+
+The real question is what you do when you need an operator — when drift correction of static manifests is not enough, when you need conditional resources, live state reactions, external API calls, cross-operator dependencies.
+
+At that point you drop into Go. And every team that does this builds the same machinery, from scratch, for every operator: informers, workqueues, leader election, worker pools, health endpoints, Prometheus metrics, retry logic, finalizers, status management, safe panic recovery, multi-version CRD handling, admission and deletion protection.
+
+That machinery is not the reason the operator exists. It is the cost of entry.
+
+Orkestra says: the machinery is the runtime's job. You focus on the reason the operator exists — your custom logic.
+
+| | Helm + ArgoCD | Orkestra |
+|---|---|---|
+| **Drift correction** | Yes — reconciles declared state | Yes — `reconcile: true` on any resource |
+| **Custom CR logic** | No | Yes — `when:`, `external:`, `status:`, hooks |
+| **Live state reactions** | No | Yes — reconciler re-runs on every change event |
+| **External API calls** | No | Yes — `external:` block, no client code |
+| **Admission control** | No | Yes — validation and mutation webhooks |
+| **Multi-version CRDs** | No | Yes — declarative conversion, no webhook code |
+| **Per-operator autoscaling** | No | Yes — workers, queue depth, resync period |
+| **Operator distribution** | Helm chart | OCI Katalog |
+
+Helm + ArgoCD is the right tool for managing static platform resources. Orkestra is the runtime for teams writing operators — so they write the part that matters and stop rebuilding the machinery every time.
+
+---
+
+## How does Orkestra compare to Kubebuilder and Operator SDK?
+
+Both Kubebuilder and Operator SDK are scaffolding frameworks. They generate the controller skeleton — informer setup, event handlers, reconcile loop stub — and reduce the boilerplate you write. You fill in the logic.
+
+You still own the machinery. Queue depth, worker count, leader election lease, health endpoints, Prometheus metrics, retry logic, panic recovery — all of it is yours to configure, test, and maintain. Kubebuilder scaffolds it. You own it.
+
+Orkestra is a runtime. You do not write controllers. The machinery is the runtime's job.
+
+| | Kubebuilder / Operator SDK | Orkestra |
+|---|---|---|
+| **Language** | Go | YAML (Go hooks optional) |
+| **Controller code** | Required — you fill in the reconciler | Not required — runtime executes your Katalog |
+| **Informer / queue / workers** | Yours to configure | Runtime-managed, per-CRD |
+| **Admission webhooks** | Write and deploy separately | Declared in Katalog, served by Gateway |
+| **Metrics** | Instrument yourself | Built-in per-CRD — queue depth, error rate, worker utilisation |
+| **Operator distribution** | Binary / Docker image | OCI Katalog |
+| **Testing** | Unit tests + envtest | `ork simulate` (in-memory) + `ork e2e` (real cluster) |
+
+The escape hatch: when the declarative layer genuinely is not enough — writing a row into PostgreSQL, calling a non-HTTP API — typed hooks let you drop back to Go without giving up the declarative layer. You write the part that requires code. The runtime handles the rest.
+
 ---
 
 ## How does Orkestra compare to kro?
@@ -17,13 +64,12 @@ The differences are significant:
 | **Multi-version CRDs** | No | Yes — declarative conversion paths |
 | **Registry/distribution** | No | Yes — OCI artifacts, Artifact Hub |
 | **Admission webhooks** | No | Yes — validation and mutation |
-| **Health API** | No | Yes — per-CRD endpoints and Prometheus |
-| **Observability** | No | Yes — Control Center, per-CRD health endpoints, Prometheus |
+| **Observability** | No | Yes — per-CRD health endpoints, Prometheus, Control Center |
 | **Hooks for external logic** | No | Yes — typed and dynamic Go hooks |
 
 kro is a composability layer. Orkestra is a runtime. The fact that three major cloud
-providers independently arrived at the same insight validates the direction. Orkestra
-is the complete version of what they were reaching for.
+providers independently arrived at the same insight validates the direction — Orkestra
+extends it into a complete operator runtime.
 
 ---
 
@@ -58,8 +104,8 @@ for the full argument.
 
 The short version: Orkestra is building toward CNCF Sandbox, then a Kubernetes
 Enhancement Proposal, then alpha/beta/GA integration into `kube-controller-manager`.
-The target timeline is five years. The prerequisite is production adoption at multiple
-organisations, with metrics.
+The prerequisite is production adoption at multiple organisations, with metrics. The
+timeline depends on that adoption curve.
 
 The Katalog and Komposer becoming native Kubernetes kinds — `kubectl get katalogs` —
 is the end state. At that point, every cluster ships with a meta-controller that

--- a/documentation/faqs/06-testing.md
+++ b/documentation/faqs/06-testing.md
@@ -1,0 +1,116 @@
+# Testing
+
+## How do I test an Orkestra operator?
+
+Two tools. One for fast iteration, one for production confidence:
+
+**`ork simulate`** — runs the reconciler against a fake in-memory cluster. No Kubernetes. No Docker. Sub-second. Declare what your operator should produce per cycle, get a pass or fail. The same reconciler code that runs in production runs here.
+
+**`ork e2e`** — runs the operator against a real kind cluster. Creates the cluster, applies CRDs and the operator, applies your CR, asserts Kubernetes resource state, tears down. Full integration truth.
+
+The pattern: simulate in your inner loop, e2e as your pre-deploy gate.
+
+---
+
+## What is the difference between `ork simulate` and `ork e2e`?
+
+| | `ork simulate` | `ork e2e` |
+|---|---|---|
+| **Cluster** | No — in-memory | Yes — kind |
+| **Speed** | Sub-second | 2–5 min |
+| **What it asserts** | Reconciler ops by cycle | Kubernetes resource state (ready, count, fields) |
+| **When to use** | Every change, CI, development loop | Pre-deploy verification, integration truth |
+
+They are not alternatives. Simulate is your inner loop. E2E is your pre-deploy gate. Use both.
+
+---
+
+## How do I generate a `simulate.yaml`?
+
+`ork simulate init` runs the reconciler once, captures the cycle-1 create operations, and writes a `simulate.yaml` pre-filled with `expect:` rules:
+
+```bash
+ork simulate init           # writes simulate.yaml in the current directory
+ork simulate init --dry-run # preview: prints to stdout, nothing written
+ork simulate init --force   # overwrite existing simulate.yaml
+```
+
+The generated file includes a commented `absent:` block seeded with the first observed resource type — a starting point for failure-path assertions you can fill in.
+
+→ [Scaffolding tests with simulate init](../concepts/simulate/03-init.md)
+
+---
+
+## What does `skipExternal: true` do?
+
+It stubs all `external:` HTTP calls with an empty 200 response instead of hitting the real network. Useful when the external service is not available in your simulate environment and you only care about the structural output — which resources are created — not the content shaped by the external response.
+
+```yaml
+spec:
+  katalog: ./katalog.yaml
+  cr: ./cr.yaml
+  skipExternal: true
+```
+
+If you need the external calls to return meaningful responses — for example, a feature flag that controls whether a resource is created — use `--dev-server` instead.
+
+---
+
+## What is `ork simulate --dev-server`?
+
+`ork simulate --dev-server` starts the Orkestra mock HTTP server at `localhost:9999` before running simulate. The dev server responds to the same endpoints used in the learning examples:
+
+- `GET /health` — 200 healthy
+- `GET /config/:name` — static JSON config blob
+- `GET /flags/:name/:flag` — feature flag value
+- `GET /status/200`, `GET /status/503` — explicit status codes
+
+This lets examples that call external services (config injection, feature flags, health gates) get realistic responses during simulate — no real network, no cluster required.
+
+`--skip-external` stubs calls with empty 200s. `--dev-server` gives them real responses. Use `--dev-server` when the response content affects what resources your operator creates.
+
+→ [simulate CLI reference](../reference/cli/05-simulate.md)
+
+---
+
+## Can I run simulate for multiple operators at once?
+
+Yes — with an aggregator. A `simulate.yaml` with `imports:` and no `spec:` runs each imported file independently:
+
+```yaml
+apiVersion: orkestra.orkspace.io/v1
+kind: Simulate
+metadata:
+  name: platform-sim
+
+imports:
+  - ./database/simulate.yaml
+  - ./cache/simulate.yaml
+  - ./api/simulate.yaml
+```
+
+Each file runs independently. The suite fails if any file fails.
+
+To run all simulate files in a directory tree:
+
+```bash
+ork simulate ./...
+```
+
+→ [Aggregator mode](../concepts/simulate/index.md)
+
+---
+
+## Does simulate run the real reconciler?
+
+Yes. `ork simulate` uses the same reconciler pipeline that runs against a live cluster — the same template evaluation, the same `when:` conditions, the same `external:` calls, the same hooks. The only difference is the backing store: instead of etcd and the Kubernetes API, simulate uses an in-memory fake client.
+
+If a test passes in simulate, the reconciler logic is correct. What you cannot verify in simulate: admission webhook behavior end-to-end, network policies, actual pod scheduling, and anything that depends on Kubernetes controllers running (e.g. ReplicaSet → Pod creation). That is what `ork e2e` is for.
+
+---
+
+## Next
+
+- **[simulate concept docs](../concepts/simulate/index.md)** — how simulate works in depth
+- **[E2E concept docs](../concepts/e2e/index.md)** — end-to-end testing
+- **[Simulate schema reference](../reference/schema/05-simulate/index.md)** — full field reference

--- a/documentation/faqs/index.md
+++ b/documentation/faqs/index.md
@@ -29,7 +29,7 @@ Setup, configuration, operations, and RBAC.
 
 ---
 
-## [Patterns](./03-patterns.md)
+## [Usage](./03-usage.md)
 
 Common usage patterns — built-in kinds, validation, mutation, conditions.
 
@@ -45,9 +45,25 @@ Common usage patterns — built-in kinds, validation, mutation, conditions.
 
 Comparisons and the path forward.
 
+- How does Orkestra compare to ArgoCD?
+- How does Orkestra compare to Kubebuilder and Operator SDK?
 - How does Orkestra compare to kro?
 - Can Orkestra manage third-party CRDs?
 - What is the path to Kubernetes core?
+
+---
+
+## [Testing](./06-testing.md)
+
+Simulate, E2E, and the testing tools.
+
+- How do I test an Orkestra operator?
+- What is the difference between `ork simulate` and `ork e2e`?
+- How do I generate a `simulate.yaml`?
+- What does `skipExternal: true` do?
+- What is `ork simulate --dev-server`?
+- Can I run simulate for multiple operators at once?
+- Does simulate run the real reconciler?
 
 ---
 

--- a/documentation/reference/schema/01-motif/index.md
+++ b/documentation/reference/schema/01-motif/index.md
@@ -1,7 +1,7 @@
 # Motif
 
 !!! note "Motif is not a Kubernetes CRD"
-    `kubectl apply` will not work. Orkestra kinds are consumed by the `ork` CLI and runtime — not by the Kubernetes API server. [Your CRD is enough](../../../blog/02-your-crd-is-enough.md).
+    `kubectl apply` will not work. Orkestra kinds are consumed by the `ork` CLI and runtime — not by the Kubernetes API server. [Your CRD is enough](/blog/your-crd-is-enough/).
 
 A Motif is the smallest reusable unit in Orkestra's composition model. It declares named inputs and contributes resource blocks to a Katalog CRD entry. It cannot run alone — it must be imported by a Katalog.
 

--- a/documentation/reference/schema/02-katalog/index.md
+++ b/documentation/reference/schema/02-katalog/index.md
@@ -1,7 +1,7 @@
 # Katalog
 
 !!! note "Katalog is not a Kubernetes CRD"
-    `kubectl apply` will not work. Orkestra kinds are consumed by the `ork` CLI and runtime — not by the Kubernetes API server. [Your CRD is enough](../../../blog/02-your-crd-is-enough.md).
+    `kubectl apply` will not work. Orkestra kinds are consumed by the `ork` CLI and runtime — not by the Kubernetes API server. [Your CRD is enough](/blog/your-crd-is-enough/).
 
 A Katalog declares one or more CRDs and defines how Orkestra manages them. It is the **unit of operator definition** — everything the runtime needs to run an operator from a single YAML file.
 

--- a/documentation/reference/schema/03-komposer/index.md
+++ b/documentation/reference/schema/03-komposer/index.md
@@ -1,7 +1,7 @@
 # Komposer
 
 !!! note "Komposer is not a Kubernetes CRD"
-    `kubectl apply` will not work. Orkestra kinds are consumed by the `ork` CLI and runtime — not by the Kubernetes API server. [Your CRD is enough](../../../blog/02-your-crd-is-enough.md).
+    `kubectl apply` will not work. Orkestra kinds are consumed by the `ork` CLI and runtime — not by the Kubernetes API server. [Your CRD is enough](/blog/your-crd-is-enough/).
 
 A Komposer is a Katalog with an `imports` block. It composes multiple Katalogs from different sources — OCI registry patterns, local files, or Helm charts — into a single running operator set. The `spec.crds` block provides per-environment overrides on top of the imported definitions.
 

--- a/documentation/reference/schema/04-e2e/index.md
+++ b/documentation/reference/schema/04-e2e/index.md
@@ -1,7 +1,7 @@
 # E2E
 
 !!! note "E2E is not a Kubernetes CRD"
-    `kubectl apply` will not work. Orkestra kinds are consumed by the `ork` CLI and runtime — not by the Kubernetes API server. [Your CRD is enough](../../../blog/02-your-crd-is-enough.md).
+    `kubectl apply` will not work. Orkestra kinds are consumed by the `ork` CLI and runtime — not by the Kubernetes API server. [Your CRD is enough](/blog/your-crd-is-enough/).
 
 An `E2E` is a declarative end-to-end test for a Katalog. It tells Orkestra exactly what to apply, which cluster to use, and what the expected state is after each step.
 

--- a/documentation/reference/schema/05-simulate/index.md
+++ b/documentation/reference/schema/05-simulate/index.md
@@ -1,7 +1,7 @@
 # Simulate
 
 !!! note "Simulate is not a Kubernetes CRD"
-    `kubectl apply` will not work. Orkestra kinds are consumed by the `ork` CLI and runtime — not by the Kubernetes API server. [Your CRD is enough](../../../blog/02-your-crd-is-enough.md).
+    `kubectl apply` will not work. Orkestra kinds are consumed by the `ork` CLI and runtime — not by the Kubernetes API server. [Your CRD is enough](/blog/your-crd-is-enough/).
 
 A `Simulate` Pattern declares what your operator should produce — which resources, in which cycle — and verifies it by running the reconciler against a fake in-memory cluster. No Kubernetes. No Docker. Sub-second.
 


### PR DESCRIPTION
## Summary

- **Ecosystem FAQ** — new ArgoCD comparison (draws from community Slack Q&A), new Kubebuilder/Operator SDK comparison, fixed duplicate kro Observability row, softened five-year Kubernetes core timeline
- **Testing FAQ** (new `06-testing.md`) — simulate vs e2e, how to generate simulate.yaml, --dev-server vs --skip-external, aggregators, and "does simulate run the real reconciler?"
- **Rename** `03-patterns.md` → `03-usage.md` — avoids confusion with the Orkestra Patterns concept page added in the pattern rename PR
- **All cross-references** updated across `index.md`, `01-concepts.md`, `02-running.md`

## Test plan

- [x] Hugo builds without broken link warnings
- [x] `/docs/faqs/` index renders correctly with new sections
- [x] `/docs/faqs/testing/` renders
- [x] `/docs/faqs/03-patterns/` now 404s (old slug gone)
- [x] `/docs/faqs/03-usage/` resolves