### PR TITLE
revert to Orkestra Documentaion

### DIFF
--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -23,7 +23,7 @@ enableGitInfo = true
   [params.algolia]
     appId = "IDBZPZV9Q6"
     searchKey = "6eadbb67e7c72aaaa5309e17c4e1e9ad"
-    indexName = "Orkestra Documentation"
+    indexName = "Orkestra Documentaion"
 
 
 [menu]


### PR DESCRIPTION
## Summary 
Search broke because the Algolia index name in `hugo.toml` was changed from the correct value (`Orkestra Documentaion`) to `Orkestra Documentation`. Algolia is still indexing under the original name, so the frontend could no longer query the correct index.

This PR:

- restores the correct index name  
- unblocks documentation search immediately  
- adds a TODO comment for the future index migration milestone  

This is tracked as a bug and will be addressed properly when we introduce the new index schema.

---

## Fix
- Temporary: revert to the working index name.

- Long-term: create a new index name and migrate the crawler +
frontend together (tracked in milestone).
