### PR TITLE
docs: schema evolution, FAQ expansion, Control Center, link fixes

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -5,6 +5,11 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - 'cmd/**'
+      - 'pkg/**'
+      - 'go.mod'
+      - 'go.sum'
 
 jobs:
   validate-notes:

--- a/Makefile
+++ b/Makefile
@@ -371,28 +371,6 @@ test-fixture-reconciler:
 
 DOCS_PORT ?= 8090
 
-docs-sync:
-	@echo "Syncing documentation/ → website/content/docs/ ..."
-	@bash website/scripts/sync-docs.sh
-	@echo "✅ Docs synced"
-
-docs: docs-sync
-	@if [ -z "$(HUGO)" ]; then echo "Hugo not found. Run: make hugo-install"; exit 1; fi
-	@echo "Starting Hugo docs server at http://localhost:$(DOCS_PORT) ..."
-	hugo server --source website --port $(DOCS_PORT) --bind 0.0.0.0 --disableFastRender --logLevel warn
-	@echo "✅ Docs server stopped"
-
-docs-build: docs-sync
-	@if [ -z "$(HUGO)" ]; then echo "Hugo not found. Run: make hugo-install"; exit 1; fi
-	@echo "Building Hugo static site..."
-	hugo --source website --minify
-	@echo "✅ Hugo site built to website/public/"
-
-docs-serve: docs-sync
-	@if [ -z "$(HUGO)" ]; then echo "Hugo not found. Run: make hugo-install"; exit 1; fi
-	@echo "Serving production Hugo build on port $(DOCS_PORT)..."
-	hugo server --source website --port $(DOCS_PORT) --bind 0.0.0.0 --renderStaticToDisk
-
 HUGO := $(shell which hugo 2>/dev/null)
 
 # Install Hugo extended if not present (Linux/macOS)
@@ -410,6 +388,28 @@ hugo-install:
 	echo "Installing Hugo v$${VER} from $$URL ..."; \
 	curl -sSL "$$URL" | tar -xz -C /tmp hugo && sudo mv /tmp/hugo /usr/local/bin/hugo; \
 	echo "✅ Hugo installed: $$(hugo version)"
+
+docs-sync:
+	@echo "Syncing documentation/ → website/content/docs/ ..."
+	@bash website/scripts/sync-docs.sh
+	@echo "✅ Docs synced"
+
+docs: hugo-install docs-sync
+	@if [ -z "$(HUGO)" ]; then echo "Hugo not found. Run: make hugo-install"; exit 1; fi
+	@echo "Starting Hugo docs server at http://localhost:$(DOCS_PORT) ..."
+	hugo server --source website --port $(DOCS_PORT) --bind 0.0.0.0 --disableFastRender --logLevel warn
+	@echo "✅ Docs server stopped"
+
+docs-build: docs-sync
+	@if [ -z "$(HUGO)" ]; then echo "Hugo not found. Run: make hugo-install"; exit 1; fi
+	@echo "Building Hugo static site..."
+	hugo --source website --minify
+	@echo "✅ Hugo site built to website/public/"
+
+docs-serve: docs-sync
+	@if [ -z "$(HUGO)" ]; then echo "Hugo not found. Run: make hugo-install"; exit 1; fi
+	@echo "Serving production Hugo build on port $(DOCS_PORT)..."
+	hugo server --source website --port $(DOCS_PORT) --bind 0.0.0.0 --renderStaticToDisk
 
 # ── Vet ───────────────────────────────────────────────────────────────────────
 vet:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,8 +14,7 @@ Security fixes will be applied to the latest minor release.
 
 If you discover a security vulnerability, please report it privately.
 
-Email: **security@orkestra.io**  
-(If this address is not yet active, use GitHub private security advisories.)
+Use [GitHub private security advisories](https://github.com/orkspace/orkestra/security/advisories/new) to report privately.
 
 Please include:
 

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -7,13 +7,12 @@ CLI command definitions for the `ork` binary. Each file registers one command or
 | Command | File | What it does |
 |---------|------|-------------|
 | `ork run` | `run.go` / `run_dev.go` | Start the runtime (reconcile loop) |
-| `ork gate` | `gateway.go` | Start the gateway (TLS + webhooks, cluster-only) |
+| `ork gate` | `gate.go` | Start the gateway (TLS + webhooks, cluster-only) |
 | `ork generate` | `generate.go` | Generate RBAC, bundles, ConfigMaps, CRDs, docs |
-| `ork validate` | `validate.go` | Validate a Katalog file |
-| `ork deploy` | `deploy.go` | Deploy an operator via `ork doctor` |
+| `ork validate` | `validate.go` | Validate an Orkestra Pattern |
 | `ork plan` | `plan.go` | Dry-run a Katalog against a live cluster |
 
-For the full command reference see [documentation/reference/cli](../../documentation/reference/cli).
+For the full command reference see [documentation/reference/cli](../../documentation/reference/cli/index.md).
 
 ## Design docs
 

--- a/documentation/concepts/conversion/01-normalize.md
+++ b/documentation/concepts/conversion/01-normalize.md
@@ -1,0 +1,143 @@
+# normalize:
+
+`normalize:` runs before mutation, validation, and reconcile. It collapses input format variation into one canonical shape — without touching etcd, without a webhook, without a multi-version CRD.
+
+Use it when you want to accept multiple CR shapes for the same field without branching logic downstream.
+
+---
+
+## How it works
+
+Declare a `normalize:` block in the Katalog alongside `mutation:` and `validation:`. Each field expression runs against the raw CR as submitted. The normalised values replace the raw values in the in-memory resolver — the stored CR is unchanged.
+
+```yaml
+normalize:
+  spec:
+    schedule: "{{ cronFromAny .spec.schedule }}"
+```
+
+After `normalize:` runs, `.spec.schedule` is always a five-field cron string — whether the user wrote `"0 2 * * 1-5"` or `{minute: "0", hour: "2", ...}`. Every downstream expression, validation rule, and template sees the canonical form. No branching required.
+
+---
+
+## The pipeline order
+
+```text
+CR submitted
+    ↓
+normalize:      ← raw input → canonical shape (in-memory only)
+    ↓
+mutation:       ← apply defaults to the normalised CR
+    ↓
+validation:     ← check required fields after defaults are set
+    ↓
+onCreate / onReconcile   ← templates see canonical fields throughout
+```
+
+`normalize:` runs before `mutation:`, so defaults apply to the normalised value. If a user submits neither a string nor a map, `normalize:` can supply a default via `{{ default "0 * * * *" (cronFromAny .spec.schedule) }}`.
+
+---
+
+## Accepting two schedule formats
+
+```yaml
+# Both of these work. The reconciler sees the same thing either way.
+
+# Cron string
+spec:
+  schedule: "0 2 * * 1-5"
+
+# Structured object
+spec:
+  schedule:
+    minute: "0"
+    hour: "2"
+    dayOfMonth: "*"
+    month: "*"
+    dayOfWeek: "1-5"
+```
+
+The Katalog:
+
+```yaml
+normalize:
+  spec:
+    schedule: "{{ cronFromAny .spec.schedule }}"
+
+mutation:
+  rules:
+    - field: spec.concurrencyPolicy
+      default: "Allow"
+
+onCreate:
+  cronJobs:
+    - name: "{{ .metadata.name }}"
+      schedule: "{{ .spec.schedule }}"   # always a cron string here
+      image: "{{ .spec.image }}"
+      reconcile: true
+```
+
+`cronFromAny` accepts a cron string or a structured map and always returns a five-field cron string. `@`-macros (`@hourly`, `@daily`) are expanded transparently.
+
+---
+
+## Alternative: branch at reconcile time
+
+If you want to preserve the raw format in etcd and handle both shapes explicitly, use `typeString` and `typeMap` in `when:` conditions instead of `normalize:`:
+
+```yaml
+onReconcile:
+  cronJobs:
+    # Path A — cron string
+    - name: "{{ .metadata.name }}"
+      schedule: "{{ .spec.schedule }}"
+      when:
+        - field: "{{ typeString .spec.schedule }}"
+          equals: "true"
+
+    # Path B — structured object
+    - name: "{{ .metadata.name }}"
+      schedule: "{{ cronFromMap .spec.schedule }}"
+      when:
+        - field: "{{ typeMap .spec.schedule }}"
+          equals: "true"
+```
+
+Only one path fires per reconcile. The child resource is identical regardless of which path ran. Use this when you want the stored format to remain as the user submitted it — for audit trails, or when the raw shape carries meaning.
+
+---
+
+## Deprecating a format without schema migration
+
+When you are ready to steer users away from the string format, add a validation rule — no etcd migration, no CRD version bump:
+
+```yaml
+validation:
+  rules:
+    - field: spec.schedule
+      operator: typeOf
+      value: map
+      message: "spec.schedule as a string is deprecated — use the structured object. See migration guide."
+      action: warn   # change to deny when ready
+```
+
+Old CRs continue to reconcile normally. `normalize:` still handles them. The warning surfaces at `kubectl apply` time — at the next admission call for each CR, not at migration time.
+
+---
+
+## Try it
+
+```bash
+ork init --pack use-cases/crd-conversion/without-webhooks
+cd without-webhooks
+# Follow the steps in README
+```
+
+This runs the CronJob operator accepting both schedule formats. Apply both CRs and observe that the operator reconciles identically regardless of which shape was submitted.
+
+---
+
+## Where to go next
+
+- **[conversion.paths:](./02-conversion-paths.md)** — when the API server needs to know about two versions
+- **[Conditionals](../conditional/index.md)** — `when:` and `anyOf:` in depth

--- a/documentation/concepts/conversion/02-conversion-paths.md
+++ b/documentation/concepts/conversion/02-conversion-paths.md
@@ -1,0 +1,150 @@
+# conversion.paths:
+
+`conversion.paths:` declares how Orkestra translates a CR between API versions. The Kubernetes API server calls Orkestra Gateway's `/convert` endpoint whenever a version mismatch exists — reading a v1 object stored as v2, or writing a v2 object that will be stored as v1.
+
+No Go. No separate webhook deployment. No certificate to manage. The same Gateway that handles admission webhooks handles conversion.
+
+---
+
+## When to use it
+
+Use `conversion.paths:` when you have committed to a multi-version CRD:
+
+- External clients target a specific API version
+- You have live objects at v1 that must remain readable as v1
+- You want the API server to enforce the schema at admission time per version
+
+If you just want to tolerate different input shapes in a single-version CRD, use [`normalize:`](./01-normalize.md) instead — no webhook, no TLS, no caBundle.
+
+---
+
+## The Katalog declaration
+
+```yaml
+spec:
+  crds:
+    cronjob-v2:
+      apiTypes:
+        group: demo.orkestra.io
+        version: v2
+        kind: CronJob
+        plural: cronjobs
+
+      conversion:
+        storageVersion: v1    # all objects stored as v1
+        updateCRD: true       # Orkestra patches caBundle on startup
+
+        paths:
+          - from: v1
+            to: v2
+            spec:
+              schedule: "{{ cronToMap .spec.schedule }}"
+
+          - from: v2
+            to: v1
+            spec:
+              schedule: "{{ cronFromMap .spec.schedule }}"
+```
+
+`updateCRD: true` tells Orkestra to patch the CRD's `spec.conversion.webhook.clientConfig.caBundle` at startup with the CA certificate it generated for Gateway. You do not base64-encode anything or touch the CRD spec manually.
+
+Declare both directions. Every field that changes between versions must appear in both paths. Fields that do not change pass through unchanged with `"{{ .spec.fieldName }}"`.
+
+---
+
+## The caBundle is continuous, not one-shot
+
+Orkestra does not patch the caBundle once and hope it stays. Two mechanisms keep it current:
+
+**CRD watch** — a goroutine watches every conversion CRD for `MODIFIED` events. Any external change to the webhook config triggers an immediate re-patch. Detected within one API round-trip.
+
+**Safety ticker** — a background timer re-patches every 30 seconds as a backstop, covering anything the watch missed (stream interruption, edge cases).
+
+If someone runs a cleanup job that removes the caBundle annotation, Orkestra restores it within 30 seconds. The protection is continuous.
+
+---
+
+## What happens at conversion time
+
+When a client requests a CR at v2 and the object is stored at v1:
+
+1. API server calls `POST /convert` on Orkestra Gateway
+2. Gateway decodes the `ConversionReview`, finds the `from: v1 → to: v2` path
+3. Builds a resolver from the source object
+4. Evaluates each field expression — `cronToMap "0 2 * * 1-5"` → `{minute:"0", hour:"2", ...}`
+5. Returns the converted object with `apiVersion` updated to v2
+
+The same note expression language used in reconcile templates works in conversion paths. No separate DSL to learn.
+
+---
+
+## The participant field
+
+For the legacy version entry, set `conversion.participant: true` instead of re-declaring paths:
+
+```yaml
+cronjob-v1:
+  apiTypes:
+    group: demo.orkestra.io
+    version: v1
+    kind: CronJob
+    plural: cronjobs
+
+  conversion:
+    participant: true   # paths live on cronjob-v2; this entry joins the pair
+```
+
+`participant: true` tells the Control Center to show conversion stats for v1 without requiring you to duplicate path declarations. The v2 entry owns the paths; v1 participates.
+
+---
+
+## Observing conversions
+
+```bash
+kubectl port-forward svc/orkestra-gateway 8080:8080 -n orkestra-system
+
+curl localhost:8080/katalog/cronjob-v2 | jq '.conversion'
+```
+
+```json
+{
+  "enabled": true,
+  "total": 11279,
+  "failures": 0,
+  "avgLatencyMs": 0.59,
+  "p95LatencyMs": 0.69
+}
+```
+
+---
+
+## Production results
+
+The with-webhooks CronJob example has been run in production:
+
+| | |
+|---|---|
+| v1 → v2 conversions | 5,024 |
+| v2 → v1 conversions | 6,255 |
+| Failures | **0** |
+| v1 → v2 p95 latency | 0.69 ms |
+| v2 → v1 p95 latency | 0.49 ms |
+
+---
+
+## Try it
+
+```bash
+ork init --pack use-cases/crd-conversion/with-webhooks
+cd with-webhooks
+# Follow the steps in README
+```
+
+This runs the multi-version CronJob operator. Apply a v1 CR, read it back as v2. Apply a v2 CR, read it back as v1. The schedule field converts losslessly in both directions.
+
+---
+
+## Where to go next
+
+- **[normalize:](./01-normalize.md)** — single-version, no webhook, input tolerance
+- **[Schema Evolution](./index.md)** — pick-one table

--- a/documentation/concepts/conversion/index.md
+++ b/documentation/concepts/conversion/index.md
@@ -1,0 +1,37 @@
+# Schema Evolution
+
+Schema evolution is the problem of changing what a CR looks like over time — without breaking the operators, clients, and stored objects that depend on the current shape.
+
+Orkestra provides two approaches. The choice comes down to one question: does the Kubernetes API server need to know there are two versions?
+
+---
+
+## Two approaches
+
+**[`normalize:`](./01-normalize.md)** — the API server never sees two versions. The Katalog normalises input format variation before reconcile runs. One CRD version. No webhook. No TLS.
+
+**[`conversion.paths:`](./02-conversion-paths.md)** — the API server stores objects at one version and serves them at another. Orkestra Gateway handles `/convert`. Multi-version CRD, bidirectional, lossless.
+
+---
+
+## Pick one
+
+| | `normalize:` | `conversion.paths:` |
+|---|---|---|
+| **CRD versions** | One | Two or more |
+| **Kubernetes sees** | One schema | Multi-version CRD spec |
+| **Conversion webhook** | No | Yes — Orkestra Gateway's `/convert` |
+| **TLS required** | No | Yes — auto-generated |
+| **Objects in etcd** | One format | One storage version, served in any declared version |
+| **Best for** | Internal operators, tolerating input shape variation | Public APIs, external clients targeting a specific version, migrating live objects |
+
+If you control who creates the CRs and want to iterate quickly: `normalize:`.
+
+If external clients target a specific API version, or you have live objects at v1 that **must** remain readable as v1: `conversion.paths:`.
+
+---
+
+## Where to go next
+
+- **[normalize:](./01-normalize.md)** — input tolerance without versioning overhead
+- **[conversion.paths:](./02-conversion-paths.md)** — multi-version API with Orkestra as the conversion webhook

--- a/documentation/concepts/index.md
+++ b/documentation/concepts/index.md
@@ -78,6 +78,14 @@ The [Operator of Operators](operator-of-operators/) pattern lets one Orkestra op
 
 ---
 
+## Schema Evolution
+
+[Schema Evolution](conversion/) is how Orkestra handles CRD field changes over time — without breaking stored objects, without manual caBundle management, and without a separate conversion webhook deployment. Two approaches: `normalize:` for single-version input tolerance, `conversion.paths:` for multi-version APIs.
+
+→ [Read: Schema Evolution](conversion/)
+
+---
+
 ## Typed Operators
 
 [Typed Operators](typed-operators/) are the escape hatch for cases that genuinely need Go code: hooks that run alongside declarative templates, constructors that replace the reconciler entirely, and operator-as-library for full control.

--- a/documentation/concepts/index.md
+++ b/documentation/concepts/index.md
@@ -110,6 +110,14 @@ The [Health Subsystem](health-subsystem/) is Orkestra's liveness, readiness, and
 
 ---
 
+## Declarative Unit Testing
+
+[Declarative Unit Testing](simulate/) is how Orkestra verifies reconciler behavior without a cluster — one `simulate.yaml`, no Kubernetes, no Docker, sub-second. Declare which resources should appear in which cycle. The same reconciler that runs in production runs here.
+
+→ [Read: Declarative Unit Testing](simulate/)
+
+---
+
 ## Declarative End-to-End Testing
 
 [Declarative E2E](e2e/) is how Orkestra verifies an operator against a real cluster — one YAML file, no test framework, no Go. Every learning example ships with a runnable `e2e.yaml`. The `imports:` field composes focused per-Katalog tests into suites that a single `ork e2e` command runs end to end.

--- a/documentation/concepts/operatorbox/04-normalize/02-patterns.md
+++ b/documentation/concepts/operatorbox/04-normalize/02-patterns.md
@@ -117,7 +117,7 @@ domain: '{{ domainBare .spec.domain }}'
 
 The equivalent long-form chain (for reference):
 
-```
+```text
 {{ trimSuffix (trimPrefix (trimPrefix (trimSpace .spec.domain) "https://") "http://") "/" }}
 ```
 

--- a/documentation/concepts/profiles/04-security-profile.md
+++ b/documentation/concepts/profiles/04-security-profile.md
@@ -73,7 +73,7 @@ securityContext:
 
 **Unknown profiles fail fast.** An unrecognized name is a Katalog load error.
 
-**Capability names are validated.** When declaring explicit capabilities, every name in `capabilities.add` and `capabilities.drop` is checked against the known Linux capability set. The special value `ALL` is always accepted. See [Pod Security — validation](../security/07-pod-security.md#validation) for the full capability list.
+**Capability names are validated.** When declaring explicit capabilities, every name in `capabilities.add` and `capabilities.drop` is checked against the known Linux capability set. The special value `ALL` is always accepted. See [Pod Security — validation](../../security/07-pod-security.md#validation) for the full capability list.
 
 ---
 

--- a/documentation/concepts/simulate/01-how-it-works.md
+++ b/documentation/concepts/simulate/01-how-it-works.md
@@ -59,7 +59,3 @@ Identical consecutive cycles are collapsed. Steady state is noted but does not s
 3. Check that cycle 2 shows only `status/...`
 4. Adjust `when:` conditions, field references, or template expressions as needed
 5. When simulation is clean, run against a real cluster with `ork e2e` and then `ork run`.
-
----
-
-→ Next: [Running simulate](02-running.md)

--- a/documentation/concepts/simulate/02-simulate-kind.md
+++ b/documentation/concepts/simulate/02-simulate-kind.md
@@ -37,7 +37,7 @@ spec:
         name: my-db-backup   # optional: assert a specific resource name
 ```
 
-**`expect:` is optional.** Without it, simulate runs in op-print mode — same output as `ork simulate -f e2e.yaml`, no pass/fail. Add `expect:` when you know the sequence and want it enforced.
+**`expect:` is optional.** Without it, simulate runs in op-print mode — prints every op recorded per cycle, always exits 0. Add `expect:` when you know the sequence and want it enforced.
 
 ---
 
@@ -96,9 +96,8 @@ metadata:
   name: advanced-suite
 
 imports:
-  files:
-    - ./09-hooks/simulate.yaml
-    - ./10-constructor/simulate.yaml
+  - ./09-hooks/simulate.yaml
+  - ./10-constructor/simulate.yaml
 ```
 
 An aggregator has no `spec:`. Each imported file runs independently; the suite fails if any file fails.
@@ -166,7 +165,3 @@ Validating Simulate...
 | What is asserted | reconciler ops by cycle | Kubernetes resources in a live cluster |
 | `expect:` | ops, steady, noErrors | resource kind/name/ready/count |
 | When to use | reconciler behavior | integration truth |
-
----
-
-**Next →** [Running simulate](03-running.md)

--- a/documentation/concepts/simulate/03-init.md
+++ b/documentation/concepts/simulate/03-init.md
@@ -171,6 +171,3 @@ Simulate reads the `simulate.yaml` automatically and runs in assert mode — eve
 | `--force` | `false` | Overwrite an existing `simulate.yaml` |
 | `--dry-run` | `false` | Print to stdout instead of writing the file |
 
----
-
-→ Next: [Running simulate](03-running.md)

--- a/documentation/concepts/simulate/03-running.md
+++ b/documentation/concepts/simulate/03-running.md
@@ -1,6 +1,6 @@
 # Running simulate
 
-`ork simulate` has three invocation forms: direct flags, an e2e.yaml file, and discovery mode.
+`ork simulate` has three invocation forms: direct flags, a simulate.yaml file, and discovery mode.
 
 ---
 
@@ -20,19 +20,22 @@ ork simulate --crd database
 
 # Run exactly 5 cycles instead of the default 10
 ork simulate --cycles 5
+
+# Start the dev server at localhost:9999 before running
+ork simulate --dev-server
 ```
 
 ---
 
-## From an e2e.yaml
+## From a simulate.yaml
 
-If you already have an `e2e.yaml`, point simulate at it directly — it reads `spec.katalog` and `spec.cr` automatically:
+Point simulate at a `simulate.yaml` directly:
 
 ```bash
-ork simulate -f e2e.yaml
+ork simulate -f simulate.yaml
 ```
 
-`spec.customOperator: true` files are skipped with a note. Aggregator files (imports but no `spec.cr`) expand their imports automatically.
+A `simulate.yaml` carries its own `spec.katalog` and `spec.cr` — you do not need to pass them separately. Aggregator files (`imports:` but no `spec:`) expand their imports automatically. See [Aggregator mode](05-aggregator.md).
 
 **Multi-document CR files** are supported — separate multiple CRs with `---`. Simulate matches each CRD to the CR whose `kind` matches and seeds the remaining CRs as peers in the fake cluster, enabling `cross:` observation between them. CRDs with no matching CR in the file are skipped with a note:
 
@@ -58,36 +61,35 @@ Simulating gated-app/my-gated-app
 
 ## Discovery mode
 
-Run simulate over every e2e.yaml under the current directory:
+Run simulate over every `simulate.yaml` under the current directory:
 
 ```bash
 ork simulate ./...
 
 # Skip specific files or directories
-ork simulate ./... --skip cr-e2e.yaml
 ork simulate ./... --skip vendor,testdata
 ```
 
 Output:
 
 ```text
-Simulating 6 e2e file(s) under .
+Simulating 6 simulate file(s) under .
 
-  01-hello-website/e2e.yaml .............. ✓ steady at cycle 2 (180ms)
-  02-external-gate/e2e.yaml .............. ✓ steady at cycle 1 (120ms)  [external: inactive]
-  03-cross-crd/e2e.yaml .................. ✓ steady at cycle 3 (210ms)
-  04-secret-copy/e2e.yaml ................ ✓ steady at cycle 2 (19ms)  [cycle errors]
-  05-custom-operator/e2e.yaml ............ ○ skipped (customOperator)
-  06-custom-operator-2/e2e.yaml .......... ○ skipped (customOperator)
+  01-hello-website/simulate.yaml ......... ✓ steady at cycle 2 (180ms)
+  02-external-gate/simulate.yaml ......... ✓ steady at cycle 1 (120ms)  [external: inactive]
+  03-cross-crd/simulate.yaml ............. ✓ steady at cycle 3 (210ms)
+  04-secret-copy/simulate.yaml ........... ✓ steady at cycle 2 (19ms)  [cycle errors]
+  05-hooks/simulate.yaml ................. ✓ steady at cycle 2 (85ms)
+  06-constructor/simulate.yaml ........... ✓ steady at cycle 1 (42ms)
 
-  6 file(s) — 4 simulated, 2 skipped
+  6 file(s) — 6 simulated
   Slowest: 03-cross-crd (cycle 3, 210ms)
 
   Files with cycle errors — run directly for full output:
-    ork simulate -f 04-secret-copy/e2e.yaml
+    ork simulate -f 04-secret-copy/simulate.yaml
 ```
 
-`customOperator: true` files show as skipped. Pure aggregators (no `spec.cr`) are skipped silently — they contain no simulation target themselves. Files tagged `[cycle errors]` reached steady state but had reconcile errors on every cycle — run them directly to see the full output.
+Pure aggregators (no `spec:`) are expanded — their imports run in place. Files tagged `[cycle errors]` reached steady state but had reconcile errors on some cycle — run them directly to see the full output.
 
 ---
 
@@ -95,13 +97,10 @@ Simulating 6 e2e file(s) under .
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `-f` | `katalog.yaml` | Path to katalog.yaml or e2e.yaml |
+| `-f` | `simulate.yaml` | Path to a `simulate.yaml` or `katalog.yaml` |
 | `--cr` | `cr.yaml` | Path to the CR YAML to simulate |
 | `--crd` | all | CRD name to simulate (default: all CRDs in the Katalog) |
 | `--cycles` | `10` | Maximum number of reconcile cycles |
+| `--dev-server` | `false` | Start the Orkestra dev server at `localhost:9999` before running |
 | `--skip` | — | Comma-separated path patterns to exclude during `./...` discovery |
-| `--skip-external` | `false` | Stub `external:` HTTP calls with empty 200 responses instead of hitting the real network |
-
----
-
-→ Next: [Hooks and constructors](04-hooks-and-constructors.md)
+| `--skip-external` | `false` | Stub `external:` HTTP calls with empty 200 responses |

--- a/documentation/concepts/simulate/04-hooks-and-constructors.md
+++ b/documentation/concepts/simulate/04-hooks-and-constructors.md
@@ -72,6 +72,3 @@ When running `ork simulate` from the standard `ork` binary (not a custom operato
 
 This is still useful for verifying template logic before building the binary.
 
----
-
-→ Next: [Aggregator mode](05-aggregator.md)

--- a/documentation/concepts/simulate/05-aggregator.md
+++ b/documentation/concepts/simulate/05-aggregator.md
@@ -82,7 +82,3 @@ Use `--skip` to exclude directories or filename patterns:
 ```bash
 ork simulate ./... --skip vendor,testdata
 ```
-
----
-
-→ Next: [Limitations](06-limitations.md)

--- a/documentation/concepts/simulate/index.md
+++ b/documentation/concepts/simulate/index.md
@@ -1,4 +1,4 @@
-# Simulate
+# Declarative Unit Testing
 
 `ork simulate` runs the operator reconcile loop against a fake in-memory cluster. No Kubernetes, no `kubectl`, no network — results in milliseconds.
 
@@ -10,9 +10,9 @@
 |------|----------------|
 | [How it works](01-how-it-works.md) | The fake cluster model, same reconciler, steady state detection |
 | [simulate.yaml](02-simulate-kind.md) | The recommended entry point — schema, `expect:`, assert mode, validation |
-| [Running simulate](03-running.md) | All invocation forms: `--cr`, `-f e2e.yaml`, `./...`, flags |
+| [Running simulate](03-running.md) | All invocation forms: `--cr`, `-f simulate.yaml`, `./...`, flags |
 | [Hooks and constructors](04-hooks-and-constructors.md) | Custom binary, registry wiring, what the standard binary shows |
-| [Aggregator mode](05-aggregator.md) | `./...` discovery and aggregator simulate/e2e files |
+| [Aggregator mode](05-aggregator.md) | `./...` discovery and aggregator simulate files |
 | [Limitations](06-limitations.md) | What simulate cannot cover and what to use instead |
 
 ---
@@ -28,8 +28,16 @@ Use simulate as the fast inner loop while writing an operator. Use `ork e2e` as 
 | Requires cluster | No | Yes |
 | Runs real reconciler | Yes | Yes |
 | Tests webhooks | No | Yes |
-| Tests external calls | No (inactive) | Yes |
+| Tests external calls | Yes | Yes |
 | Speed | Milliseconds | Minutes |
 | Best for | Template correctness | System correctness |
+
+---
+
+## Where to go next
+
+- **[How it works](01-how-it-works.md)** — the fake cluster model, same reconciler, steady state detection
+- **[simulate.yaml](02-simulate-kind.md)** — schema, `expect:`, assert mode, op-print mode, validation
+- **[Running simulate](03-running.md)** — all invocation forms, `--dev-server`, `./...` discovery, flag reference
 
 → See also: [`ork simulate` CLI reference](../../reference/cli/05-simulate.md)

--- a/documentation/faqs/01-concepts.md
+++ b/documentation/faqs/01-concepts.md
@@ -67,7 +67,7 @@ conditional logic not covered by the `when:` and `anyOf:` blocks. But hooks are 
 declarative layer handles everything else.
 
 !!! note "When Go becomes necessary"
-    The 20% of operator logic that genuinely requires code — creating a user
+    The 10-20% of operator logic that genuinely requires code — creating a user
     inside PostgreSQL, reading another cluster's state
     — is handled by hooks. Hooks coexist with declarative templates. You do not
     choose one or the other.
@@ -162,6 +162,134 @@ The `spec.crds` inline block always wins on name conflict — it is the override
 mechanism. Platform teams publish Katalogs; application teams compose and override.
 
 See the [Komposer Schema](../reference/schema/03-komposer/index.md) for all options.
+
+---
+
+## Are Katalog, Komposer, Motif, E2E, and Simulate Kubernetes CRDs?
+
+No. None of them are registered as `CustomResourceDefinition` objects in the cluster.
+
+They are plain YAML files loaded from the local filesystem or OCI registry at startup. A `Katalog` struct in Go has no `metav1.TypeMeta`, no `metav1.ObjectMeta`, no `DeepCopyObject()`. The Katalog loader calls `os.ReadFile()` and `yaml.Unmarshal()` — no Kubernetes client, no API server call.
+
+The same applies to Komposer, Motif, E2E, and Simulate. They are instruction sets for the runtime. They live on disk and in OCI artifacts, not in etcd.
+
+!!! note "The Artifact Hub display metadata"
+    `charts/orkestra/Chart.yaml` lists these types under `artifacthub.io/crds` — that is Artifact Hub display metadata only. The Helm chart deploys no CRD YAML for any of them.
+
+→ [Why Katalog and Komposer are not CRDs](./05-why-not-crds.md) — the full design reasoning
+
+---
+
+## What is a Motif?
+
+A Motif is a reusable operatorBox fragment. It packages everything one pattern of operator behavior needs — resources, status fields, validation rules, mutation rules — under a named, parameterized declaration. Katalogs import Motifs instead of repeating those declarations.
+
+A Motif can declare:
+
+- **`resources:`** — Kubernetes and custom resources to create (`deployments`, `statefulSets`, `services`, `custom`, and more), split into `onCreate` and `onReconcile` phases
+- **`status:`** — status fields merged into the importing CRD's status layer
+- **`admission:`** — validation and mutation rules contributed alongside the Katalog's own rules
+
+```yaml
+apiVersion: orkestra.orkspace.io/v1
+kind: Motif
+metadata:
+  name: postgres
+  version: v1
+
+inputs:
+  - name: image
+    required: true
+  - name: volumeSize
+    default: "10Gi"
+
+resources:
+  statefulSets:
+    - name: "{{ .metadata.name }}-db"
+      image: "{{ index .inputs \"image\" }}"
+      storageSize: "{{ index .inputs \"volumeSize\" }}"
+
+status:
+  fields:
+    - path: dbEndpoint
+      value: "{{ .metadata.name }}-db.{{ .metadata.namespace }}.svc.cluster.local"
+
+admission:
+  validation:
+    rules:
+      - field: spec.image
+        operator: exists
+        message: "spec.image is required"
+        action: deny
+```
+
+A Katalog imports it with `with:` bindings:
+
+```yaml
+operatorBox:
+  imports:
+    - motif: postgres
+      with:
+        image: "{{ .spec.dbImage }}"
+        volumeSize: "{{ .spec.storage }}"
+```
+
+Orkestra expands the Motif at Katalog load time — bindings resolved, resources and rules merged into the operatorBox as if declared inline.
+
+Publish a Motif by pushing its directory to the registry:
+
+```bash
+ork registry push postgres:v1 ./motifs/postgres/
+```
+
+Import it in a Katalog by OCI address, or by bare name if `ORK_MOTIFS_REGISTRY` is set:
+
+```yaml
+operatorBox:
+  imports:
+    - motif: ghcr.io/myorg/motifs/postgres:v1   # full OCI ref
+    - motif: postgres                            # bare name — resolved via ORK_MOTIFS_REGISTRY
+```
+
+Motifs can share the same registry address as Katalogs — separate them with folders (`/katalogs/`, `/motifs/`) rather than separate registries.
+
+→ [Motif schema reference](../reference/schema/01-motif/index.md)
+
+---
+
+## What is the note expression language?
+
+Notes are the pure transformation functions available inside every `{{ }}` expression in a Katalog — `onCreate`, `onReconcile`, `status.fields`, `when:` conditions, `normalize:`, `mutation:`, `conversion.paths:`.
+
+```yaml
+status:
+  fields:
+    - path: phase
+      value: '{{ boolTernary .spec.suspend "Suspended" "Active" }}'
+    - path: endpoint
+      value: "{{ .metadata.name }}.{{ .metadata.namespace }}.svc.cluster.local"
+
+onCreate:
+  secrets:
+    - name: "{{ .metadata.name }}-creds"
+      once: true
+      data:
+        password: "{{ randomAlphanumeric 32 }}"
+```
+
+Notes are **pure** (same input → same output), **safe** (nil/empty input never panics), and **stateless** (no I/O, no external calls). They are not Go `text/template` — they are a separate vocabulary built on top of it.
+
+There are over 100 notes across domains: strings, math, conditionals, type coercion, cron expressions, random generation, Kubernetes object navigation, replica state, Job lifecycle, Service networking, and more.
+
+Discover them from the terminal:
+
+```bash
+ork notes                      # list all notes
+ork notes search job           # search by keyword
+ork notes show jobSucceeded    # full detail and example
+```
+
+→ [Notes reference](../reference/orkestra-notes/index.md)
 
 ---
 

--- a/documentation/faqs/02-running.md
+++ b/documentation/faqs/02-running.md
@@ -143,6 +143,36 @@ This produces a scoped ClusterRole, ClusterRoleBinding, and a ConfigMap containi
 
 ---
 
+## What does `ork generate bundle` do, and when do I re-run it?
+
+`ork generate bundle` reads your Katalog and produces a single YAML document stream — ready to apply — containing:
+
+- **ServiceAccounts** for runtime, gateway and control center
+- **ClusterRole** with the minimal permissions derived from your Katalog
+- **ClusterRoleBinding**
+- **ConfigMap** embedding the Katalog itself
+
+```bash
+ork generate bundle --file katalog.yaml -o bundle.yaml
+kubectl apply -f bundle.yaml
+```
+
+The ClusterRole is derived, not hand-written: only the API groups declared in your Katalog, only the verbs those resources actually need. If your operator creates no Deployments, the runtime has no `apps/deployments` permission.
+
+**Re-run it every time the Katalog changes.** Adding a CRD, a new resource type, or a new API group makes the deployed bundle stale — the runtime will lack the permissions it now needs. Run it in CI alongside `ork validate`:
+
+```bash
+ork validate --full   # preview exact permissions per CRD per component
+ork generate bundle --file katalog.yaml -o bundle.yaml
+```
+
+Both commands run entirely offline. No cluster connection required.
+
+!!! tip "GitOps"
+    Commit `bundle.yaml` to your repository. A diff on the bundle in code review makes every RBAC change visible and reviewable before it reaches the cluster.
+
+---
+
 ## How do I debug a CRD in production?
 
 Use the **Control Center** — it gives you a full view of all CRDs, worker pools, queue depth, reconcile metrics, and dependency health without any additional tooling.
@@ -181,6 +211,39 @@ The most common issues:
 
 ---
 
+## What is the Control Center?
+
+The Control Center is a web UI that reads directly from the Orkestra runtime APIs — no instrumentation, no custom metrics, no extra cluster resources. Start it locally with:
+
+```bash
+ork control
+# Opens at http://localhost:8081
+```
+
+Five views, each a drill-down from the last:
+
+| View | What it shows |
+|---|---|
+| **Control Center** | All Katalogs from all configured runtimes on one page |
+| **Control Panel** | Per-Katalog: CRD cards, worker pools, queue pressure, error rates |
+| **CRD Detail** | Per-CRD: every worker's state, RBAC, dependencies, admission metrics |
+| **Resources** | Live CR list for that CRD — the actual objects being reconciled |
+| **CR Detail** | Single CR: status fields, conditions, and child Kubernetes resources (grouped by kind, each with ready state and replica counts) |
+
+To watch multiple clusters at once:
+
+```bash
+ork control --urls "http://cluster1:8080,http://cluster2:8080"
+```
+
+The Control Center holds no state of its own. It polls `/katalog`, `/katalog/{crd}`, and `/katalog/{crd}/health` on each runtime and renders the results. Refresh interval defaults to 10 seconds (`--refresh 5s` to tighten it).
+
+Default credentials are `orkestra` / `orkestra`. Set `ADMIN_USERNAME`, `ADMIN_PASSWORD`, and `SESSION_SECRET` environment variables before exposing it beyond localhost.
+
+→ [Control Center reference](../orkestra-core/03-controlcenter/)
+
+---
+
 ## Is Orkestra safe for production?
 
 Yes. Orkestra is designed for and demonstrated in production.
@@ -199,6 +262,22 @@ Yes. Orkestra is designed for and demonstrated in production.
 
 See [Trust and Failure Model](/publications/trust-and-failure-model/) for every
 failure mode, what it means, and how Orkestra handles it.
+
+---
+
+## Does the deletion protection webhook protect Orkestra itself?
+
+Yes — including the webhook itself.
+
+Every resource Orkestra deploys via Helm carries `orkestra.io/deletion-protection: "true"` from installation. The webhook intercepts every DELETE request and blocks any resource carrying that label — the runtime Deployment, the gateway Deployment, the control center, all Services.
+
+The self-protection loop: the webhook also blocks deletion of its own `ValidatingWebhookConfiguration`. You cannot delete the webhook while it is running, because the webhook intercepts its own deletion request.
+
+In full runtime mode, if the protection label is manually removed from a resource, the reconciler detects the drift on the next reconcile cycle and reapplies it. The label is treated as desired state, same as any other field in the Katalog.
+
+!!! note "Gateway-only mode"
+    Without `ork run`, the webhook still blocks deletions — but there is no reconciler to restore labels if they are manually removed. In gateway-only mode you are responsible for maintaining protection labels yourself.
+    You can enable `strictMode` in this case.
 
 ---
 

--- a/documentation/faqs/03-usage.md
+++ b/documentation/faqs/03-usage.md
@@ -125,6 +125,180 @@ See [CRD Entry Schema](../reference/schema/02-katalog/02-crd-entry.md) for the f
 
 ---
 
+## What does `forEach` do?
+
+`forEach` expands one resource declaration into N resources — one per element in a list field on the CR spec. Each iteration element is bound to a name and available as a template variable alongside the parent CR's fields.
+
+```yaml
+# CR spec
+spec:
+  replicationFactor: 3
+  shards:
+    - name: us-east
+      region: us-east-1
+      size: 50Gi
+    - name: eu-west
+      region: eu-west-1
+      size: 50Gi
+
+# Katalog
+onCreate:
+  custom:
+    - apiVersion: storage.example.io/v1alpha1
+      kind: Shard
+      forEach:
+        field: spec.shards   # iterate over this list
+        as: shard            # bind each element as .shard
+      metadata:
+        name: "{{ .metadata.name }}-{{ .shard.name }}"
+        namespace: "{{ .metadata.namespace }}"
+        namespaced: true
+      spec:
+        region: "{{ .shard.region }}"
+        size: "{{ .shard.size }}"
+        replicationFactor: "{{ .spec.replicationFactor }}"
+```
+
+This creates two `Shard` CRs — `my-store-us-east` and `my-store-eu-west` — from a single declaration. If the parent CR's `spec.shards` is updated at runtime, Orkestra adds new entries and deletes removed ones on the next reconcile.
+
+`forEach` works on the `custom:` block (Custom Resources) and on standard resource blocks (`deployments:`, `services:`, etc.).
+
+Try it:
+
+```bash
+ork init --pack advanced/16-custom-resources
+cd 05-forEach-sharding
+# Follow the steps in README
+```
+
+---
+
+## What is the difference between `normalize:` and `conversion.paths:`?
+
+Both use note expressions to transform CR fields, but they solve different problems.
+
+**`normalize:`** — runs in-memory before every reconcile. The raw CR in etcd is unchanged. Kubernetes never sees two versions of the CRD. Use it when you want to tolerate input shape variation within a single schema version:
+
+```yaml
+normalize:
+  spec:
+    schedule: "{{ cronFromAny .spec.schedule }}"
+    # accepts both "*/5 * * * *" and {minute:"*/5", hour:"*",...}
+    # downstream templates always see a plain cron string
+```
+
+No webhook registration. No TLS. No infrastructure cost.
+
+**`conversion.paths:`** — runs in the gateway's `/convert` HTTPS endpoint, called by the Kubernetes API server. Use it when you have a real multi-version CRD (`v1`, `v2`) and need Kubernetes to translate between stored and requested versions:
+
+```yaml
+conversion:
+  storageVersion: v1
+  updateCRD: true
+  paths:
+    - from: v1
+      to: v2
+      spec:
+        schedule: "{{ cronToMap .spec.schedule }}"
+```
+
+The rule: if you control the CRD and want to tolerate different input shapes — `normalize:`. If you have committed to multiple API versions and need the API server to convert between them — `conversion.paths:`.
+
+→ [Schema Evolution](../concepts/conversion/index.md)
+
+---
+
+## When do I need Go hooks?
+
+The `external:` block handles HTTP already — GET, POST, bearer tokens, chained calls where each result flows into the next via `.external.{name}.body`. `when:` and `anyOf:` handle conditional logic. For most operators, those are enough.
+
+Hooks become necessary when the work is genuinely outside HTTP:
+
+- **Non-HTTP protocols** — gRPC, database connections, message queue operations, anything that isn't an HTTP endpoint
+- **Complex computed fields from non-HTTP sources** — deriving values that require SDK calls, database queries, or binary protocols where there is no HTTP endpoint to call
+
+For AWS, GCP, and Stripe — providers are in development for common SDK integrations (`aws:`, `gcp:`, `stripe:` blocks in the Katalog). Until a provider covers your case, hooks are the path.
+
+Hooks are additive: the hook runs, then Orkestra applies `onCreate`/`onReconcile` templates as normal. The template layer does not disappear.
+
+```yaml
+operatorBox:
+  default: true   # GenericReconciler still runs; hooks are additive
+
+  hooks:
+    location: github.com/myorg/database-operator/hooks
+    function: DatabaseHooks
+```
+
+Try it:
+
+```bash
+ork init --pack advanced/09-hooks
+cd 09-hooks
+# Follow the steps in README
+```
+
+→ [Typed Operators — Hooks](../concepts/typed-operators/01-hooks.md)
+
+---
+
+## When do I need a constructor?
+
+When you need to own the full reconcile loop — typically when integrating an existing operator without rewriting it.
+
+```yaml
+operatorBox:
+  default: false   # GenericReconciler is replaced; constructor owns everything
+```
+
+`default: false` is the one field change that replaces the entire reconciler. Your constructor receives Orkestra's `KubeClient` and informer — no `controller-runtime` required. Declarative templates (`onCreate`, `onReconcile`, `status.fields`) are not applied when `default: false`; the constructor is responsible for all state.
+
+Try it:
+
+```bash
+ork init --pack advanced/10-constructor
+cd 10-constructor
+# Follow the steps in README
+```
+
+→ [Typed Operators — Constructor](../concepts/typed-operators/02-constructor.md)
+
+---
+
+## Can I mix declarative, hooks, and constructor operators in one binary?
+
+Yes. Each CRD in a Katalog or Komposer can use a different mode. One binary, one process:
+
+```yaml
+# komposer.yaml
+spec:
+  crds:
+    database:          # typed hooks — Go SDK calls alongside declarative templates
+      workers: 5
+    website:           # dynamic — pure YAML, no Go
+      dependsOn:
+        database:
+          condition: healthy
+    pipeline:          # constructor — full custom reconciler
+      dependsOn:
+        website:
+          condition: started
+```
+
+You promote along a single axis: start pure YAML, add `hooks:` when you need Go logic, flip `default: false` when you need full control. No project restructure. No framework switch.
+
+Try it:
+
+```bash
+ork init --pack advanced/11-mixed-operator-pattern
+cd 11-mixed-operator-pattern
+# Follow the steps in README
+```
+
+→ [Typed Operators — Mixing all three](../concepts/typed-operators/03-mixed.md)
+
+---
+
 ## Next
 
 - **[Running](./02-running.md)** — setup, configuration, and operations

--- a/documentation/faqs/04-ecosystem.md
+++ b/documentation/faqs/04-ecosystem.md
@@ -8,7 +8,7 @@ The real question is what you do when you need an operator — when drift correc
 
 At that point you drop into Go. And every team that does this builds the same machinery, from scratch, for every operator: informers, workqueues, leader election, worker pools, health endpoints, Prometheus metrics, retry logic, finalizers, status management, safe panic recovery, multi-version CRD handling, admission and deletion protection.
 
-That machinery is not the reason the operator exists. It is the cost of entry.
+**That machinery is not the reason the operator exists. It is the cost of entry.**
 
 Orkestra says: the machinery is the runtime's job. You focus on the reason the operator exists — your custom logic.
 
@@ -33,7 +33,7 @@ Both Kubebuilder and Operator SDK are scaffolding frameworks. They generate the 
 
 You still own the machinery. Queue depth, worker count, leader election lease, health endpoints, Prometheus metrics, retry logic, panic recovery — all of it is yours to configure, test, and maintain. Kubebuilder scaffolds it. You own it.
 
-Orkestra is a runtime. You do not write controllers. The machinery is the runtime's job.
+**Orkestra is a runtime. You do not write controllers. The machinery is the runtime's job.**
 
 | | Kubebuilder / Operator SDK | Orkestra |
 |---|---|---|
@@ -112,7 +112,6 @@ is the end state. At that point, every cluster ships with a meta-controller that
 understands declarative operator definitions. Platform teams write Katalogs. Kubernetes
 manages them.
 
----
 
 ## Next
 

--- a/documentation/faqs/06-testing.md
+++ b/documentation/faqs/06-testing.md
@@ -73,6 +73,31 @@ This lets examples that call external services (config injection, feature flags,
 
 ---
 
+## What does `--debug-ops` do?
+
+`--debug-ops` prints every operation the reconciler performed across every cycle before the assertion output — the full picture of what your operator actually did:
+
+```text
+  [debug-ops] 7 total ops recorded across all cycles:
+  [debug-ops]   cycle=1   verb=create   resource=deployments         name=my-website
+  [debug-ops]   cycle=1   verb=create   resource=services            name=my-website
+  [debug-ops]   cycle=2   verb=update   resource=deployments         name=my-website
+  [debug-ops]   cycle=3   verb=get      resource=deployments         name=my-website
+```
+
+Use it to understand what your operator does before writing assertions. The intended authoring workflow:
+
+```bash
+ork simulate --debug-ops     # see every op across all cycles
+ork simulate init            # capture cycle-1 creates as assertions automatically
+# edit simulate.yaml         # add absent: blocks, later cycles, edge cases
+ork registry push            # simulate gate runs these assertions before publish
+```
+
+`--debug-ops` works in all three invocation modes: direct flags, a `simulate.yaml` file, and `./...` discovery.
+
+---
+
 ## Can I run simulate for multiple operators at once?
 
 Yes — with an aggregator. A `simulate.yaml` with `imports:` and no `spec:` runs each imported file independently:
@@ -107,7 +132,6 @@ Yes. `ork simulate` uses the same reconciler pipeline that runs against a live c
 
 If a test passes in simulate, the reconciler logic is correct. What you cannot verify in simulate: admission webhook behavior end-to-end, network policies, actual pod scheduling, and anything that depends on Kubernetes controllers running (e.g. ReplicaSet → Pod creation). That is what `ork e2e` is for.
 
----
 
 ## Next
 

--- a/documentation/faqs/index.md
+++ b/documentation/faqs/index.md
@@ -7,9 +7,12 @@ Core concepts — what Orkestra is, how it works, and how it compares.
 - What is Orkestra?
 - Is Orkestra an operator?
 - Does Orkestra install my CRDs?
+- Are Katalog, Komposer, Motif, E2E, and Simulate Kubernetes CRDs?
 - Do I need to write Go code?
 - How does Orkestra differ from Helm or Kustomize?
 - What is a Katalog? What is a Komposer?
+- What is a Motif?
+- What is the note expression language?
 - What is the OrkestraRegistry?
 - What is the super-operator model?
 - Does Orkestra support multi-version CRDs?
@@ -26,8 +29,11 @@ Setup, configuration, operations, and RBAC.
 - Does Orkestra require cert-manager?
 - What environment variables does Orkestra read?
 - What RBAC permissions does Orkestra need?
+- What does `ork generate bundle` do, and when do I re-run it?
 - How do I debug a CRD in production?
+- What is the Control Center?
 - Is Orkestra safe for production?
+- Does the deletion protection webhook protect Orkestra itself?
 - What happens when Orkestra restarts?
 
 ---
@@ -41,6 +47,11 @@ Common usage patterns — built-in kinds, validation, mutation, conditions.
 - Does `ENABLE_ADMISSION_WEBHOOK=true` block the API server if Orkestra is down?
 - How do I use `when:` conditions?
 - How does `dependsOn` ordering work?
+- What does `forEach` do?
+- What is the difference between `normalize:` and `conversion.paths:`?
+- When do I need Go hooks?
+- When do I need a constructor?
+- Can I mix declarative, hooks, and constructor operators in one binary?
 
 ---
 
@@ -63,6 +74,7 @@ Simulate, E2E, and the testing tools.
 - How do I test an Orkestra operator?
 - What is the difference between `ork simulate` and `ork e2e`?
 - How do I generate a `simulate.yaml`?
+- What does `--debug-ops` do?
 - What does `skipExternal: true` do?
 - What is `ork simulate --dev-server`?
 - Can I run simulate for multiple operators at once?

--- a/documentation/orkestra-core/03-controlcenter/index.md
+++ b/documentation/orkestra-core/03-controlcenter/index.md
@@ -17,6 +17,8 @@ Open [http://localhost:8081](http://localhost:8081).
 - **Control Center** — the global view. All Katalogs from all configured runtimes on one page.
 - **Control Panel** — per-Katalog drill-down. CRD cards, worker pools, queue pressure, error rates.
 - **CRD Detail** — per-CRD deep dive. Every worker's state, RBAC permissions, dependencies, admission metrics.
+- **Resources** — live CR list for that CRD. The actual objects being reconciled.
+- **CR Detail** — single CR view. Status fields, conditions, and child Kubernetes resources created by the reconciler, grouped by kind with ready state and replica counts.
 
 ---
 
@@ -50,8 +52,8 @@ ork control --ignore-default
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `ADMIN_USERNAME` | Login username | `admin` |
-| `ADMIN_PASSWORD` | Login password | `admin` |
+| `ADMIN_USERNAME` | Login username | `orkestra` |
+| `ADMIN_PASSWORD` | Login password | `orkestra` |
 | `SESSION_SECRET` | Cookie signing secret | `dev-secret` |
 | `ORK_CC_PORT` | Override port | `8081` |
 | `ORK_CC_REFRESH` | Override refresh interval | `10s` |

--- a/documentation/reference/orkestra-notes/index.md
+++ b/documentation/reference/orkestra-notes/index.md
@@ -2,7 +2,7 @@
 
 Notes are pure transformation functions available in every `{{ }}` expression across a Katalog — status fields, `when:` conditions, resource names, `onCreate`, `onReconcile`, mutation rules, conversion paths. They are the vocabulary of declarative operator behavior.
 
-**Contract:** pure (same input → same output), safe (nil/empty input never panics), stateless (no I/O, no side effects). Use katalog `external` block or [hooks](../typed-operators/01-hooks.md) for anything requiring external calls.
+**Contract:** pure (same input → same output), safe (nil/empty input never panics), stateless (no I/O, no side effects). Use katalog `external` block or [hooks](../../concepts/typed-operators/01-hooks.md) for anything requiring external calls.
 
 ---
 

--- a/documentation/reference/schema/01-motif/index.md
+++ b/documentation/reference/schema/01-motif/index.md
@@ -174,4 +174,4 @@ ork registry list --kind Motif
 - [Katalog schema](../02-katalog/01-top-level.md) — where `imports:` lives on the CRD entry
 - [operatorBox](../02-katalog/04-operatorbox.md) — the Katalog's own resources, merged alongside Motif resources
 - [Komposer schema](../03-komposer/index.md) — composing multiple Katalogs
-- [Orkestra Registry](../../../orkestra-registry.md) — publishing and consuming Motifs
+- [Orkestra Registry](../../../orkestra-registry/index.md) — publishing and consuming Motifs

--- a/documentation/reference/schema/02-katalog/13-external.md
+++ b/documentation/reference/schema/02-katalog/13-external.md
@@ -124,4 +124,4 @@ operatorBox:
         value: "{{ .external.healthCheck.status }}"
 ```
 
-See the [External concept doc](../../concepts/operatorbox/07-external/index.md) for patterns and best practices.
+See the [External concept doc](../../../concepts/operatorbox/07-external/index.md) for patterns and best practices.

--- a/documentation/reference/schema/02-katalog/index.md
+++ b/documentation/reference/schema/02-katalog/index.md
@@ -89,4 +89,4 @@ This scaffolds the simplest Katalog — a single CRD that creates a Deployment a
 - [Motif schema](../01-motif/index.md) — reusable resource blocks imported by Katalogs
 - [Komposer schema](../03-komposer/index.md) — composing multiple Katalogs
 - [E2E schema](../04-e2e/index.md) — testing a Katalog
-- [Orkestra Registry](../../../orkestra-registry.md) — publishing and consuming Katalogs
+- [Orkestra Registry](../../../orkestra-registry/index.md) — publishing and consuming Katalogs

--- a/documentation/support.md
+++ b/documentation/support.md
@@ -15,7 +15,7 @@ Most questions are answered in:
 - **Orkestra logs** — structured JSON logs with `crd`, `cr`, and `error` fields
 - **Existing GitHub issues** — search before opening a new one
 
-The `/katalog/{crd}` endpoint resolves the majority of operational questions without any external help. For a full live view, use the [Control Center](./controlcenter/controlcenter.md).
+The `/katalog/{crd}` endpoint resolves the majority of operational questions without any external help. For a full live view, use the [Control Center](./orkestra-core/03-controlcenter/index.md).
 
 ---
 
@@ -72,7 +72,7 @@ solution.
 
 !!! warning "Do not open public GitHub issues for security vulnerabilities"
 
-See the [Security](./security.md) page for responsible disclosure instructions.
+See the [Security](./security/) page for responsible disclosure instructions.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Schema Evolution** — new `concepts/conversion/` section (3 pages) covering `normalize:` vs `conversion.paths:` with decision table, pipeline diagrams, and Try-it packs
- **FAQ expansion** — new questions across concepts, usage, and testing: Motif structure, note language, `forEach`, `normalize:` vs `conversion.paths:`, hooks/constructor/mixed operators, `--debug-ops`
- **Control Center** — new FAQ covering all five views, multi-runtime setup, and default credentials; reference doc corrected to match source
- **Broken link fixes** — seven genuinely broken internal links repaired (wrong depths, wrong section roots, missing folder slashes)
- **Code fence and command fixes** — two bare opening fences tagged `text`; Motif registry commands corrected to directory push / OCI address import

## Test plan

- [x] Run sync script and verify all links resolve on rendered site
- [x] Check `concepts/conversion/` renders as a section with index + two sub-pages
- [x] Verify Control Center FAQ appears in `02-running.md` between debug and production FAQ
- [x] Confirm no bare ` ``` ` opening fences remain in modified files
