### PR TITLE
feat(registry): typed annotations, deprecation struct, plan defaults fix

### DIFF
--- a/cmd/cli/registry_info.go
+++ b/cmd/cli/registry_info.go
@@ -36,6 +36,15 @@ var registryInfoCmd = &cobra.Command{
 		}
 
 		m := info.Meta
+		if m.Deprecated != nil {
+			fmt.Printf("\n%s  This pattern is deprecated.\n", yellow("⚠"))
+			if m.Deprecated.MigratedTo != "" {
+				fmt.Printf("  Migrate to:  %s\n", bold(m.Deprecated.MigratedTo))
+			}
+			if m.Deprecated.Message != "" {
+				fmt.Printf("  Note:        %s\n", m.Deprecated.Message)
+			}
+		}
 		fmt.Printf("\n%s:%s\n", m.Name, m.Version)
 		fmt.Printf("  Registry:    %s\n", ref.Registry)
 		if m.Kind != "" {
@@ -93,6 +102,19 @@ var registryInfoCmd = &cobra.Command{
 			}
 		} else {
 			fmt.Printf("  E2E:         %s\n", e2eNotVerified())
+		}
+		if m.Typed != nil {
+			parts := []string{}
+			if m.Typed.HasHooks {
+				parts = append(parts, "hooks")
+			}
+			if m.Typed.HasConstructor {
+				parts = append(parts, "constructor")
+			}
+			fmt.Printf("  Typed:       %s · %s\n",
+				green("✓ "+strings.Join(parts, ", ")),
+				yellow("requires custom runtime image"),
+			)
 		}
 		fmt.Printf("\nTo pull:\n")
 		fmt.Printf("  ork registry pull %s:%s\n", m.Name, m.Version)

--- a/cmd/cli/registry_list.go
+++ b/cmd/cli/registry_list.go
@@ -116,7 +116,11 @@ var registryListCmd = &cobra.Command{
 			case "skipped":
 				e2eBadge = "~"
 			}
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", e.Name, e.LatestVersion, k, e2eBadge, tags, desc)
+			name := e.Name
+			if e.Deprecated {
+				name = yellow("⚠") + " " + name
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", name, e.LatestVersion, k, e2eBadge, tags, desc)
 			count++
 		}
 		w.Flush()

--- a/cmd/cli/registry_push.go
+++ b/cmd/cli/registry_push.go
@@ -225,6 +225,12 @@ var registryPushCmd = &cobra.Command{
 			}
 		}
 
+		// Detect typed annotations for katalog patterns.
+		var typedMeta *registry.PatternTyped
+		if patternKind == registry.KatalogKind {
+			typedMeta = detectTypedKatalog(filepath.Join(dir, registry.FileKatalog))
+		}
+
 		client, err := registry.NewClient()
 		if err != nil {
 			return fmt.Errorf("initializing client: %w", err)
@@ -234,7 +240,7 @@ var registryPushCmd = &cobra.Command{
 			fmt.Printf("  → %-20s (%s)\n", file, formatSize(size))
 		}
 
-		digest, err := client.Push(cmd.Context(), ref, dir, e2eMeta, simulateMeta, progress)
+		digest, err := client.Push(cmd.Context(), ref, dir, e2eMeta, simulateMeta, typedMeta, progress)
 		if err != nil {
 			return fmt.Errorf("push failed: %w", err)
 		}
@@ -250,7 +256,7 @@ var registryPushCmd = &cobra.Command{
 				motifRef, err := registry.ResolveForKind(fmt.Sprintf("%s:%s", meta.Name, meta.Version), registry.MotifKind)
 				if err == nil {
 					fmt.Printf("\nAlso pushing %s to %s...\n", registry.FileMotif, motifRef.Registry)
-					if mDigest, err := client.Push(cmd.Context(), motifRef, dir, nil, nil, progress); err != nil {
+					if mDigest, err := client.Push(cmd.Context(), motifRef, dir, nil, nil, nil, progress); err != nil {
 						fmt.Fprintf(os.Stderr, "warning: motif push failed: %v\n", err)
 					} else {
 						fmt.Printf("%s Pushed motif: %s\n", successMark(), motifRef.String())
@@ -273,6 +279,32 @@ var registryPushCmd = &cobra.Command{
 		_ = meta
 		return nil
 	},
+}
+
+// detectTypedKatalog parses a katalog.yaml and returns a PatternTyped if any
+// CRD declares customHooks or customConstructor. Returns nil on parse error.
+func detectTypedKatalog(katalogPath string) *registry.PatternTyped {
+	k, err := katalog.ParseFile(katalogPath)
+	if err != nil {
+		return nil
+	}
+	var t registry.PatternTyped
+	for _, name := range k.CRDNames() {
+		entry, ok := k.CRDEntry(name)
+		if !ok {
+			continue
+		}
+		if entry.CustomHooksEnabled() {
+			t.HasHooks = true
+		}
+		if entry.ConstructorEnabled() {
+			t.HasConstructor = true
+		}
+	}
+	if !t.HasHooks && !t.HasConstructor {
+		return nil
+	}
+	return &t
 }
 
 // simulateFileHasAssertions returns true when simulate.yaml contains an

--- a/pkg/konfig/type.go
+++ b/pkg/konfig/type.go
@@ -197,7 +197,11 @@ func NewDefaultKonfig() *Konfig {
 			writeTimeout: 5 * time.Second,
 		},
 		katalog: katalogKonfig{
-			paths: []string{"katalog.yaml"},
+			paths:                   []string{"katalog.yaml"},
+			defaultWorkers:          GetIntEnv("DEFAULT_WORKERS", 3),
+			defaultResync:           GetDurEnvSeconds("DEFAULT_RESYNC", 15),
+			defaultQueueDepth:       GetIntEnv("QUEUE_DEPTH", 100),
+			defaultFailureThreshold: GetIntEnv("FAILURE_THRESHOLD", 5),
 		},
 	}
 }

--- a/pkg/merger/registry.go
+++ b/pkg/merger/registry.go
@@ -35,6 +35,7 @@ var knownPatternFiles = []string{
 	pkgregistry.FileReadme,
 	pkgregistry.FileCR,
 	pkgregistry.FileE2E,
+	pkgregistry.FileSimulate,
 }
 
 // loadRegistrySource loads a single registry pattern entry.
@@ -90,6 +91,17 @@ func (m *Merger) loadRegistrySource(src orktypes.RegistrySource) (map[string]ork
 			"registry %q@%s: %s is not a valid Katalog or Komposer document",
 			cleanURL, version, src.SourceFile(),
 		)
+	}
+
+	if dep := doc.Metadata.Deprecation; dep != nil {
+		msg := fmt.Sprintf("warning: registry pattern %q@%s is deprecated", cleanURL, version)
+		if dep.MigratedTo != "" {
+			msg += fmt.Sprintf(" — migrate to: %s", dep.MigratedTo)
+		}
+		if dep.Message != "" {
+			msg += fmt.Sprintf(" (%s)", dep.Message)
+		}
+		fmt.Fprintln(os.Stderr, msg)
 	}
 
 	switch doc.Kind {

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -26,6 +26,7 @@ import (
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/file"
 	"oras.land/oras-go/v2/content/memory"
+
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/credentials"
@@ -50,9 +51,10 @@ func NewClient() (*Client, error) {
 
 // Push validates the directory, auto-detects the pattern kind, and pushes all
 // files to the registry. Returns the manifest digest on success.
-// e2eMeta is optional; when non-nil its fields are embedded as io.orkestra.e2e.*
-// OCI annotations on the published artifact.
-func (c *Client) Push(ctx context.Context, ref *Ref, dir string, e2eMeta *PatternE2E, simulateMeta *PatternSimulate, progress func(file string, size int64)) (string, error) {
+// e2eMeta and simulateMeta are optional; when non-nil their fields are embedded
+// as OCI annotations on the published artifact.
+// typedMeta is optional; when non-nil it is written as typed-operator annotations.
+func (c *Client) Push(ctx context.Context, ref *Ref, dir string, e2eMeta *PatternE2E, simulateMeta *PatternSimulate, typedMeta *PatternTyped, progress func(file string, size int64)) (string, error) {
 	patternKind, spec, files, err := ValidatePatternDirectory(dir)
 	if err != nil {
 		return "", fmt.Errorf("validation failed: %w", err)
@@ -68,6 +70,9 @@ func (c *Client) Push(ctx context.Context, ref *Ref, dir string, e2eMeta *Patter
 	}
 	if simulateMeta != nil {
 		meta.Simulate = simulateMeta
+	}
+	if typedMeta != nil {
+		meta.Typed = typedMeta
 	}
 
 	store := memory.New()
@@ -127,6 +132,9 @@ func (c *Client) Push(ctx context.Context, ref *Ref, dir string, e2eMeta *Patter
 	}
 	if meta.Simulate != nil {
 		entry.SimulateStatus = meta.Simulate.Status
+	}
+	if meta.Deprecated != nil {
+		entry.Deprecated = true
 	}
 	if err := c.updateIndex(ctx, ref, entry); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: index update failed: %v\n", err)
@@ -394,6 +402,26 @@ func artifactMetaToAnnotations(meta *PatternMeta, ref *Ref) map[string]string {
 			ann["io.orkestra.simulate.tested_at"] = meta.Simulate.TestedAt
 		}
 	}
+	if meta.Typed != nil {
+		if meta.Typed.HasHooks {
+			ann["io.orkestra.katalog.has_hooks"] = "true"
+		}
+		if meta.Typed.HasConstructor {
+			ann["io.orkestra.katalog.has_constructor"] = "true"
+		}
+		if meta.Typed.HasHooks || meta.Typed.HasConstructor {
+			ann["io.orkestra.katalog.typed"] = "true"
+		}
+	}
+	if meta.Deprecated != nil {
+		ann["io.orkestra.katalog.deprecated"] = "true"
+		if meta.Deprecated.MigratedTo != "" {
+			ann["io.orkestra.katalog.deprecated.migrated_to"] = meta.Deprecated.MigratedTo
+		}
+		if meta.Deprecated.Message != "" {
+			ann["io.orkestra.katalog.deprecated.message"] = meta.Deprecated.Message
+		}
+	}
 	return ann
 }
 
@@ -445,6 +473,18 @@ func annotationsToMeta(ann map[string]string) *PatternMeta {
 			Status:   status,
 			Duration: ann["io.orkestra.simulate.duration"],
 			TestedAt: ann["io.orkestra.simulate.tested_at"],
+		}
+	}
+	if ann["io.orkestra.katalog.typed"] == "true" {
+		meta.Typed = &PatternTyped{
+			HasHooks:       ann["io.orkestra.katalog.has_hooks"] == "true",
+			HasConstructor: ann["io.orkestra.katalog.has_constructor"] == "true",
+		}
+	}
+	if ann["io.orkestra.katalog.deprecated"] == "true" {
+		meta.Deprecated = &PatternDeprecated{
+			MigratedTo: ann["io.orkestra.katalog.deprecated.migrated_to"],
+			Message:    ann["io.orkestra.katalog.deprecated.message"],
 		}
 	}
 	return meta

--- a/pkg/registry/meta_test.go
+++ b/pkg/registry/meta_test.go
@@ -1,0 +1,212 @@
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ── annotation round-trip ─────────────────────────────────────────────────────
+
+func TestAnnotationRoundTrip_Typed(t *testing.T) {
+	ref, _ := parseRef("ghcr.io/test/patterns/postgres:v1")
+	meta := &PatternMeta{
+		Kind:    KatalogKind,
+		Name:    "postgres",
+		Version: "v1",
+		Typed: &PatternTyped{
+			HasHooks:       true,
+			HasConstructor: false,
+		},
+	}
+
+	ann := artifactMetaToAnnotations(meta, ref)
+
+	if ann["io.orkestra.katalog.typed"] != "true" {
+		t.Errorf("typed annotation not set")
+	}
+	if ann["io.orkestra.katalog.has_hooks"] != "true" {
+		t.Errorf("has_hooks annotation not set")
+	}
+	if ann["io.orkestra.katalog.has_constructor"] == "true" {
+		t.Errorf("has_constructor should not be set when HasConstructor=false")
+	}
+
+	got := annotationsToMeta(ann)
+	if got.Typed == nil {
+		t.Fatal("Typed is nil after round-trip")
+	}
+	if !got.Typed.HasHooks {
+		t.Errorf("HasHooks lost in round-trip")
+	}
+	if got.Typed.HasConstructor {
+		t.Errorf("HasConstructor should be false after round-trip")
+	}
+}
+
+func TestAnnotationRoundTrip_TypedBoth(t *testing.T) {
+	ref, _ := parseRef("ghcr.io/test/patterns/redis:v2")
+	meta := &PatternMeta{
+		Kind:    KatalogKind,
+		Name:    "redis",
+		Version: "v2",
+		Typed: &PatternTyped{
+			HasHooks:       true,
+			HasConstructor: true,
+		},
+	}
+
+	ann := artifactMetaToAnnotations(meta, ref)
+	got := annotationsToMeta(ann)
+
+	if got.Typed == nil {
+		t.Fatal("Typed is nil after round-trip")
+	}
+	if !got.Typed.HasHooks || !got.Typed.HasConstructor {
+		t.Errorf("Typed fields lost: hooks=%v constructor=%v", got.Typed.HasHooks, got.Typed.HasConstructor)
+	}
+}
+
+func TestAnnotationRoundTrip_Deprecated(t *testing.T) {
+	ref, _ := parseRef("ghcr.io/test/patterns/old-postgres:v1")
+	meta := &PatternMeta{
+		Kind:    KatalogKind,
+		Name:    "old-postgres",
+		Version: "v1",
+		Deprecated: &PatternDeprecated{
+			MigratedTo: "ghcr.io/test/patterns/postgres:v14",
+			Message:    "Use postgres:v14 — supports logical replication",
+		},
+	}
+
+	ann := artifactMetaToAnnotations(meta, ref)
+
+	if ann["io.orkestra.katalog.deprecated"] != "true" {
+		t.Errorf("deprecated annotation not set")
+	}
+	if ann["io.orkestra.katalog.deprecated.migrated_to"] != meta.Deprecated.MigratedTo {
+		t.Errorf("migrated_to = %q; want %q", ann["io.orkestra.katalog.deprecated.migrated_to"], meta.Deprecated.MigratedTo)
+	}
+	if ann["io.orkestra.katalog.deprecated.message"] != meta.Deprecated.Message {
+		t.Errorf("message = %q; want %q", ann["io.orkestra.katalog.deprecated.message"], meta.Deprecated.Message)
+	}
+
+	got := annotationsToMeta(ann)
+	if got.Deprecated == nil {
+		t.Fatal("Deprecated is nil after round-trip")
+	}
+	if got.Deprecated.MigratedTo != meta.Deprecated.MigratedTo {
+		t.Errorf("MigratedTo lost: got %q", got.Deprecated.MigratedTo)
+	}
+	if got.Deprecated.Message != meta.Deprecated.Message {
+		t.Errorf("Message lost: got %q", got.Deprecated.Message)
+	}
+}
+
+func TestAnnotationRoundTrip_NoTypedNoDeprecated(t *testing.T) {
+	ref, _ := parseRef("ghcr.io/test/patterns/plain:v1")
+	meta := &PatternMeta{
+		Kind:    KatalogKind,
+		Name:    "plain",
+		Version: "v1",
+	}
+
+	ann := artifactMetaToAnnotations(meta, ref)
+	got := annotationsToMeta(ann)
+
+	if got.Typed != nil {
+		t.Errorf("Typed should be nil for plain katalog")
+	}
+	if got.Deprecated != nil {
+		t.Errorf("Deprecated should be nil for plain katalog")
+	}
+}
+
+// ── fixture: testdata/katalog.yaml ───────────────────────────────────────────
+
+// TestLoadPatternMeta_Fixture reads the testdata katalog and asserts that
+// metadata.deprecation and metadata.name are parsed correctly.
+func TestLoadPatternMeta_Fixture(t *testing.T) {
+	dir := "testdata"
+	spec := &PatternSpec{Kind: KatalogKind, PrimaryFile: FileKatalog}
+
+	meta, err := LoadPatternMeta(dir, spec)
+	if err != nil {
+		t.Fatalf("LoadPatternMeta: %v", err)
+	}
+
+	if meta.Name != "registry-pack-probe" {
+		t.Errorf("Name = %q; want registry-pack-probe", meta.Name)
+	}
+	if meta.Deprecated == nil {
+		t.Fatal("Deprecated is nil — fixture has metadata.deprecation")
+	}
+	if meta.Deprecated.MigratedTo == "" {
+		t.Errorf("MigratedTo is empty")
+	}
+	if meta.Deprecated.Message == "" {
+		t.Errorf("Message is empty")
+	}
+}
+
+// ── LoadPatternMeta reads deprecation from YAML ───────────────────────────────
+
+func TestLoadPatternMeta_Deprecation(t *testing.T) {
+	dir := t.TempDir()
+	katalogYAML := `
+kind: Katalog
+metadata:
+  name: old-redis
+  version: v6
+  description: "Legacy Redis operator"
+  deprecation:
+    migratedTo: ghcr.io/test/patterns/redis:v7
+    message: "Upgrade to v7 — adds TLS support"
+spec:
+  crds: {}
+`
+	if err := os.WriteFile(filepath.Join(dir, FileKatalog), []byte(katalogYAML), 0o644); err != nil {
+		t.Fatalf("writing test katalog: %v", err)
+	}
+
+	spec := &PatternSpec{Kind: KatalogKind, PrimaryFile: FileKatalog}
+	meta, err := LoadPatternMeta(dir, spec)
+	if err != nil {
+		t.Fatalf("LoadPatternMeta: %v", err)
+	}
+
+	if meta.Deprecated == nil {
+		t.Fatal("Deprecated is nil — deprecation: block not read")
+	}
+	if meta.Deprecated.MigratedTo != "ghcr.io/test/patterns/redis:v7" {
+		t.Errorf("MigratedTo = %q; want ghcr.io/test/patterns/redis:v7", meta.Deprecated.MigratedTo)
+	}
+	if meta.Deprecated.Message != "Upgrade to v7 — adds TLS support" {
+		t.Errorf("Message = %q", meta.Deprecated.Message)
+	}
+}
+
+func TestLoadPatternMeta_NoDeprecation(t *testing.T) {
+	dir := t.TempDir()
+	katalogYAML := `
+kind: Katalog
+metadata:
+  name: postgres
+  version: v14
+spec:
+  crds: {}
+`
+	if err := os.WriteFile(filepath.Join(dir, FileKatalog), []byte(katalogYAML), 0o644); err != nil {
+		t.Fatalf("writing test katalog: %v", err)
+	}
+
+	spec := &PatternSpec{Kind: KatalogKind, PrimaryFile: FileKatalog}
+	meta, err := LoadPatternMeta(dir, spec)
+	if err != nil {
+		t.Fatalf("LoadPatternMeta: %v", err)
+	}
+
+	if meta.Deprecated != nil {
+		t.Errorf("Deprecated should be nil for a non-deprecated pattern")
+	}
+}

--- a/pkg/registry/pattern.go
+++ b/pkg/registry/pattern.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 
+	orktypes "github.com/orkspace/orkestra/pkg/types"
 	"gopkg.in/yaml.v3"
 )
 
@@ -107,12 +108,13 @@ func LoadPatternMeta(dir string, spec *PatternSpec) (*PatternMeta, error) {
 	var raw struct {
 		Kind     string `yaml:"kind"`
 		Metadata struct {
-			Name        string   `yaml:"name"`
-			Version     string   `yaml:"version"`
-			Description string   `yaml:"description"`
-			Author      string   `yaml:"author"`
-			License     string   `yaml:"license"`
-			Tags        []string `yaml:"tags"`
+			Name        string                       `yaml:"name"`
+			Version     string                       `yaml:"version"`
+			Description string                       `yaml:"description"`
+			Author      string                       `yaml:"author"`
+			License     string                       `yaml:"license"`
+			Tags        []string                     `yaml:"tags"`
+			Deprecation *orktypes.KatalogDeprecation `yaml:"deprecation"`
 		} `yaml:"metadata"`
 	}
 	if err := yaml.Unmarshal(data, &raw); err != nil {
@@ -129,6 +131,12 @@ func LoadPatternMeta(dir string, spec *PatternSpec) (*PatternMeta, error) {
 		Author:      raw.Metadata.Author,
 		License:     raw.Metadata.License,
 		Tags:        raw.Metadata.Tags,
+	}
+	if d := raw.Metadata.Deprecation; d != nil {
+		meta.Deprecated = &PatternDeprecated{
+			MigratedTo: d.MigratedTo,
+			Message:    d.Message,
+		}
 	}
 	if meta.Version == "" {
 		meta.Version = "latest"

--- a/pkg/registry/testdata/katalog.yaml
+++ b/pkg/registry/testdata/katalog.yaml
@@ -1,0 +1,24 @@
+apiVersion: orkestra.orkspace.io/v1
+kind: Katalog
+metadata:
+  name: registry-pack-probe
+  version: v0.1.0
+  description: Minimal fixture for typed annotations and deprecation detection
+  deprecation:
+    migratedTo: ghcr.io/orkspace/orkestra-registry/registry-pack-probe:v0.2.0
+    message: "Upgrade to v0.2.0"
+
+spec:
+  crds:
+    probe:
+      workers: 1
+      resync: 15s
+
+      operatorBox:
+        default: true
+
+        onCreate:
+          deployments:
+            - name: "{{ .metadata.name }}-probe"
+              image: "busybox:latest"
+              replicas: "1"

--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -24,8 +24,22 @@ type PatternMeta struct {
 	Author      string
 	License     string
 	Tags        []string
-	E2E         *PatternE2E      // populated at push time from running ork e2e; nil when absent
-	Simulate    *PatternSimulate // populated at push time from running simulate gate; nil when absent
+	E2E         *PatternE2E        // populated at push time from running ork e2e; nil when absent
+	Simulate    *PatternSimulate   // populated at push time from running simulate gate; nil when absent
+	Typed       *PatternTyped      // populated at push time from inspecting katalog CRDs; nil for motifs or non-typed katalogs
+	Deprecated  *PatternDeprecated // populated from metadata.deprecation in the source YAML; nil when absent
+}
+
+// PatternTyped carries the typed-operator annotation flags for a katalog.
+type PatternTyped struct {
+	HasHooks       bool // one or more CRDs declare customHooks
+	HasConstructor bool // one or more CRDs declare customConstructor
+}
+
+// PatternDeprecated carries the deprecation metadata declared in the source YAML.
+type PatternDeprecated struct {
+	MigratedTo string // full OCI ref of the replacement version
+	Message    string // human-readable migration guidance
 }
 
 // PatternE2E holds E2E verification metadata embedded in OCI annotations at push time.
@@ -57,6 +71,7 @@ type PatternEntry struct {
 	Kind           string   `json:"kind,omitempty"`           // "Katalog" or "Motif"
 	E2EStatus      string   `json:"e2eStatus,omitempty"`      // "passed", "skipped", or ""
 	SimulateStatus string   `json:"simulateStatus,omitempty"` // "passed", "skipped", "no-assertion", or ""
+	Deprecated     bool     `json:"deprecated,omitempty"`
 }
 
 // PatternIndex is the top-level index stored at registry/index:latest.

--- a/pkg/types/katalog.go
+++ b/pkg/types/katalog.go
@@ -125,6 +125,16 @@ type KatalogMeta struct {
 	// time. The operator and runtime ignore this field — it is purely for
 	// persona-aware tooling and Control Center UI.
 	Projects map[string]interface{} `yaml:"projects,omitempty" json:"projects,omitempty"`
+
+	// Deprecation marks this pattern as deprecated. When set, consumers
+	// (ork validate, ork registry info, ork registry list) display a warning.
+	Deprecation *KatalogDeprecation `yaml:"deprecation,omitempty" json:"deprecation,omitempty"`
+}
+
+// KatalogDeprecation carries deprecation guidance for registry consumers.
+type KatalogDeprecation struct {
+	MigratedTo string `yaml:"migratedTo,omitempty" json:"migratedTo,omitempty"`
+	Message    string `yaml:"message,omitempty"    json:"message,omitempty"`
 }
 
 // KatalogSources declares where to load CRD definitions from.


### PR DESCRIPTION
## Summary

Infrastructure PR for the `examples/registry-guide` pack. The examples will be released as a follow-up once this ships.

**Fixes**
- `pkg/konfig/type.go`: `NewDefaultKonfig()` sets same defaults as the runtime — `workers: 3`, `resync: 15s`, `queueDepth: 100`, `failureThreshold: 5`. Fixes `ork plan` spurious diffs for unset CRD fields.
- `pkg/merger/registry.go`: `simulate.yaml` added to `knownPatternFiles` — was missing from Git pull attempts.

**Typed katalog annotations**
- On push, inspect each CRD for `customHooks` / `customConstructor` and write OCI annotations: `io.orkestra.katalog.has_hooks`, `io.orkestra.katalog.has_constructor`, `io.orkestra.katalog.typed`.
- `ork registry info` surfaces `Typed: ✓ hooks · requires custom runtime image`.

**Deprecation struct**
- New `deprecation:` struct under `metadata:` in Katalog and Motif — fields: `migratedTo`, `message`.
- `ork registry push` derives OCI annotations from it.
- `ork registry info` + `ork registry list` surface the warning.
- `ork validate` warns when a Komposer imports a deprecated pattern.

## Test plan

- [x] `ork plan --bundle bundle.yaml` against katalog with workers unset — shows "No changes"
- [x] `ork registry push` typed katalog — `ork registry info` shows `Typed: ✓ hooks`
- [x] `ork registry push` non-typed katalog — no Typed line
- [x] `ork registry push` with `deprecation:` in metadata — info shows warning
- [x] `ork registry list` — deprecated patterns flagged ⚠
- [x] `ork validate -f komposer.yaml` importing deprecated pattern — warns with migratedTo ref
- [x] `ork validate -f komposer.yaml` importing live pattern — clean