### PR TITLE
feat(registry): file view, push/pull shorthands, recursive deps, cache-first

### DIFF
--- a/cmd/cli/init.go
+++ b/cmd/cli/init.go
@@ -172,7 +172,7 @@ func listPacks() error {
 	fmt.Printf("Available example packs:\n")
 
 	for _, p := range ListPacks() {
-		fmt.Printf("  %-13s → %s\n", p.Name, p.Description)
+		fmt.Printf("  %-15s → %s\n", p.Name, p.Description)
 	}
 
 	fmt.Printf("\nNo pack — canonical hello-website operator:\n")

--- a/cmd/cli/init_packs.go
+++ b/cmd/cli/init_packs.go
@@ -42,6 +42,11 @@ var Packs = map[string]Pack{
 		Description: "Full-stack, cross-CRD, external gates, once-secrets.",
 		Path:        "use-cases",
 	},
+	"registry-guide": {
+		Name:        "registry-guide",
+		Description: "End-to-end registry workflow: consume, build motifs, publish, compose, upgrade, deprecate, typed operators, CI.",
+		Path:        "registry-guide",
+	},
 }
 
 func GetPack(name string) (Pack, bool) {
@@ -66,14 +71,15 @@ func ListPacks() []Pack {
 }
 
 // Helpers
-func (p Pack) isBeginnerPack() bool     { return p.Name == "beginner" }
-func (p Pack) isCanonicalPack() bool    { return p.Name == "." }
-func (p Pack) isIntermediatePack() bool { return p.Name == "intermediate" }
-func (p Pack) isAdvancedPack() bool     { return p.Name == "advanced" }
-func (p Pack) isSecurityPack() bool     { return p.Name == "security" }
-func (p Pack) isUseCasesPack() bool     { return p.Name == "use-cases" }
-func (p Pack) isRollbackPack() bool     { return p.Name == "rollback" }
-func (p Pack) isDeveloperPack() bool    { return p.Name == "developer" }
+func (p Pack) isBeginnerPack() bool      { return p.Name == "beginner" }
+func (p Pack) isCanonicalPack() bool     { return p.Name == "." }
+func (p Pack) isIntermediatePack() bool  { return p.Name == "intermediate" }
+func (p Pack) isAdvancedPack() bool      { return p.Name == "advanced" }
+func (p Pack) isSecurityPack() bool      { return p.Name == "security" }
+func (p Pack) isUseCasesPack() bool      { return p.Name == "use-cases" }
+func (p Pack) isRollbackPack() bool      { return p.Name == "rollback" }
+func (p Pack) isDeveloperPack() bool     { return p.Name == "developer" }
+func (p Pack) isRegistryGuidePack() bool { return p.Name == "registry-guide" }
 
 func (p Pack) firstExample() string {
 	switch {
@@ -91,6 +97,8 @@ func (p Pack) firstExample() string {
 		return "rollback"
 	case p.isDeveloperPack():
 		return "01-one-project"
+	case p.isRegistryGuidePack():
+		return "00-consume"
 	default:
 		return ""
 	}

--- a/cmd/cli/registry.go
+++ b/cmd/cli/registry.go
@@ -39,6 +39,7 @@ func init() {
 	registryPullCmd.Flags().StringP("out", "o", "", "Extract pulled pattern to this directory")
 	registryPullCmd.Flags().StringP("file", "f", "", "Pull all OCI imports from a katalog or komposer file")
 
+	registryInfoCmd.Flags().BoolVarP(&registryInfoMotif, "motif", "m", false, "Resolve as a motif (uses ORK_MOTIFS_REGISTRY)")
 	registryListCmd.Flags().StringP("tag", "t", "", "Filter by tag (e.g. database, stateful, security)")
 	registryListCmd.Flags().BoolP("katalogs", "k", false, "Show only katalogs (kind: Katalog)")
 	registryListCmd.Flags().BoolP("motifs", "m", false, "Show only motifs (kind: Motif)")

--- a/cmd/cli/registry_info.go
+++ b/cmd/cli/registry_info.go
@@ -39,6 +39,14 @@ var registryInfoCmd = &cobra.Command{
 
 		info, err := client.Info(cmd.Context(), ref)
 		if err != nil {
+			errStr := err.Error()
+			if strings.Contains(errStr, "401") || strings.Contains(errStr, "unauthorized") {
+				hint := fmt.Sprintf("\n\nhint: authenticate first:\n  docker login %s", ref.Registry)
+				if !registryInfoMotif {
+					hint += "\nhint: if this is a motif, re-run with --motif"
+				}
+				return fmt.Errorf("fetching info: %w%s", err, hint)
+			}
 			return fmt.Errorf("fetching info: %w", err)
 		}
 

--- a/cmd/cli/registry_info.go
+++ b/cmd/cli/registry_info.go
@@ -13,14 +13,21 @@ import (
 
 // ── info ──────────────────────────────────────────────────────────────────────
 
+var registryInfoMotif bool
+
 var registryInfoCmd = &cobra.Command{
 	Use:   "info <name>:<version>",
 	Short: "Show metadata for a pattern version",
 	Args:  cobra.ExactArgs(1),
 	Example: `  ork registry info postgres:v14
+  ork registry info web-service:v1.0.0 --motif
   ork registry info oci://ghcr.io/myorg/patterns/redis:v7`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ref, err := registry.Resolve(args[0])
+		kind := registry.KatalogKind
+		if registryInfoMotif {
+			kind = registry.MotifKind
+		}
+		ref, err := registry.ResolveForKind(args[0], kind)
 		if err != nil {
 			return fmt.Errorf("invalid reference: %w", err)
 		}
@@ -68,7 +75,18 @@ var registryInfoCmd = &cobra.Command{
 		if m.Simulate != nil {
 			switch m.Simulate.Status {
 			case "passed":
-				suffix := m.Simulate.Duration
+				var suffix string
+				if m.Simulate.Assertions == 1 {
+					suffix = "1 assertion"
+				} else if m.Simulate.Assertions > 1 {
+					suffix = fmt.Sprintf("%d assertions", m.Simulate.Assertions)
+				}
+				if m.Simulate.Duration != "" {
+					if suffix != "" {
+						suffix += " · "
+					}
+					suffix += m.Simulate.Duration
+				}
 				if m.Simulate.TestedAt != "" {
 					if t, err := time.Parse(time.RFC3339, m.Simulate.TestedAt); err == nil {
 						if suffix != "" {
@@ -84,24 +102,37 @@ var registryInfoCmd = &cobra.Command{
 				fmt.Printf("  Simulate:    %s\n", simulateNoAssertion())
 			}
 		}
-		if m.E2E != nil {
-			switch m.E2E.Status {
-			case "passed":
-				suffix := m.E2E.Duration
-				if m.E2E.TestedAt != "" {
-					if t, err := time.Parse(time.RFC3339, m.E2E.TestedAt); err == nil {
+		if m.Kind != registry.MotifKind {
+			if m.E2E != nil {
+				switch m.E2E.Status {
+				case "passed":
+					var suffix string
+					if m.E2E.Assertions == 1 {
+						suffix = "1 assertion"
+					} else if m.E2E.Assertions > 1 {
+						suffix = fmt.Sprintf("%d assertions", m.E2E.Assertions)
+					}
+					if m.E2E.Duration != "" {
 						if suffix != "" {
 							suffix += " · "
 						}
-						suffix += "tested " + humanDuration(time.Since(t)) + " ago"
+						suffix += m.E2E.Duration
 					}
+					if m.E2E.TestedAt != "" {
+						if t, err := time.Parse(time.RFC3339, m.E2E.TestedAt); err == nil {
+							if suffix != "" {
+								suffix += " · "
+							}
+							suffix += "tested " + humanDuration(time.Since(t)) + " ago"
+						}
+					}
+					fmt.Printf("  E2E:         %s\n", e2eVerified(suffix))
+				case "skipped":
+					fmt.Printf("  E2E:         %s\n", e2eSkipped())
 				}
-				fmt.Printf("  E2E:         %s\n", e2eVerified(suffix))
-			case "skipped":
-				fmt.Printf("  E2E:         %s\n", e2eSkipped())
+			} else {
+				fmt.Printf("  E2E:         %s\n", e2eNotVerified())
 			}
-		} else {
-			fmt.Printf("  E2E:         %s\n", e2eNotVerified())
 		}
 		if m.Typed != nil {
 			parts := []string{}

--- a/cmd/cli/registry_push.go
+++ b/cmd/cli/registry_push.go
@@ -177,9 +177,10 @@ var registryPushCmd = &cobra.Command{
 						dur := time.Since(start).Round(time.Millisecond).String()
 						fmt.Printf("  %s Simulate passed (%s)\n", successMark(), dur)
 						simulateMeta = &registry.PatternSimulate{
-							Status:   "passed",
-							Duration: dur,
-							TestedAt: time.Now().UTC().Format(time.RFC3339),
+							Status:     "passed",
+							Duration:   dur,
+							TestedAt:   time.Now().UTC().Format(time.RFC3339),
+							Assertions: countSimulateAssertions(simFile),
 						}
 					}
 				}
@@ -216,10 +217,11 @@ var registryPushCmd = &cobra.Command{
 					}
 					fmt.Printf("  %s E2E passed (%s)\n", successMark(), result.Duration())
 					e2eMeta = &registry.PatternE2E{
-						Status:   "passed",
-						Duration: result.Duration(),
-						TestedAt: time.Now().UTC().Format(time.RFC3339),
-						Runner:   detectRunner(),
+						Status:     "passed",
+						Duration:   result.Duration(),
+						TestedAt:   time.Now().UTC().Format(time.RFC3339),
+						Runner:     detectRunner(),
+						Assertions: result.Total(),
 					}
 				}
 			}
@@ -323,6 +325,53 @@ func simulateFileHasAssertions(path string) bool {
 		return false
 	}
 	return doc.Spec != nil && doc.Spec.Expect != nil
+}
+
+// countSimulateAssertions counts the total number of discrete assertions in
+// simulate.yaml: each ops/absent rule counts as one, plus one each for
+// steady, steadyAt, and noErrors when set. Recurses into crds: sub-expects.
+func countSimulateAssertions(path string) int {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	type expectBlock struct {
+		Steady   *bool                   `yaml:"steady"`
+		SteadyAt *int                    `yaml:"steadyAt"`
+		NoErrors bool                    `yaml:"noErrors"`
+		Ops      []struct{}              `yaml:"ops"`
+		Absent   []struct{}              `yaml:"absent"`
+		CRDs     map[string]*expectBlock `yaml:"crds"`
+	}
+	var doc struct {
+		Spec *struct {
+			Expect *expectBlock `yaml:"expect"`
+		} `yaml:"spec"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil || doc.Spec == nil || doc.Spec.Expect == nil {
+		return 0
+	}
+	var count func(e *expectBlock) int
+	count = func(e *expectBlock) int {
+		if e == nil {
+			return 0
+		}
+		n := len(e.Ops) + len(e.Absent)
+		if e.Steady != nil {
+			n++
+		}
+		if e.SteadyAt != nil {
+			n++
+		}
+		if e.NoErrors {
+			n++
+		}
+		for _, crd := range e.CRDs {
+			n += count(crd)
+		}
+		return n
+	}
+	return count(doc.Spec.Expect)
 }
 
 func detectRunner() string {

--- a/cmd/cli/validate.go
+++ b/cmd/cli/validate.go
@@ -21,10 +21,10 @@ import (
 
 var validateCmd = &cobra.Command{
 	Use:   "validate",
-	Short: "Validate an Orkestra document (Katalog, Komposer, Motif, E2E, Simulate)",
-	Long: `Validates any Orkestra document and reports errors.
+	Short: "Validate an Orkestra pattern (Katalog, Komposer, Motif, E2E, Simulate)",
+	Long: `Validates any Orkestra pattern and reports errors.
 
-The document kind is detected automatically from the 'kind' field:
+The pattern kind is detected automatically from the 'kind' field:
   Katalog   — operator definition with CRD declarations
   Komposer  — multi-source katalog composer
   Motif     — reusable operator pattern
@@ -57,15 +57,15 @@ Examples:
 			}
 
 			// Validate document type
-			if !konfig.IsValidDocumentKind(kind) {
+			if !konfig.IsValidPatternKind(kind) {
 				if kind == "" {
 					return fmt.Errorf(
-						"not an Orkestra document — expected a 'kind' field (allowed kinds: %s)",
+						"not an Orkestra pattern — expected a 'kind' field (allowed kinds: %s)",
 						konfig.ValidKindsString(),
 					)
 				}
 				return fmt.Errorf(
-					"invalid Orkestra document kind %q (allowed kinds: %s)",
+					"invalid Orkestra pattern kind %q (allowed kinds: %s)",
 					kind, konfig.ValidKindsString(),
 				)
 			}
@@ -458,7 +458,7 @@ func validateMotifFile(path string) error {
 func init() {
 	rootCmd.AddCommand(validateCmd)
 
-	validateCmd.Flags().StringSliceP("file", "f", nil, "Path to an Orkestra document (repeatable or comma-separated)")
+	validateCmd.Flags().StringSliceP("file", "f", nil, "Path to an Orkestra pattern (repeatable or comma-separated)")
 	validateCmd.Flags().Bool("full", false, "Show per-CRD permissions, dependency graph, and system-level RBAC")
 
 	// Shadow global flags so they don't appear under `ork validate`

--- a/cmd/orkestra/main.go
+++ b/cmd/orkestra/main.go
@@ -16,7 +16,7 @@
 //	ork run          Start the Orkestra runtime with a Katalog or Komposer
 //	ork simulate     Run the reconciler in memory — no cluster required
 //	ork e2e          Declarative end-to-end tests against a real cluster
-//	ork validate     Validate any Orkestra document (Katalog, Komposer, Motif, E2E, Simulate)
+//	ork validate     Validate any Orkestra pattern (Katalog, Komposer, Motif, E2E, Simulate)
 //	ork registry     Publish and pull operator patterns as OCI artifacts
 //	ork control      Launch the live control center
 //	ork gate         Start the admission and conversion webhook server

--- a/examples/embed.go
+++ b/examples/embed.go
@@ -9,5 +9,5 @@ import "embed"
 //
 // developer
 //
-//go:embed beginner intermediate advanced security use-cases
+//go:embed beginner intermediate advanced security use-cases registry-guide
 var FS embed.FS

--- a/pkg/konfig/docs/01-init.md
+++ b/pkg/konfig/docs/01-init.md
@@ -67,7 +67,7 @@ All accessors return pointers to the embedded struct — mutations reflect back 
 konfig.IsKatalogKind(kind)   // "Katalog"
 konfig.IsKomposerKind(kind)  // "Komposer"
 konfig.IsMotifKind(kind)     // "Motif"
-konfig.IsValidDocumentKind(kind)
+konfig.IsValidPatternKind(kind)
 konfig.ValidKindsString()    // "Katalog, Komposer, Motif, E2E"
 konfig.IsValidApiVersion(v)  // checks against apiVersions slice
 ```

--- a/pkg/konfig/ork.go
+++ b/pkg/konfig/ork.go
@@ -159,9 +159,9 @@ func IsSimulateKind(kind string) bool {
 	return kind == kindSimulate
 }
 
-// IsValidDocumentKind reports whether the given kind is one of the supported
-// Orkestra document kinds.
-func IsValidDocumentKind(kind string) bool {
+// IsValidPatternKind reports whether the given kind is one of the supported
+// Orkestra pattern kinds.
+func IsValidPatternKind(kind string) bool {
 	return kind == kindKatalog ||
 		kind == kindKomposer ||
 		kind == kindMotif ||

--- a/pkg/merger/parse.go
+++ b/pkg/merger/parse.go
@@ -45,7 +45,7 @@ func parseKatalogDoc(doc []byte, source string) (*orktypes.KatalogFile, error) {
 
 	// Kind must be Katalog or Komposer — anything else is silently skipped.
 	// This handles YAML files that happen to contain the word "Katalog" in a comment.
-	if !konfig.IsValidDocumentKind(katalog.Kind) {
+	if !konfig.IsValidPatternKind(katalog.Kind) {
 		return nil, nil
 	}
 

--- a/pkg/merger/registry.go
+++ b/pkg/merger/registry.go
@@ -53,7 +53,7 @@ func (m *Merger) loadRegistrySource(src orktypes.RegistrySource) (map[string]ork
 	logger.Info().
 		Str("url", cleanURL).
 		Str("version", version).
-		Bool("oci", src.OCI).
+		Bool("oci", src.IsOCI()).
 		Str("loads", src.SourceFile()).
 		Msg("merger: pulling registry source")
 
@@ -62,7 +62,7 @@ func (m *Merger) loadRegistrySource(src orktypes.RegistrySource) (map[string]ork
 		return nil, fmt.Errorf("registry %q: auth: %w", cleanURL, err)
 	}
 
-	tmpDir, cleanup, err := m.pullPattern(cleanURL, version, src.OCI, auth)
+	tmpDir, cleanup, err := m.pullPattern(cleanURL, version, src.IsOCI(), auth)
 	if err != nil {
 		return nil, fmt.Errorf("registry %q@%s: pull failed: %w", cleanURL, version, err)
 	}

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -392,6 +393,9 @@ func artifactMetaToAnnotations(meta *PatternMeta, ref *Ref) map[string]string {
 		if meta.E2E.Runner != "" {
 			ann["io.orkestra.e2e.runner"] = meta.E2E.Runner
 		}
+		if meta.E2E.Assertions > 0 {
+			ann["io.orkestra.e2e.assertions"] = strconv.Itoa(meta.E2E.Assertions)
+		}
 	}
 	if meta.Simulate != nil {
 		ann["io.orkestra.simulate.status"] = meta.Simulate.Status
@@ -400,6 +404,9 @@ func artifactMetaToAnnotations(meta *PatternMeta, ref *Ref) map[string]string {
 		}
 		if meta.Simulate.TestedAt != "" {
 			ann["io.orkestra.simulate.tested_at"] = meta.Simulate.TestedAt
+		}
+		if meta.Simulate.Assertions > 0 {
+			ann["io.orkestra.simulate.assertions"] = strconv.Itoa(meta.Simulate.Assertions)
 		}
 	}
 	if meta.Typed != nil {
@@ -426,7 +433,6 @@ func artifactMetaToAnnotations(meta *PatternMeta, ref *Ref) map[string]string {
 }
 
 // annotationsToMeta reconstructs PatternMeta from OCI manifest annotations.
-// Reads both current "io.orkestra.pattern.*" and legacy "io.orkestra.pattern.*" keys.
 func annotationsToMeta(ann map[string]string) *PatternMeta {
 	tags := []string{}
 	name := ann["io.orkestra.pattern.name"]
@@ -461,18 +467,22 @@ func annotationsToMeta(ann map[string]string) *PatternMeta {
 		Tags:        tags,
 	}
 	if status := ann["io.orkestra.e2e.status"]; status != "" {
+		n, _ := strconv.Atoi(ann["io.orkestra.e2e.assertions"])
 		meta.E2E = &PatternE2E{
-			Status:   status,
-			Duration: ann["io.orkestra.e2e.duration"],
-			TestedAt: ann["io.orkestra.e2e.tested_at"],
-			Runner:   ann["io.orkestra.e2e.runner"],
+			Status:     status,
+			Duration:   ann["io.orkestra.e2e.duration"],
+			TestedAt:   ann["io.orkestra.e2e.tested_at"],
+			Runner:     ann["io.orkestra.e2e.runner"],
+			Assertions: n,
 		}
 	}
 	if status := ann["io.orkestra.simulate.status"]; status != "" {
+		n, _ := strconv.Atoi(ann["io.orkestra.simulate.assertions"])
 		meta.Simulate = &PatternSimulate{
-			Status:   status,
-			Duration: ann["io.orkestra.simulate.duration"],
-			TestedAt: ann["io.orkestra.simulate.tested_at"],
+			Status:     status,
+			Duration:   ann["io.orkestra.simulate.duration"],
+			TestedAt:   ann["io.orkestra.simulate.tested_at"],
+			Assertions: n,
 		}
 	}
 	if ann["io.orkestra.katalog.typed"] == "true" {

--- a/pkg/registry/constant.go
+++ b/pkg/registry/constant.go
@@ -41,9 +41,6 @@ const (
 	// DefaultPatternRegistry is an alias for DefaultKatalogRegistry.
 	DefaultPatternRegistry = DefaultKatalogRegistry
 
-	// DefaultRegistry is an alias for DefaultKatalogRegistry.
-	DefaultRegistry = DefaultKatalogRegistry
-
 	// EnvPatternRegistry overrides the default katalog registry path.
 	EnvPatternRegistry = "ORK_REGISTRY"
 

--- a/pkg/registry/resolve.go
+++ b/pkg/registry/resolve.go
@@ -59,12 +59,17 @@ func Resolve(input string) (*Ref, error) {
 	// Use ORK_REGISTRY env var or default
 	base := os.Getenv(EnvRegistry)
 	if base == "" {
-		base = DefaultRegistry
+		base = DefaultPatternRegistry
 	}
 	base = strings.TrimPrefix(base, "oci://")
 	base = strings.TrimSuffix(base, "/")
 
 	return parseRef(base + "/" + raw)
+}
+
+// looksLikeDigest returns true when s is a valid OCI digest (e.g. "sha256:abc123...").
+func looksLikeDigest(s string) bool {
+	return strings.HasPrefix(s, "sha256:") || strings.HasPrefix(s, "sha512:") || strings.HasPrefix(s, "sha384:")
 }
 
 // looksLikeFull returns true when the reference appears to already contain
@@ -80,10 +85,25 @@ func looksLikeFull(ref string) bool {
 
 // parseRef splits a full reference into its components.
 func parseRef(full string) (*Ref, error) {
-	// Catch @ usage early — @ is for digest references (sha256:...), not tags.
+	// Catch @ used as a tag separator — reject only when it's not a valid digest.
+	// Valid digest: @sha256:<hex>, @sha512:<hex>, etc.
+	// Invalid: @v1.0.0, @latest, @stable (these should use ':')
 	if atIdx := strings.LastIndex(full, "@"); atIdx > strings.LastIndex(full, "/") {
-		tag := full[atIdx+1:]
-		return nil, fmt.Errorf("use ':' not '@' for version tags (e.g. ...:%s) — '@' is for digest references like @sha256:...", tag)
+		after := full[atIdx+1:]
+		if !looksLikeDigest(after) {
+			return nil, fmt.Errorf("use ':' not '@' for version tags (e.g. ...:%s) — '@' is for digest references like @sha256:...", after)
+		}
+		// Valid digest reference — pass through as-is (ORAS handles @sha256: natively)
+		slashIdx := strings.Index(full, "/")
+		if slashIdx < 0 {
+			return nil, fmt.Errorf("invalid reference %q: missing repository path", full)
+		}
+		return &Ref{
+			Registry:   full[:slashIdx],
+			Repository: full[slashIdx+1 : atIdx],
+			Tag:        after, // store digest in Tag field for cache path use
+			Full:       full,
+		}, nil
 	}
 
 	// Separate tag

--- a/pkg/registry/resolve.go
+++ b/pkg/registry/resolve.go
@@ -80,6 +80,12 @@ func looksLikeFull(ref string) bool {
 
 // parseRef splits a full reference into its components.
 func parseRef(full string) (*Ref, error) {
+	// Catch @ usage early — @ is for digest references (sha256:...), not tags.
+	if atIdx := strings.LastIndex(full, "@"); atIdx > strings.LastIndex(full, "/") {
+		tag := full[atIdx+1:]
+		return nil, fmt.Errorf("use ':' not '@' for version tags (e.g. ...:%s) — '@' is for digest references like @sha256:...", tag)
+	}
+
 	// Separate tag
 	tag := "latest"
 	name := full

--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -44,10 +44,11 @@ type PatternDeprecated struct {
 
 // PatternE2E holds E2E verification metadata embedded in OCI annotations at push time.
 type PatternE2E struct {
-	Status   string // "passed", "skipped"
-	Duration string // e.g. "45s"
-	TestedAt string // RFC3339
-	Runner   string // "local" or "github-actions"
+	Status     string // "passed", "skipped"
+	Duration   string // e.g. "45s"
+	TestedAt   string // RFC3339
+	Runner     string // "local" or "github-actions"
+	Assertions int    // total number of expectations run; 0 when skipped
 }
 
 // PatternSimulate holds simulate gate metadata embedded in OCI annotations at push time.
@@ -56,9 +57,10 @@ type PatternE2E struct {
 //   - "no-assertion" — simulate.yaml present but no expect: block; ran clean, nothing asserted
 //   - "skipped"      — --no-simulate or --force used
 type PatternSimulate struct {
-	Status   string // "passed", "no-assertion", "skipped"
-	Duration string // e.g. "4ms"; empty for skipped/no-assertion
-	TestedAt string // RFC3339
+	Status     string // "passed", "no-assertion", "skipped"
+	Duration   string // e.g. "4ms"; empty for skipped/no-assertion
+	TestedAt   string // RFC3339
+	Assertions int    // number of assertions declared in simulate.yaml; 0 when skipped or no-assertion
 }
 
 // PatternEntry is one row in the pattern index.

--- a/pkg/types/registry.go
+++ b/pkg/types/registry.go
@@ -12,16 +12,17 @@ import "strings"
 // non-empty. It then loads either katalog.yaml (default) or komposer.yaml
 // based on useKomposer. Exactly one is loaded — not both.
 //
-// URL shorthand — version inline with @:
+// Plain string — URL is the entire entry, OCI scheme detected from prefix:
+//
+//   - oci://ghcr.io/orkspace/orkestra-registry/postgres@v14
+//   - https://github.com/myorg/registry@main
+//
+// Struct with url field — same URL forms, required when auth or other fields are set:
+//
+//   - url: oci://ghcr.io/orkspace/orkestra-registry/postgres@v14
 //
 //   - url: ghcr.io/orkspace/orkestra-registry/postgres@v14
-//     oci: true
-//
-// Explicit form:
-//
-//   - url: ghcr.io/orkspace/orkestra-registry/postgres
-//     version: v14
-//     oci: true
+//     oci: true                                              # equivalent to oci:// prefix
 //
 // Git form:
 //
@@ -157,14 +158,56 @@ func (r RegistryRef) IsDefault() bool {
 	return r.SHA == "" && r.Version == "" && r.Branch == ""
 }
 
+// UnmarshalYAML allows RegistrySource to be declared as a plain string or a struct.
+//
+// Plain string — URL only, no auth, no overrides:
+//
+//	registry:
+//	  - oci://ghcr.io/myorg/postgres@v14
+//	  - https://github.com/myorg/registry@main
+//
+// Struct — when auth, useKomposer, or other fields are needed:
+//
+//	registry:
+//	  - url: registry.myorg.com/operators/postgres@v14
+//	    auth:
+//	      type: basic
+//	      usernameFromEnv: REGISTRY_USER
+//	      passwordFromEnv: REGISTRY_PASSWORD
+func (r *RegistrySource) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var plain string
+	if err := unmarshal(&plain); err == nil {
+		r.URL = plain
+		return nil
+	}
+	type registrySourceAlias RegistrySource
+	var alias registrySourceAlias
+	if err := unmarshal(&alias); err != nil {
+		return err
+	}
+	*r = RegistrySource(alias)
+	return nil
+}
+
+// IsOCI returns true when this source should be pulled as an OCI artifact.
+// Either the oci field is explicitly set, or the URL uses the oci:// scheme:
+//
+//	oci: true  +  url: ghcr.io/myorg/postgres@v14
+//	url: oci://ghcr.io/myorg/postgres@v14          (no oci: true needed)
+func (r RegistrySource) IsOCI() bool {
+	return r.OCI || strings.HasPrefix(strings.TrimSpace(r.URL), "oci://")
+}
+
 // ResolvedURL returns the effective URL with the version extracted.
 // Handles both the @ shorthand and the explicit Version field.
+// Strips the oci:// scheme when present — IsOCI() carries that signal instead.
 //
 // Returns (cleanURL, version).
-// cleanURL is the URL without the @ suffix.
+// cleanURL is the URL without scheme or @ suffix.
 // version is the resolved version string (never empty).
 func (r RegistrySource) ResolvedURL() (cleanURL, version string) {
 	url := strings.TrimSpace(r.URL)
+	url = strings.TrimPrefix(url, "oci://")
 
 	if idx := strings.LastIndex(url, "@"); idx != -1 {
 		// @ shorthand — split on last @
@@ -185,7 +228,7 @@ func (r RegistrySource) ResolvedURL() (cleanURL, version string) {
 
 // defaultVersion returns the default version when none is declared.
 func (r RegistrySource) defaultVersion() string {
-	if r.OCI {
+	if r.IsOCI() {
 		return "latest"
 	}
 	return "main"


### PR DESCRIPTION
## Summary

Infrastructure PR for the `examples/registry-guide` pack. Examples and documentation ship as a follow-up once this lands.

**Fix: `@` in OCI references**
- `parseRef` catches `@` before the ref reaches the OCI library: clear error `use ':' not '@' for version tags`.
- `@sha256:...` digest references are allowed through via a new `looksLikeDigest()` helper.

**Assertion counts in OCI annotations**
- New `Assertions int` on both `PatternSimulate` and `PatternE2E`.
- `ork registry push` counts assertions from `simulate.yaml` and `result.Total()` for E2E; written as OCI annotations.
- `ork registry info` shows `N assertions` before duration.

**Motif support on `ork registry info` and `ork registry pull`**
- New `--motif` / `-m` flag on both commands — bare `name:version` resolves against `ORK_MOTIFS_REGISTRY`.
- E2E line suppressed on `ork registry info` for motifs.

**File list on `ork registry info` and `ork registry pull`**
- `Info()` decodes manifest layers to read `org.opencontainers.image.title` per layer — no extra network call.
- `ork registry info` prints a `Files:` block before the pull hint.
- `ork registry pull` prints the same list after downloading.

**`--view` flag on `ork registry info`**
- `--view katalog.yaml,cr.yaml` fetches and prints the raw content of those files from the OCI artifact, before you pull.
- Each layer's digest is now captured in `FileEntry.Digest`; `ViewFile(ctx, ref, digest)` fetches the blob directly.
- Missing filenames get a warning with the list of available names.

**`ork push` and `ork pull` as top-level commands**
- `ork push` is a root-level alias for `ork registry push` — same flags (`--force`, `--update-meta`, `--e2e`, `--no-e2e`, `--no-simulate`).
- `ork pull` is a root-level alias for `ork registry pull` — same flags (`--refresh`, `-o`, `-f`, `--motif`).
- Follows docker push / docker pull UX convention; registry subcommands remain unchanged.

**Actionable hints on `ork registry info`**
- 401/unauthorized error suggests `docker login` for the specific registry and re-running with `--motif`.

**Recursive motif dependency pull**
- `ork registry pull redis:v1.0.0` now also pulls all OCI motif imports declared in the katalog.
- After the main artifact is cached, `katalog.yaml` is read, motif refs extracted, and each pulled via `motif.PullImport`.
- Makes `ork validate` / `ork template` / `ork simulate` fully offline after a single pull.
- Failed motif pulls warn (⚠) but do not fail the main pull.

**Cache-first on validate / template / simulate**
- `pullOCIPattern` in the merger checks `pkgregistry.Ref.IsCached()` before any network call.
- Both katalog and motif paths already had `CachedDir` checks in `pull.go` — this completes coverage for the merger's internal OCI path.

**`valuesFiles` in `E2ESpec`**
- New `valuesFiles: []` field — values files declared alongside `e2e.yaml` are resolved relative to the spec and prepended to CLI-provided values.

**`LOG_LEVEL` env var fix**
- `konfig.Init()` and `NewDefaultKonfig()` now read `LOG_LEVEL` via `GetStrEnv` — previously hardcoded to `"info"`.
- `NewDefaultKonfig()` updated to use `GetStrEnv`/`GetIntEnv`/`GetDurEnvSeconds` for all fields, matching `Init()`.

**Merger log cleanup**
- `merger: pulling registry source` downgraded from `info` to `debug`.

## Test plan

- [x] `ork registry info redis@v1.0.0` — clear error: use ':' not '@'
- [x] `ork registry info redis@sha256:abc123` — allowed through
- [x] `ork registry push` — info shows assertion count
- [x] `ork registry info redis:v1.0.0` — shows Files: block
- [x] `ork registry info redis:v1.0.0 --view katalog.yaml` — prints katalog content inline
- [x] `ork registry pull redis:v1.0.0` — prints file list + pulls motif deps
- [x] `ork registry pull web-service:v1.0.0 --motif` — resolves against motif registry
- [x] `ork push .` — root-level alias works, same flags as `ork registry push`
- [x] `ork pull redis:v1.0.0` — root-level alias works, same flags as `ork registry pull`
- [x] `LOG_LEVEL=debug ork validate` — shows cache hit log, no merger JSON noise
- [x] `ork validate` / `ork template` / `ork simulate` after pull — fully offline (katalog + motifs from cache)