### PR TITLE
Docs/foundations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 A structured, zero-to-production walkthrough of the Orkestra registry — 13 self-contained steps from consuming a published pattern on day one to automated CI publishing with GitHub Actions. Covers declarative operators, typed Go operators with hooks, multi-katalog Komposers, CRD API evolution, deprecation workflows, and the full `ork push` gate pipeline.
 
 ```bash
-ork init --pack registry-guide --example 10-hooks-katalog
+ork init --pack registry-guide
 ```
 
 ### CLI UX polish

--- a/documentation/foundations/00-operators-for-everyone.md
+++ b/documentation/foundations/00-operators-for-everyone.md
@@ -1,0 +1,88 @@
+# Operators for Everyone
+
+Most engineers who have tried to write a Kubernetes operator hit the same wall. Not because operators are conceptually difficult — the idea is straightforward. Because getting from idea to a working implementation required expert-level knowledge just to start. client-go, informers, schemes, workqueues, hundreds of lines of scaffolding — all before writing a single line of the thing you actually wanted to build. Most people never got past it. The ones who did spent days on infrastructure that had nothing to do with the problem they came to solve.
+
+That wall is what Orkestra removes.
+
+The full story is in the blog: [Why I Built This](/docs/blog/04-why-i-built-this). But the mission underneath all of it is this: make accessible what was once inaccessible — including to the person who built it.
+
+---
+
+## Solving problems once
+
+The deeper insight was not just about scaffolding. It was about patterns.
+
+The more operators you read, the more you notice that the reconcile loop is always the same shape. The deployment is always the same structure. The service is always the same structure. The secret generated once and watched for drift is the same pattern, repeated across thousands of operators by thousands of engineers who each solved it independently.
+
+**Every part of Orkestra is an answer to that.** Each artifact in the system was designed around a specific problem that operator developers hit repeatedly — and had to solve from scratch, every time.
+
+A **Motif** solves the problem of repeated resource logic. Every operator author writes a Deployment template, a Service, a health check — independently, without knowing what the author in the next team wrote last week. The same resource pattern, solved a hundred times across a hundred operators, each with its own subtle variation. A Motif encodes the solution once: reusable, tested, versionable, importable by any Katalog.
+
+A **Katalog** solves the problem of the reconciler itself. Before Orkestra, writing an operator meant writing client-go setup, informer registration, work queues, retry logic — hundreds of lines of infrastructure before a single line of business logic. The Katalog is a declaration of what the operator should do. The runtime is the one implementation that reads all Katalogs and runs them.
+
+A **Komposer** solves the platform problem. Teams that need five operators end up running five separate binaries, five deployments, five things to upgrade and operate — for what is logically one platform. A Komposer collapses all of that into a single process, managed as a unit.
+
+**Simulate** solves the feedback loop problem. Testing operator behavior without simulate means deploying to a cluster, applying a CR, reading logs, cleaning up, changing something, doing it again. Simulate runs the full reconcile cycle in memory, with assertions, in milliseconds — no cluster, no cleanup, no waiting.
+
+**E2E** solves the trust problem. "It worked on my cluster" is not a proof anyone else can verify. An `e2e.yaml` is a reproducible integration test, attached to the artifact, runnable by any consumer before they decide to import. The quality signal baked into every pushed artifact — ✓ Simulate passed, ✓ E2E verified — is the result of those tests, not a claim someone made.
+
+Every Motif pushed to a registry, every Katalog gated and published, every simulate assertion written — is a problem that no one downstream has to solve again. The goal is that common problems get solved collectively and once, not individually and repeatedly.
+
+---
+
+## Learning that evolves with the system
+
+The same principle applies to learning. Documentation that lives separately from the system it describes will drift. Tutorials that are not versioned will mislead. Examples that require cloning a repository before you can run them add friction that should not exist.
+
+**[Learning to Orkestrate](/docs/getting-started/01-learning-to-orkestrate/)** is a set of versioned, progressive learning packs — runnable examples that grow with you from your first operator through production patterns, security, and registry distribution. Every capability Orkestra has is demonstrated in a pack you can pull and run:
+
+```bash
+ork init --pack beginner
+ork init --pack registry-guide
+```
+
+No cloning. No searching. One command.
+
+The packs are versioned alongside the CLI. When Orkestra adds a capability, the pack that demonstrates it ships in the same release. When you upgrade, the new examples are available immediately.
+
+---
+
+## Notes that evolve with the CLI
+
+Every Katalog expression — status fields, mutation, validation, enrichment — is written using **Notes**: the built-in template functions that power the Orkestra expression language. Notes are not a separate library to install. They are compiled into the binary.
+
+```bash
+ork notes                     # browse all 115+ built-in functions
+ork notes search <term>       # find a function by keyword
+ork notes show <name>         # full signature and examples
+```
+
+When you upgrade, you get the updated note set automatically — no separate install, no version mismatch between the CLI and the function library it uses.
+
+---
+
+## One upgrade, everything current
+
+```bash
+ork upgrade
+```
+
+This updates the binary, which means:
+
+- **Notes** — the full updated function library, compiled in
+- **Packs** — the updated learning examples, available immediately via `ork init --pack`
+- **Runtime** — the reconciler, gateway, and control center, all at the same version
+
+You do not clone a repository to find the current examples. You do not search for the right version of a tutorial. You upgrade the CLI and everything moves together.
+
+This is not incidental. It is a deliberate design decision rooted in the same principle as Motifs and Katalogs: things that belong together should move together. The learning materials are part of the system, not documentation written separately about the system.
+
+---
+
+## The principle underneath
+
+Accessibility is not about simplifying the concepts. Kubernetes operators are not simple, and pretending otherwise produces fragile systems. Accessibility is about removing the distance between where someone is and where they need to be — reducing the wall, not lowering the ceiling.
+
+Orkestra removes the scaffolding wall by encoding the reconcile loop. It removes the learning wall by shipping examples with the CLI. It removes the distribution wall by building quality gates into the push workflow. It removes the repetition wall by letting teams share solutions through the registry.
+
+The goal is that you spend your time on the problem you actually want to solve.

--- a/documentation/foundations/01-blindness-by-design.md
+++ b/documentation/foundations/01-blindness-by-design.md
@@ -1,0 +1,91 @@
+# Blindness by Design
+
+When two components know too much about each other, changing one breaks the other. In Kubernetes operator development this happens constantly — resource templates written for one specific operator, operator behavior tightly coupled to the infrastructure that runs it, a runtime that assumes it knows where its configuration came from. The coupling is invisible until the moment you try to upgrade something, and then it is everywhere.
+
+Orkestra separates these concerns into distinct layers: reusable resource templates, operator behavior declarations, and the infrastructure — runtime and gateway — that runs them. Each layer is intentionally opaque to the layers around it.
+
+A Motif has no knowledge of the Katalog that imports it. A Katalog has no knowledge of the Komposer that composes it. The Runtime has no knowledge of the registry that published the pattern. None of this is an oversight. Each layer is blind to the next by design — because that blindness is what makes the composition model work at scale, across teams, and across registries you do not control.
+
+---
+
+## The only contract is the Katalog
+
+Orkestra has one universal contract: the **Katalog**. It is what you declare. It is what the Runtime runs. Everything else — Motifs, Komposers, registries — is infrastructure for producing or distributing Katalogs. The Katalog itself is the boundary where your intent meets the system.
+
+This contract has exactly two participants: **your declaration** and **Kubernetes**.
+
+Orkestra does not need to know where your Katalog came from. It does not need to know what Motifs it was built from, which Komposer imported it, or which registry published it. It reads the Katalog. It runs it. That is all.
+
+```text
+Your declaration (Katalog)  +  Kubernetes  =  Running operator
+```
+
+Nothing else is required. Nothing else is assumed.
+
+---
+
+## Each layer is blind to what the next does
+
+**Motifs** are resource templates. A Motif declares inputs and the resources it expands into. It has no knowledge of the Katalog that will import it, which CRD it will be bound to, which CR fields will be passed as inputs, or whether anyone imports it at all. It simply defines a reusable shape.
+
+**Katalogs** import Motifs and declare operators. A Katalog knows its own CRDs, its own reconcile behavior, its own admission rules. It has no knowledge of the Komposer that composes it, the platform that deploys it, or the cluster it runs in. It simply declares intent.
+
+**Komposers** compose Katalogs. A Komposer knows which Katalogs to import and what overrides to apply. It has no knowledge of how any individual Katalog works internally, what Motifs it uses, or what child resources it creates. It simply combines.
+
+**The Runtime** knows the Katalog and Kubernetes. It knows nothing about the registry, the Komposer, the Motifs, or any tooling that produced the Katalog. It reads the resolved declaration and reconciles against the cluster API. That is its entire job.
+
+This is not incidental. It follows directly from [Do One Thing Well](02-do-one-thing-well.md) — a layer that does only one thing needs to know only what that one thing requires. Blindness is the consequence of focus.
+
+---
+
+## You can stop at any layer
+
+The layering is additive, not mandatory. You do not need to use all of it.
+
+**Motifs only** — write a Motif, validate it, publish it. Other teams import it. You are done. The Motif does not know or care whether anyone uses it.
+
+**Katalogs only** — write a Katalog that imports local Motifs or declares resources directly. Run it with `ork run`. Publish it to the registry. Never write a Komposer. A Katalog is a complete, deployable operator on its own.
+
+**Komposers** — compose multiple Katalogs into a single Runtime deployment. This is an optional coordination layer. It does not change what any individual Katalog does; it only determines which Katalogs run together.
+
+You choose how far to go. The system does not pull you further than your problem requires.
+
+---
+
+## The Runtime and Gateway are blind to each other
+
+The blindness between artifact layers — Motif, Katalog, Komposer — is easy to see. Less obvious is that it applies between the production components themselves.
+
+The Runtime reconciles CRs. On every cycle, before creating any child resource, it re-checks the admission rules declared in the Katalog — validation rules, deletion protection, mutation. It does not know whether a Gateway is running. It does not know whether that Gateway intercepted the CR at admission time. It enforces the rules because they are its rules to enforce, unconditionally.
+
+The Gateway serves admission webhooks. When a CR arrives at the API server, the Gateway validates it, mutates it if needed, and either admits or rejects it — before the Runtime ever sees it. The Gateway does not know whether the Runtime will enforce the same rules on every subsequent reconcile. It does not need to.
+
+Both enforce. Neither defers to the other. Neither knows whether the other is present.
+
+This is what makes the two-layer protection real. If the Gateway is absent — not deployed, or temporarily unavailable — the Runtime still enforces at reconcile time. If the Runtime restarts mid-cycle, the Gateway still caught the admission. A CR that slips past one layer runs into the other. The protection does not depend on coordination because there is no coordination to break.
+
+The blindness between them is not a gap. It is what guarantees that both layers enforce independently.
+
+---
+
+## Blindness scales across trust boundaries
+
+The same property that makes composition work within a team makes it work across teams and across registries.
+
+A platform engineer imports a Postgres Katalog from the official Orkestra registry and a WebApp Katalog from an internal registry. The Komposer that combines them knows only that both exist and what overrides to apply. It does not know how Postgres is implemented, what Motif it uses, or what version of the Postgres image is set as default.
+
+The Postgres Katalog does not know it is being composed with WebApp. It does not know it came from a public registry while WebApp came from an internal one. It behaves identically in both cases because it is blind to both.
+
+This is what makes cross-registry, cross-team composition safe. There is no hidden dependency on what any other team is doing. The contract is the Katalog. The contract is public. Everything else is internal.
+
+---
+
+## The orchestra analogy
+
+A violinist in an orchestra knows how to play the violin. That is their job. They do not need to know how the cellos work, what the percussion section is doing, or how the conductor chose the tempo. They play their part.
+
+Together — without any one of them knowing what the others are doing internally — they produce a symphony. The harmony emerges from composition, not from coordination.
+
+Orkestra is built on this principle. Each layer does its job. The Runtime reconciles the Katalog. The Katalog imports the Motif. The Komposer combines the Katalogs. None of them need to understand each other's internals. The composition produces the platform.
+
+The blindness is not a constraint. It is what makes the symphony possible.

--- a/documentation/foundations/02-do-one-thing-well.md
+++ b/documentation/foundations/02-do-one-thing-well.md
@@ -1,0 +1,97 @@
+# Do One Thing Well
+
+The more responsibilities something accumulates, the harder it is to reason about, the more it knows about things it shouldn't, and the more it breaks when something adjacent changes. This is true for software in general. In operator infrastructure, where components compose across teams and registries, it becomes a stability problem.
+
+Each piece of Orkestra has exactly one responsibility. Not "one primary responsibility with some secondary ones." One.
+
+This is the Unix philosophy applied to operator infrastructure. A tool that does one thing can be understood completely. It can be composed freely. It can be replaced, upgraded, or extended without disturbing anything that depends on it.
+
+---
+
+## From packages to CLI
+
+The principle is not a design guideline applied at the architecture level and then forgotten inside the codebase. It runs from the Go packages up through the CLI to the artifacts users write.
+
+`main.go` is 11 lines of actual code. It loads configuration, initializes a context, and calls `cli.Execute`. That is all it does — because it is the entry point, not the program. The program lives in the packages.
+
+Each package has one job: `pkg/konfig` loads and validates configuration, `pkg/logger` provides structured logging, `pkg/merger` resolves and merges Katalog sources, `pkg/simulate` runs the in-memory reconcile loop, `pkg/registry` handles OCI push and pull. None of them know about each other unless the dependency is explicit and necessary.
+
+The CLI commands `(cmd/cli)` are thin wires between user input and package logic. A command parses flags, calls a package function, and formats the result. It does not contain business logic.
+
+This is why the `runtime` build tag works cleanly. The production binary includes only `cmd/cli/run.go` and the packages it depends on. Every other command and its transitive dependencies are absent — not stubbed, not gated, absent. The surface is minimal because the code was written to be minimal.
+
+---
+
+## Each artifact has one role
+
+**Motif** — a reusable resource template. A Motif declares named inputs and the Kubernetes resources it expands into when those inputs are bound. It does not reconcile. It does not run. It does not know who imports it.
+
+**Katalog** — an operator declaration. A Katalog declares one or more CRDs and how to reconcile them: what resources to create, what rules to enforce, what status to propagate. It is a complete operator. It does not know how it was built or who composes it.
+
+**Komposer** — a composition. A Komposer names the Katalogs to run together and any overrides to apply. It does not declare CRDs. It does not contain reconcile logic. It composes.
+
+**Simulate** — a behavioral assertion set. A `simulate.yaml` declares what the reconciler should create and in which cycle. It does not deploy. It does not test a live cluster. It asserts.
+
+**E2E** — a cluster test. An `e2e.yaml` applies CRs to a real cluster and asserts that the right resources appear. It does not simulate. It does not gate publication directly. It tests.
+
+Each of these can be used without the others. A Katalog can be written without Motifs. An operator can be deployed without a Komposer. Simulate and E2E can each be run independently. The layering is additive because each layer is complete on its own.
+
+---
+
+## Orkestra itself is three things — each doing one
+
+The principle applies to the artifacts you write. It also applies to Orkestra as a system.
+
+Orkestra ships as three separate binaries, each with a single job:
+
+| Component | One job |
+|-----------|---------|
+| **Runtime** | Reconcile CRs against Kubernetes |
+| **Gateway** | Handle admission — validation, mutation, deletion protection, version conversion |
+| **Control Center** | Observe — surface health, events, and drift across the cluster |
+
+None of the three knows how to do the other's job. The Control Center cannot reconcile. The Runtime cannot serve admission webhooks. The Gateway cannot render the dashboard. They are not feature flags on a single binary. They are separate processes, separate ServiceAccounts, separate ClusterRoles, and separate containers — each with a surface area limited to exactly what its job requires.
+
+This means each component can fail, be replaced, or be omitted independently. Deploy without a Gateway when you do not need admission webhooks. Run without a Control Center in an environment where observability is handled elsewhere. The system is additive because each piece is complete on its own.
+
+---
+
+## The Runtime does one thing
+
+The Runtime knows the Katalog and Kubernetes. It reads the resolved Katalog at startup, and it reconciles CRs against the Kubernetes API for as long as it runs.
+
+It does not know where the Katalog came from. It does not know whether a Komposer produced it. It does not know which registry the Motifs came from. By the time the Runtime sees the Katalog, all of that context has been resolved away. The Runtime sees a complete declaration, and it runs it.
+
+This is why `ork run` locally and the production Helm deployment behave identically. They are the same binary running the same code on the same input. The only variable is the Katalog.
+
+---
+
+## The Gateway does one thing
+
+The Gateway handles admission — validation, mutation, deletion protection, namespace protection, and version conversion. It registers webhook configurations with the API server, serves the HTTPS endpoints those webhooks call, and manages TLS automatically.
+
+It does not reconcile CRs. It does not read the reconcile templates. It does not know what child resources your operator creates. It knows the admission rules you declared and the Kubernetes API for registering webhooks.
+
+A compromise of the Gateway cannot reach the reconciler. A compromise of the Runtime cannot touch the webhook infrastructure. The separation is enforced by separate Kubernetes ServiceAccounts, separate ClusterRoles, and separate processes — each doing exactly one thing.
+
+---
+
+## The Control Center does one thing
+
+The Control Center observes. It surfaces health state, reconcile events, drift, and status across every CRD the Runtime manages — in one dashboard, across namespaces.
+
+It does not reconcile. It does not validate. It does not intercept API calls. It reads from the same Kubernetes API the Runtime writes to, and it presents what it finds. That is its entire job.
+
+Because the Control Center has no write permissions to CRs or cluster resources, it cannot affect the behavior of the system it watches. You can port-forward it, expose it, or shut it down without changing anything about how the Runtime or Gateway behave. Observation and operation are separated by design — the observer cannot become an actor.
+
+---
+
+## Why this compounds with Blindness
+
+[Blindness by Design](01-blindness-by-design.md) is the consequence of Do One Thing Well.
+
+A layer that does only one thing needs to know only what that one thing requires. The Runtime needs the Katalog and Kubernetes. It does not need the registry, the Komposer, or the Motifs — so it does not know about them. The Motif needs to declare inputs and resources. It does not need to know the Katalog, the Komposer, or the Runtime — so it does not know about them.
+
+The blindness is not imposed from outside. It falls out naturally from the constraint that each piece has one job. Give something one job and it will only need to see what that job requires. Give it multiple jobs and it starts accumulating dependencies.
+
+Orkestra stays composable because every piece stays focused. A platform composed of a hundred Katalogs from a dozen registries works because no piece needed to know about any other piece to do its job correctly.

--- a/documentation/foundations/03-no-autosync.md
+++ b/documentation/foundations/03-no-autosync.md
@@ -1,0 +1,147 @@
+# Configuration is Deliberate
+
+Most infrastructure tools are built around one idea:
+
+> If the source changes, apply the change.
+
+This works well for deployments. It breaks down for APIs.
+
+Orkestra makes a deliberate choice: **it does not automatically re-fetch or re-apply your Katalog when a remote source changes.** That is not a missing feature. It is the point.
+
+---
+
+## CRDs Are Not Deployments
+
+A Deployment is disposable. A CRD is not.
+
+CRDs define long-lived state stored in etcd, API contracts that clients depend on, and reconciliation behavior that shapes how your cluster evolves. Changing a CRD is not shipping a new version — it is changing the rules of the system while it is running.
+
+Auto-syncing that kind of change is dangerous:
+
+- You can introduce breaking schema changes mid-operation
+- Reconciliation logic can silently shift under a running workload
+- Behavior can diverge across environments when sources update at different times
+
+In practice, this leads to instability disguised as automation.
+
+---
+
+## What Orkestra Does Instead
+
+When Orkestra starts, it:
+
+1. Pulls all sources — files, OCI artifacts, Komposer imports
+2. Merges them into a single resolved Katalog
+3. Validates everything
+4. Starts the runtime
+
+And then it stops listening to sources.
+
+No polling. No background updates. No surprise changes.
+
+From that moment on, **the configuration is fixed. Only the cluster state evolves.**
+
+The reconciler watches your CRs continuously and corrects drift forever. But the Katalog it reconciles against — the templates, the rules, the resource declarations — is what was resolved at startup. It does not change until you change it and restart.
+
+---
+
+## Why This Matters at Scale
+
+A single Orkestra runtime can compose multiple sources:
+
+- Public baselines from the Orkestra registry
+- Internal platform Katalogs
+- Security policies
+- Compliance katalogs
+
+This is not one source of truth. It is a composed system. If Orkestra auto-synced all of these:
+
+- One bad commit to one source could corrupt the entire runtime
+- Partial updates could leave the system in an inconsistent intermediate state
+- Network issues could create behavioral divergence between replicas
+
+When you manage multiple CRDs in one process, **input integrity becomes critical to system stability.** So Orkestra treats configuration as immutable during execution.
+
+---
+
+## Production Is the Default
+
+Most systems treat production as a special mode. Orkestra treats every run as production.
+
+Starting Orkestra is a deployment:
+
+- Configuration is resolved
+- State is locked in
+- Reconciliation begins
+
+Upgrading Orkestra is also a deployment:
+
+- You update the bundle
+- You restart the runtime
+- You take responsibility for the change
+
+Nothing happens implicitly. This is what makes Orkestra safe to operate — and safe to leave running.
+
+---
+
+## Upgrading Deliberately
+
+Because configuration locks in at startup, upgrading a Katalog requires a restart. The restart is not a limitation. It is the handoff.
+
+```bash
+# 1. Update your Komposer or Katalog
+# 2. Regenerate the bundle
+ork generate bundle -f komposer.yaml -o bundle.yaml
+
+# 3. Apply the new bundle
+kubectl apply -f bundle.yaml
+
+# 4. Restart — this is the moment the new contract takes effect
+kubectl rollout restart deployment/orkestra-runtime -n orkestra-system
+kubectl rollout status deployment/orkestra-runtime -n orkestra-system
+```
+
+Between step 3 and step 4, the ConfigMap has changed but the runtime has not. The old behavior continues. The restart is the explicit signal: *I am ready to serve the new contract.*
+
+This means rollback is the same operation in reverse — reapply the previous bundle, restart. The old version is still in the registry. Nothing was deleted. The contract simply reverts.
+
+---
+
+## The Trade-Off
+
+You lose:
+
+- Automatic updates from a Git push or a registry tag bump
+- Continuous sync behavior familiar from GitOps tools
+
+You gain:
+
+- Deterministic runtime behavior — the Katalog at startup is the Katalog forever
+- Stable APIs — clients calling the API server get the same schema throughout the runtime's lifetime
+- Clear deployment boundaries — every configuration change is a named, auditable event
+- Safe CRD evolution — schema changes do not surprise running reconcilers mid-cycle
+
+For systems built around APIs — not just containers — that trade is worth it.
+
+---
+
+## The Principle
+
+> Reconciliation is continuous.
+> Configuration is deliberate.
+
+The reconciler watches your CRs forever and corrects drift without interruption. The Katalog it reconciles against is what you deployed, locked in at start time, unchanged until you say otherwise. These two properties together make Orkestra predictable to operate and safe to upgrade.
+
+---
+
+## Where this appears in practice
+
+- **The upgrade story** — two Katalogs in the same cluster on different versions of the same Motif, each changing on its own schedule.
+
+  **Try it**
+  ```bash
+  ork init --pack registry-guide
+  cd registry-guide/07-upgrade
+  ```
+
+- **`ork plan`** — shows you the reconciler template diff before you apply a new bundle and restart, so you know what changes before you commit to the restart.

--- a/documentation/foundations/04-secure-by-design.md
+++ b/documentation/foundations/04-secure-by-design.md
@@ -1,0 +1,213 @@
+# Secure by Design
+
+The typical pattern for security in infrastructure tooling is additive: build the system first, then restrict what it can do. Add a flag to disable the admin endpoint. Strip permissions in the production role. Document which commands are "for development only." The result is a system that is secure if you remember to configure it correctly — and fragile everywhere you forget.
+
+Orkestra inverts this. Security is not a layer added afterward. It is a property of the design — present by default at every layer, from the binaries that ship to the permissions they request to the rules that govern what reaches the cluster.
+
+The goal is simple: the system should be trustworthy by construction, not by configuration.
+
+---
+
+## The binary surface is minimal by construction
+
+Orkestra ships three compiled binaries from a single codebase. Go build tags separate them at compile time — not behind a flag, not at runtime.
+
+| Binary | What it can do |
+|--------|---------------|
+| `ork` (developer CLI) | Everything — validate, generate, simulate, e2e, template, init, run |
+| `ork` (runtime, `//go:build runtime`) | `ork run` only |
+| `ork-gateway` (gateway, `//go:build gateway`) | `ork gate` only |
+
+The runtime binary cannot generate RBAC bundles. It cannot scaffold operators. It cannot enumerate registered CRDs or exfiltrate Katalog definitions. That code does not exist in the binary.
+
+This is a structural guarantee, not a permissions check. A permissions check can be misconfigured. A compile-time exclusion cannot.
+
+The developer CLI is intentionally feature-complete — `ork validate`, `ork simulate`, `ork e2e`, `ork generate`, `ork template` are all available locally. Nothing is held back from the engineer writing and testing patterns. What is held back is from the production process running them.
+
+---
+
+## Two trust domains that cannot cross
+
+The Runtime and Gateway run as two separate processes with separate Kubernetes ServiceAccounts and separate ClusterRoles. Neither carries the permissions of the other.
+
+The **Runtime** reconciles custom resources. It reads CRs, applies templates, manages the resources declared in `onCreate` and `onReconcile` blocks, and emits events. It has no permissions to touch webhook configurations or TLS certificates.
+
+The **Gateway** serves admission webhooks — validation, mutation, deletion protection, and version conversion. It manages TLS automatically. It has no permissions to reconcile CRs or manage the resources your operator controls.
+
+A compromise of the Runtime cannot touch webhook infrastructure. A compromise of the Gateway cannot touch your CRs. The blast radius of either failure is bounded by what that process was ever permitted to do.
+
+When a feature is disabled in the Katalog, the Gateway removes the corresponding webhook configuration — the security surface shrinks automatically to match the declared intent.
+
+---
+
+## CRD isolation: each operator runs in its own cell
+
+Each CRD declared in a Katalog runs inside its own **OperatorBox** — an isolated runtime cell with its own informer, event queue, worker pool, health state, and reconciler instance. Nothing is shared.
+
+A panic in one reconciler — any unrecovered Go panic — is caught, logged with the full stack trace, and requeued with backoff. The affected OperatorBox retries. Every other OperatorBox continues uninterrupted.
+
+Queue pressure in one OperatorBox does not affect reconcile latency in another. A misbehaving CRD does not destabilize the rest of the platform.
+
+Communication between OperatorBoxes is always opt-in via a `cross:` declaration in the Katalog. What is not declared does not happen.
+
+---
+
+## RBAC is derived, not authored
+
+Orkestra never auto-creates permissions. Every right your operator has is computed from what you declared in the Katalog and reviewed by you before it reaches the cluster.
+
+```bash
+ork validate --full    # see exactly what permissions will be requested
+ork generate bundle    # produce the bundle containing those permissions
+kubectl apply -f bundle.yaml
+```
+
+The generated bundle contains three separate ClusterRoles — one for the Runtime, one for the Gateway, one for the Control Center. They do not overlap. Gateway permissions are only generated if the features that require them are declared: no validation rules means no `admissionregistration.k8s.io` entries in the bundle at all.
+
+Traditional operators often ship with:
+
+```yaml
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+```
+
+The Orkestra bundle contains:
+
+```yaml
+- apiGroups: ["platform.orkestra.io"]
+  resources: ["websites"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["platform.orkestra.io"]
+  resources: ["websites/status"]
+  verbs: ["get", "update", "patch"]
+```
+
+Only the API groups you declared. Only the resource kinds those groups produce. Only the verbs those resources need. Built-in resources (Deployments, Services, ConfigMaps) only appear if your Katalog actually uses them.
+
+The bundle diffs cleanly in GitOps workflows. Every change to the Katalog produces a visible, reviewable diff in the bundle before it reaches the cluster.
+
+---
+
+## The containers are hardened by default
+
+Both production binaries run in a distroless base image: no shell, no package manager, no curl, no tar, no standard Unix utilities. An attacker who gains code execution in the container has a single static binary and nothing to pivot with.
+
+The Helm chart applies a hardened security context to every pod by default:
+
+```yaml
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  capabilities:
+    drop: ["ALL"]
+seccompProfile:
+  type: RuntimeDefault
+```
+
+These are on by default. Nothing needs to be configured to get them. They apply to the runtime, the gateway, and the control center.
+
+The same security profiles are available to workloads you declare in your Katalog:
+
+```yaml
+securityContext:
+  profile: hardened
+podSecurity:
+  profile: hardened
+```
+
+`hardened` maps to `readOnlyRootFilesystem: true`, `runAsNonRoot: true`, `capabilities.drop: ["ALL"]`, UID 65534. A one-line declaration. No need to repeat the same five fields across every Deployment in the Katalog.
+
+---
+
+## Each layer is designed for the one below it to fail
+
+This is the principle that ties every security property together.
+
+The level-triggered reconciler assumes it will be interrupted — crash, SIGKILL, node failure, all produce a partial state that the next reconcile corrects. The panic recovery in each OperatorBox assumes individual reconciles will fail. The isolated worker pools assume one CRD's failure will happen. The leader election assumes the entire process will crash. The admission layer assumes the reconciler may not see every CR. The production binary assumes someone might try to misuse whatever surface is exposed.
+
+**Each layer is designed for the one below it to fail, and to remain correct when it does.**
+
+The result is a system where trustworthy behavior does not depend on everything going right. It depends on the guarantees holding even when things go wrong.
+
+---
+
+## Validation runs at five independent points
+
+Security rules declared in a Katalog are not enforced once. They are enforced at every layer where enforcement is possible:
+
+```text
+1. Parse time         — strict YAML: unknown fields are errors, not silent defaults
+2. ork validate       — offline: schema, templates, dependency graph, namespace rules
+3. ork simulate       — offline: reconcile loop against in-memory state
+4. Admission webhook  — live: Gateway intercepts CREATE/UPDATE before etcd storage
+5. Reconcile time     — live: Runtime re-checks every rule on every reconcile cycle
+```
+
+A `deny` rule that catches a bad CR at admission time will also catch it if the CR somehow bypasses the webhook. The Runtime enforces rules independently of the Gateway. Both layers must fail independently before a rule is violated.
+
+Each enforcement point assumes the one before it may be absent or imperfect. This is not redundancy — it is how the system stays correct when parts of it fail.
+
+---
+
+## Orkestra's own credentials are never hardcoded
+
+A Katalog is a behavioral contract — a description of what the operator does. It is committed to source control, reviewed in pull requests, distributed as a versioned OCI artifact. Anywhere Orkestra itself needs a credential — to fetch a private source, to send a notification, to pull from a protected registry — the credential is named, not embedded.
+
+The pattern is consistent: the YAML names an environment variable; the runtime resolves it.
+
+**File source authentication** — when a Katalog imports a private file over HTTPS or from GitHub:
+
+```yaml
+files:
+  - url: https://private.host/platform-policy.yaml
+    auth:
+      type: bearer
+      fromEnv: PLATFORM_TOKEN
+
+  - url: https://github.com/myorg/private-registry
+    auth:
+      type: github
+      fromEnv: GITHUB_TOKEN
+
+  - url: https://internal.host/policy.yaml
+    auth:
+      type: basic
+      usernameFromEnv: REGISTRY_USER
+      passwordFromEnv: REGISTRY_PASSWORD
+```
+
+**Registry source authentication** — when a Komposer pulls from a private OCI registry or a private Git registry:
+
+```yaml
+imports:
+  registry:
+    - url: registry.myorg.com/operators/postgres@v14-hardened
+      oci: true
+      auth:
+        type: basic
+        usernameFromEnv: REGISTRY_USER
+        passwordFromEnv: REGISTRY_PASSWORD
+
+    - url: https://github.com/myorg/private-registry
+      auth:
+        type: github
+        fromEnv: GITHUB_TOKEN
+```
+
+**Notification credentials** — SMTP credentials (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM`) are read from the runtime's process environment at startup. They are never declared in the Katalog YAML. The Slack webhook URL is declared per team in the notification block; it should be treated with the same care as any other credential — injected via the Helm chart's `runtime.env` block rather than committed to source control.
+
+In each case, the YAML file that ships in the OCI artifact contains no credential. The artifact is the same in every environment. Only the environment it runs in differs.
+
+---
+
+## Where this appears across the documentation
+
+- **[Binaries & build tags](../security/01-binaries.md)** — complete command matrix by binary
+- **[RBAC](../security/02-rbac.md)** — full bundle contents and `--for` flag for component-scoped generation
+- **[Admission webhooks](../security/03-admission.md)** — validation, mutation, and conversion details
+- **[Deletion protection](../security/04-deletion-protection.md)** — protecting CRs and Orkestra's own infrastructure
+- **[Validation pipeline](../security/06-validation-pipeline.md)** — all five enforcement points in detail
+- **[Pod security](../security/07-pod-security.md)** — `baseline`, `restricted`, `hardened` profiles
+- **[Trust and Failure Model](../publications/02-trust-and-failure-model.md)** — how the security layers compound

--- a/documentation/foundations/05-production-mode-as-default.md
+++ b/documentation/foundations/05-production-mode-as-default.md
@@ -1,0 +1,127 @@
+# Production Mode as Default
+
+Most systems distinguish between a local development mode and a production mode. Development mode relaxes things — faster feedback, looser validation, skipped steps. Production mode adds them back. The gap between the two is where most surprises live.
+
+Orkestra does not have two modes. Every run is a production run.
+
+---
+
+## `ork run` is a production-grade deployment
+
+`ork run` is not a convenience wrapper for local development. When you run it locally, you are running the full developer CLI — every command available. In production, the runtime binary has all other commands stripped out at compile time. But `ork run` itself is identical: the same reconciler, the same validation pipeline, the same behavior. What production removes is the surface you do not need there. What it runs is exactly what you ran locally.
+
+`ork run --dev` creates a real kind cluster — real Kubernetes API server, real etcd, real admission webhooks. The `--dev` flag provisions the infrastructure you do not already have. It does not relax anything about how Orkestra behaves inside it.
+
+---
+
+## The producer pipeline has no shortcuts
+
+Every Orkestra pattern goes through the same pipeline before it can be distributed:
+
+```text
+ork validate   →   ork simulate   →   ork e2e   →   ork push
+    ↓                  ↓                ↓                  ↓
+schema valid?     assertions pass?   cluster test?    gates passed?
+                  no cluster        real cluster      → artifact ships
+```
+
+`ork simulate` runs the reconciler loop against an in-memory state machine. No cluster. No infrastructure. Sub-second. It asserts that what the Katalog claims to create is what the reconciler actually creates.
+
+`ork e2e` runs the same assertions against a real Kubernetes cluster. A CR is applied. Resources are checked. Conditions are verified. The operator behaves exactly as it would in production — because it is production.
+
+`ork push` runs both gates automatically before publishing. Simulate fails → push is blocked. E2E fails → push is blocked. The gates can be overridden — `--no-simulate`, `--no-e2e`, `--force` — but the override is visible. A skipped gate is recorded in the OCI annotations. Every consumer who inspects the artifact will see what was not run. The proof travels with the artifact because the gates are the default, and bypassing them leaves a permanent mark.
+
+---
+
+## The proof travels with the artifact
+
+When a pattern is pushed to the registry, Orkestra writes the gate results as OCI annotations on the artifact:
+
+```yaml
+io.orkestra.simulate.status:  passed
+io.orkestra.simulate.count:   4
+io.orkestra.e2e.status:       passed
+```
+
+These annotations are immutable — they record what the author proved before they shipped. A consumer who pulls the pattern can read them with `ork inspect` before writing a single line of YAML:
+
+```bash
+ork inspect ghcr.io/myorg/katalogs/postgres@v1.0.0
+# Simulate:  ✓ Passed — 4 assertions
+# E2E:       ✓ Passed
+```
+
+A pattern showing `simulate: skipped` or `e2e: failed` signals to every consumer that the author bypassed a gate. This is not hidden. It is surfaced in every inspection command.
+
+Consumers can go further. They can pull the pattern and re-run the author's assertions in their own cluster:
+
+```bash
+ork pull ghcr.io/myorg/katalogs/postgres@v1.0.0
+ork simulate -f ~/.orkestra/cache/postgres-v1.0.0/simulate.yaml
+ork e2e -f ~/.orkestra/cache/postgres-v1.0.0/e2e.yaml
+```
+
+The same simulate.yaml and e2e.yaml the author ran are embedded in the artifact. The consumer is not trusting the annotation — they are reproducing the proof. This is the supply chain verification model: behavior you can confirm yourself, before you let it manage your cluster.
+
+---
+
+## Supply chain security
+
+A pattern in the Orkestra registry is not just a YAML file. It is a versioned, immutable artifact with embedded behavioral proof. Each of these properties has a security implication:
+
+**Versioned** — consumers pin to an exact version. A new push to `latest` does not automatically flow to anyone. Breaking changes cannot silently appear in a production operator.
+
+**Embedded proof** — the simulate and e2e assertions are in the artifact. Not in a separate wiki. Not in a README that may have been edited after the push. In the artifact, written at push time by the tool that verified them.
+
+**Reproducible** — any consumer can re-run the proof in their environment. The annotations describe what passed; the embedded files let you confirm it.
+
+**Visible signal** — `ork patterns` shows E2E status for every pattern. `ork inspect` shows simulate assertions. A pattern that skipped its gates is visible at a glance, before anyone imports it.
+
+Together these properties mean that importing a pattern from the Orkestra registry is not an act of trust. It is an act of verification. You inspect the proof, you re-run it if you choose, and you know exactly what you are deploying before you deploy it.
+
+---
+
+## No divergence between environments
+
+The only thing that differs between a local `ork run` and a production Helm deployment is configuration — the Katalog you give it, the environment variables set, the resources available. The runtime behavior is identical.
+
+This means:
+- A bug caught by `ork simulate` locally is a bug that would have appeared in production.
+- A pattern that passes `ork e2e` against a local kind cluster behaves the same way in a production EKS cluster.
+- The RBAC bundle generated by `ork generate bundle` is the same bundle in every environment.
+- The validation rules enforced at admission time in staging are the same rules in production.
+
+There is no "we'll harden it before it goes to production." Production is always already the standard. The only question is which cluster you are running it against.
+
+---
+
+## Every decision is a production decision
+
+This principle extends beyond the runtime to how Orkestra is designed.
+
+The production binary excludes developer commands at compile time — not because production has stricter flags, but because the production binary was never built with those commands. [Secure by Design](04-secure-by-design.md) follows from production-as-default: if every run is a production run, then every binary is a production binary.
+
+`ork validate --full` shows you permissions before any cluster interaction — not because you might deploy to production soon, but because the review step belongs before deployment, always, not just before the final deployment.
+
+The bundle you generate and review is the same bundle in every environment. The deliberate restart that upgrades the runtime is the same operation locally and in production. [Configuration is deliberate](03-no-autosync.md) follows from the same premise: if every run is a production run, then every configuration change is a production change.
+
+---
+
+## What this means for teams
+
+A pattern that passes `ork simulate` and `ork e2e` locally is a pattern that is ready for production. Not "ready to be hardened." Ready.
+
+A PR that includes a failing `ork simulate` is a PR that contains a broken operator. Not "broken in a way we'll fix before production." Broken.
+
+An artifact in the registry with `e2e: passed` is an artifact that a stranger can pull, re-run the proof, and deploy with confidence — because production was the standard the author worked to when they shipped it.
+
+---
+
+## Where this appears across the documentation
+
+- **[Registry: Publish with gates](../orkestra-registry/02-katalogs.md)** — `ork push` gate behavior, `--no-simulate`, `--no-e2e` flags and their annotation consequences
+- **[Simulate](../concepts/simulate/)** — the in-memory reconcile loop and assertion model
+- **[E2E](../concepts/e2e/)** — the declarative cluster test format
+- **[Supply chain verification](../orkestra-registry/02-katalogs.md#supply-chain-verification)** — re-running author proofs as a consumer
+- **[Configuration is Deliberate](03-no-autosync.md)** — why upgrades require an explicit restart
+- **[Secure by Design](04-secure-by-design.md)** — why the production binary is narrower than the developer CLI

--- a/documentation/foundations/index.md
+++ b/documentation/foundations/index.md
@@ -1,0 +1,47 @@
+# Foundations
+
+These are the decisions that shaped everything else. Not rules imposed from outside — convictions earned while building, tested against real problems, and refined until the design held together.
+
+Writing them down is the starting point. For the engineers who use Orkestra and want to understand why it behaves the way it does. For the contributors who want to push it further without breaking what makes it work. For anyone who arrives here wondering whether this is a system worth investing in.
+
+They are not features. They are not configuration options. They are the load-bearing assumptions the whole design rests on. When something in Orkestra feels unexpected, the explanation is usually here.
+
+The principles are not independent. Blindness makes do-one-thing-well possible — a layer can focus on its single job because it has no surface area with any other layer. Do-one-thing-well makes deliberate configuration meaningful — if each layer has one job, the contract that locks in at startup is small and knowable. Deliberate configuration is what makes production-as-default safe — you cannot accidentally promote a partially-updated runtime because the update requires an explicit restart. And secure-by-design is what makes the whole composable system trustworthy — each layer's security posture is derived from its declared intent, not from what the author remembered to configure.
+
+They compound. Read them in order if you can.
+
+---
+
+**[Operators for Everyone](00-operators-for-everyone.md)** — The mission underneath all of it. Operators were hard to write not because the concept is hard, but because the wall between the idea and a working implementation was too high. Orkestra removes that wall — through the runtime, through the patterns in the registry, through learning materials that ship with the CLI and evolve with it. Common problems solved collectively and once, so that every team can focus on the problem they actually came to solve.
+
+→ [Read: Operators for Everyone](00-operators-for-everyone.md)
+
+---
+
+**[Blindness by Design](01-blindness-by-design.md)** — Every layer in Orkestra is intentionally opaque to the layers around it. A Motif has no knowledge of the Katalog that imports it. A Katalog has no knowledge of the Komposer that composes it. The runtime has no knowledge of the registry that published the pattern. This blindness is not a limitation — it is the property that makes composition safe across teams, trust boundaries, and registries.
+
+→ [Read: Blindness by Design](01-blindness-by-design.md)
+
+---
+
+**[Do One Thing Well](02-do-one-thing-well.md)** — Each Orkestra artifact has exactly one responsibility. A Motif is a resource template. A Katalog is an operator declaration. A Komposer is a composition. None does more than its role, and none knows more than its role requires. This is why you can add a Katalog without touching any other Katalog, upgrade a Motif without rewriting the operator that imports it, and compose patterns from registries you do not control.
+
+→ [Read: Do One Thing Well](02-do-one-thing-well.md)
+
+---
+
+**[Configuration is Deliberate](03-no-autosync.md)** — Orkestra reads your Katalog at startup and shuts the door. No polling. No background updates. No automatic re-sync when a source changes. Reconciliation is continuous — the runtime watches your CRs and corrects drift forever. But configuration is a contract that locks in at start time, and changing it is a deliberate act: update the bundle, restart the runtime.
+
+→ [Read: Configuration is Deliberate](03-no-autosync.md)
+
+---
+
+**[Secure by Design](04-secure-by-design.md)** — Security in Orkestra is structural, not a layer bolted on after the fact. Least-privilege RBAC is derived from what you declared — not requested. Admission gates enforce the same rules at two independent points. The production binary cannot run developer commands. These properties hold by default; you do not opt into them.
+
+→ [Read: Secure by Design](04-secure-by-design.md)
+
+---
+
+**[Production Mode as Default](05-production-mode-as-default.md)** — Orkestra does not have a relaxed local mode and a strict production mode. Every run — local, CI, staging, production — starts the same runtime, applies the same validation, enforces the same rules. The only difference between environments is your configuration. This is what makes behavior consistent and promotions predictable.
+
+→ [Read: Production Mode as Default](05-production-mode-as-default.md)

--- a/examples/registry-guide/12-ork-action/.github/workflows/publish-typed.yml
+++ b/examples/registry-guide/12-ork-action/.github/workflows/publish-typed.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           go-version-file: ./database-operator/go.mod
 
+      - name: Set lowercase owner
+        run: echo "OWNER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       # 1. Generate pkg/typeregistry/zz_generated_typeregistry.go from katalog.yaml.
       #    Uses the standard ork installed by the action — only needs ork generate registry.
       - name: Generate runtime registry
@@ -61,7 +64,7 @@ jobs:
         with:
           context: ./database-operator
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/database-operator:${{ github.ref_name }}
+          tags: ghcr.io/${{ env.OWNER }}/database-operator:${{ github.ref_name }}
 
       # 4. Same publish step as the declarative workflow — validate, simulate, push.
       #    The custom ork from step 2 is in PATH; the action uses it automatically.
@@ -73,7 +76,7 @@ jobs:
           validate: "true"
           simulate: "true"
           registry-push: "database-operator:${{ github.ref_name }} ."
-          registry-url: "ghcr.io/${{ github.repository_owner }}/katalogs"
+          registry-url: "ghcr.io/${{ env.OWNER }}/katalogs"
           registry-username: ${{ github.actor }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
           working-directory: ./database-operator

--- a/examples/registry-guide/12-ork-action/.github/workflows/publish.yml
+++ b/examples/registry-guide/12-ork-action/.github/workflows/publish.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set lowercase owner
+        run: echo "OWNER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Publish to registry
         uses: orkspace/orkestra-action@v1
         with:
@@ -20,7 +23,7 @@ jobs:
           validate: "true"
           simulate: "true"
           registry-push: "webapp-operator:${{ github.ref_name }} ."
-          registry-url: "ghcr.io/${{ github.repository_owner }}/katalogs"
+          registry-url: "ghcr.io/${{ env.OWNER }}/katalogs"
           registry-username: ${{ github.actor }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
           working-directory: ./webapp-operator


### PR DESCRIPTION
## Summary

- Adds `documentation/foundations/` — six principle pages (operators for everyone, blindness by design, do one thing well, deliberate configuration, secure by design, production mode as default) plus an index
- Fixes GHCR uppercase owner bug in registry-guide `publish.yml` and `publish-typed.yml` — `github.repository_owner` preserves casing; GHCR requires lowercase

## Notes

The foundations pages are written for both audiences: engineers who have written operators (recognize the pain) and those who haven't (get enough context to understand why the design decisions matter). The blindness-by-design page explicitly covers the Runtime ↔ Gateway independence as the clearest instance of the principle.
