### PR TITLE
feat: prep for new packs — ork migrate, deletion protection

### DIFF
--- a/cmd/cli/migrate.go
+++ b/cmd/cli/migrate.go
@@ -95,6 +95,7 @@ func writeOutputDir(dir, inputPath string, res *migrate.Result, files migrate.Fi
 		{"go.mod", files.GoMod},
 		{"Makefile", files.Makefile},
 		{"Dockerfile", files.Dockerfile},
+		{"README.md", files.README},
 	}
 	for _, f := range generated {
 		dest := filepath.Join(dir, f.name)
@@ -113,7 +114,7 @@ func replaceInPlace(inputPath string, res *migrate.Result, files migrate.Files) 
 	dir := filepath.Dir(inputPath)
 
 	fmt.Printf("This will replace %s and write %s alongside it.\n",
-		bold(inputPath), bold("katalog.yaml, simulate.yaml, e2e.yaml, go.mod, Makefile, Dockerfile"))
+		bold(inputPath), bold("katalog.yaml, simulate.yaml, e2e.yaml, go.mod, Makefile, Dockerfile, README.md"))
 	fmt.Printf("%s [y/N] ", yellow("Continue?"))
 
 	scanner := bufio.NewScanner(os.Stdin)

--- a/cmd/cli/simulate.go
+++ b/cmd/cli/simulate.go
@@ -465,8 +465,8 @@ func runSimulateFromSpec(ctx context.Context, path string, crdName string, maxCy
 		return fmt.Errorf("reading %s: %w", path, err)
 	}
 	var doc orktypes.Simulate
-	if err := yaml.Unmarshal(data, &doc); err != nil {
-		return fmt.Errorf("parsing %s:\n%s", path, orkutils.FormatYAMLError(err, data))
+	if err := orkutils.StrictUnmarshal(data, &doc); err != nil {
+		return fmt.Errorf("parsing %s:\n%s", path, err)
 	}
 
 	dir := filepath.Dir(path)

--- a/cmd/cli/validate.go
+++ b/cmd/cli/validate.go
@@ -15,6 +15,7 @@ import (
 	"github.com/orkspace/orkestra/pkg/katalog"
 	"github.com/orkspace/orkestra/pkg/konfig"
 	orktypes "github.com/orkspace/orkestra/pkg/types"
+	orkutils "github.com/orkspace/orkestra/pkg/utils"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -207,7 +208,7 @@ func validateE2EFile(path string) error {
 	}
 
 	var doc orktypes.E2E
-	if err := yaml.Unmarshal(data, &doc); err != nil {
+	if err := orkutils.StrictUnmarshal(data, &doc); err != nil {
 		return fmt.Errorf("parsing %s: %w", path, err)
 	}
 

--- a/documentation/getting-started/01-learning-to-orkestrate/08-ecosystem.md
+++ b/documentation/getting-started/01-learning-to-orkestrate/08-ecosystem.md
@@ -18,8 +18,8 @@ ork init --pack ecosystem-composition
 | `01-cert-manager` | `SecurityConfig` → cert-manager `Certificate` |
 | `02-prometheus` | `MonitoringConfig` → `ServiceMonitor` + `PrometheusRule` |
 | `03-crossplane` | `Infra` → Crossplane Composite Claim |
-| `04-platform-stack` | All four in one Komposer |
-| `05-policy-layer` | Shared admission motif across all four |
+| `04-platform-stack` | All four in one Komposer, gateway admission + deletion protection |
+| `05-all-in-one` | One `PlatformResource` CRD, `workloadType` discriminator |
 
 ---
 

--- a/pkg/e2e/runner.go
+++ b/pkg/e2e/runner.go
@@ -33,7 +33,9 @@ import (
 	"github.com/orkspace/orkestra/pkg/motif"
 	"github.com/orkspace/orkestra/pkg/ork"
 	"github.com/orkspace/orkestra/pkg/registry"
+	"github.com/orkspace/orkestra/pkg/spinner"
 	orktypes "github.com/orkspace/orkestra/pkg/types"
+	orkutils "github.com/orkspace/orkestra/pkg/utils"
 	"gopkg.in/yaml.v3"
 )
 
@@ -82,7 +84,7 @@ func New(e2eFile, clusterCtx string, useCurrentCtx, keepCluster, devServer bool,
 	}
 
 	var e2e orktypes.E2E
-	if err := yaml.Unmarshal(data, &e2e); err != nil {
+	if err := orkutils.StrictUnmarshal(data, &e2e); err != nil {
 		return nil, fmt.Errorf("parsing %s: %w", e2eFile, err)
 	}
 	if e2e.Kind != "E2E" {
@@ -300,12 +302,13 @@ func (r *Runner) Run(ctx context.Context) (*Result, error) {
 			}
 
 			if !ork.RuntimeInstalled() {
-				fmt.Printf("→ Installing Orkestra%s\n", text)
+				sp := spinner.Start("Installing Orkestra" + text)
 				if err := ork.InstallOrUpgradeOrkestra(r.orkestraVersion, r.valueFiles, r.helmArgs...); err != nil {
+					sp.Failure()
 					return nil, fmt.Errorf("helm install: %w", err)
 				}
+				sp.Success()
 				installedOrkestra = true
-				fmt.Printf("  ✓ Orkestra installed\n")
 			} else {
 				// Orkestra already running — sync bundle silently.
 				if err := ork.SyncRuntime(); err != nil {
@@ -317,12 +320,13 @@ func (r *Runner) Run(ctx context.Context) (*Result, error) {
 							return nil, fmt.Errorf("syncing Orkestra gateway: %w", err)
 						}
 					} else {
-						fmt.Printf("→ Upgrading Orkestra to enable gateway...\n")
+						sp := spinner.Start("Upgrading Orkestra to enable gateway...")
 						if err := ork.InstallOrUpgradeOrkestra(r.orkestraVersion, r.valueFiles, r.helmArgs...); err != nil {
+							sp.Failure()
 							return nil, fmt.Errorf("helm upgrade: %w", err)
 						}
+						sp.Success()
 						installedOrkestra = true
-						fmt.Printf("  ✓ Orkestra upgraded with gateway\n")
 					}
 				}
 				// Health check — silent, still blocks until ready.
@@ -337,20 +341,15 @@ func (r *Runner) Run(ctx context.Context) (*Result, error) {
 			}
 
 			if installedOrkestra {
-				fmt.Printf("→ Waiting for Orkestra to be ready...\n")
 				status := ork.CheckRuntimeHealth()
 				if !status.Running {
 					return nil, fmt.Errorf("Orkestra runtime not ready: %s", status.Reason)
 				}
-				fmt.Printf("  ✓ Orkestra runtime ready\n\n")
-
 				if gatewayEnabled {
-					fmt.Printf("→ Waiting for Orkestra gateway to be ready...\n")
 					status := ork.CheckGatewayHealth()
 					if !status.Running {
 						return nil, fmt.Errorf("Orkestra gateway not ready: %s", status.Reason)
 					}
-					fmt.Printf("  ✓ Orkestra gateway ready\n\n")
 				}
 			}
 		}
@@ -514,7 +513,6 @@ func (r *Runner) ensureCluster(ctx context.Context) error {
 		}
 	}
 
-	fmt.Printf("→ Ensuring cluster '%s'...\n", name)
 	return ork.EnsureKindCluster(name)
 }
 
@@ -683,11 +681,12 @@ func (r *Runner) applySetup(ctx context.Context) ([]string, error) {
 
 	// ── Phase 2: helm ─────────────────────────────────────────────────────────
 	for _, h := range s.Helm {
-		fmt.Printf("→ Installing %s/%s...\n", h.Repo, h.Chart)
+		sp := spinner.Start(fmt.Sprintf("Installing %s...", h.ReleaseName()))
 		if err := ork.HelmInstall(ctx, h); err != nil {
+			sp.Failure()
 			return applied, fmt.Errorf("setup helm %s/%s: %w", h.Repo, h.Chart, err)
 		}
-		fmt.Printf("  ✓ Installed %s\n", h.ReleaseName())
+		sp.Success()
 	}
 
 	// ── Phase 3: wait ─────────────────────────────────────────────────────────
@@ -696,11 +695,12 @@ func (r *Runner) applySetup(ctx context.Context) ([]string, error) {
 		if w.Namespace != "" {
 			loc += " (" + w.Namespace + ")"
 		}
-		fmt.Printf("→ Waiting for %s...\n", loc)
+		sp := spinner.Start(fmt.Sprintf("Waiting for %s...", loc))
 		if err := ork.WaitForResource(ctx, w); err != nil {
+			sp.Failure()
 			return applied, fmt.Errorf("setup wait: %w", err)
 		}
-		fmt.Printf("  ✓ Ready\n")
+		sp.Success()
 	}
 
 	return applied, nil

--- a/pkg/katalog/deletion_protection.go
+++ b/pkg/katalog/deletion_protection.go
@@ -22,9 +22,12 @@ package katalog
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/orkspace/orkestra/pkg/children"
+	orktypes "github.com/orkspace/orkestra/pkg/types"
 	"github.com/orkspace/orkestra/pkg/utils"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // DeletionProtectionGVRs returns the list of GVRs that the deletion‑protection
@@ -117,7 +120,10 @@ func orkestraInternalGVRs() []GVREntry {
 // Those are protected separately by the first webhook (CRD protection) using
 // DeletionProtectedCRDNames(), which respects ShouldProtectCRD().
 func (k *Katalog) customResourceGVRs() []GVREntry {
+	seen := make(map[string]bool)
 	var gvrList []GVREntry
+
+	// Owner CRDs managed by this Katalog.
 	for _, crd := range k.enabledCRDs {
 		if !crd.ShouldProtectCRs() {
 			continue
@@ -126,15 +132,69 @@ func (k *Katalog) customResourceGVRs() []GVREntry {
 			continue
 		}
 		gvr := crd.GVR()
+		key := gvr.String()
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
 		gvrList = append(gvrList, GVREntry{
-			Key:        gvr.String(),
+			Key:        key,
 			Group:      gvr.Group,
 			Version:    gvr.Version,
 			Resource:   gvr.Resource,
 			Operations: []string{"DELETE"},
 		})
 	}
+
+	// Custom children declared in onCreate/onReconcile custom blocks.
+	// Respects the parent CRD's ShouldProtectCRs() — if the parent opts out,
+	// its children are not registered either.
+	for _, crd := range k.enabledCRDs {
+		if !crd.ShouldProtectCRs() {
+			continue
+		}
+		gvrList = append(gvrList, customChildGVRs(crd, seen)...)
+	}
+
 	return gvrList
+}
+
+// customChildGVRs derives GVREntries from the custom: blocks of one CRD's
+// onCreate and onReconcile, skipping any already in seen.
+func customChildGVRs(crd orktypes.CRDEntry, seen map[string]bool) []GVREntry {
+	var entries []orktypes.CustomResourceTemplateSource
+	if crd.OperatorBox.OnCreate != nil {
+		entries = append(entries, crd.OperatorBox.OnCreate.CustomResource...)
+	}
+	if crd.OperatorBox.OnReconcile != nil {
+		entries = append(entries, crd.OperatorBox.OnReconcile.CustomResource...)
+	}
+
+	var out []GVREntry
+	for _, entry := range entries {
+		if entry.APIVersion == "" || entry.Kind == "" {
+			continue
+		}
+		gv, err := schema.ParseGroupVersion(entry.APIVersion)
+		if err != nil {
+			continue
+		}
+		plural := strings.ToLower(entry.Kind) + "s"
+		gvr := schema.GroupVersionResource{Group: gv.Group, Version: gv.Version, Resource: plural}
+		key := gvr.String()
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, GVREntry{
+			Key:        key,
+			Group:      gv.Group,
+			Version:    gv.Version,
+			Resource:   plural,
+			Operations: []string{"DELETE"},
+		})
+	}
+	return out
 }
 
 // DeletionProtectedCRDNames returns the set of CRD full names (plural.group)
@@ -163,6 +223,8 @@ func (k *Katalog) DeletionProtectedCRDNames() map[string]struct{} {
 		return nil
 	}
 	names := make(map[string]struct{}, len(k.enabledCRDs))
+
+	// Owner CRDs managed by this Katalog.
 	for _, crd := range k.enabledCRDs {
 		if crd.IsBuiltIn {
 			continue
@@ -174,5 +236,35 @@ func (k *Katalog) DeletionProtectedCRDNames() map[string]struct{} {
 			names[crd.APITypes.Plural+"."+crd.APITypes.Group] = struct{}{}
 		}
 	}
+
+	// Custom children declared in onCreate/onReconcile custom blocks.
+	// Protecting CR instances without protecting the CRD type is incomplete —
+	// deleting the CRD cascades all instances regardless of instance-level protection.
+	// Respects the parent CRD's ShouldProtectCRD() — if the parent opts out,
+	// its children's CRD types are not protected either.
+	for _, crd := range k.enabledCRDs {
+		if !crd.ShouldProtectCRD() {
+			continue
+		}
+		var entries []orktypes.CustomResourceTemplateSource
+		if crd.OperatorBox.OnCreate != nil {
+			entries = append(entries, crd.OperatorBox.OnCreate.CustomResource...)
+		}
+		if crd.OperatorBox.OnReconcile != nil {
+			entries = append(entries, crd.OperatorBox.OnReconcile.CustomResource...)
+		}
+		for _, entry := range entries {
+			if entry.APIVersion == "" || entry.Kind == "" {
+				continue
+			}
+			gv, err := schema.ParseGroupVersion(entry.APIVersion)
+			if err != nil || gv.Group == "" {
+				continue
+			}
+			plural := strings.ToLower(entry.Kind) + "s"
+			names[plural+"."+gv.Group] = struct{}{}
+		}
+	}
+
 	return names
 }

--- a/pkg/katalog/docs/03-deletion-protection.md
+++ b/pkg/katalog/docs/03-deletion-protection.md
@@ -39,14 +39,16 @@ Built-in types (ConfigMap, Deployment) are excluded — they are not CRDs and ca
 
 ## Protected GVRs
 
-`DeletionProtectionGVRs()` returns the four rules that back the two webhook entries:
+`DeletionProtectionGVRs()` returns the rules that back the two webhook entries:
 
-| Resource | Group | Entry |
-|----------|-------|-------|
+| Resource | Source | Entry |
+|----------|--------|-------|
 | `customresourcedefinitions` | `apiextensions.k8s.io/v1` | Entry 1 (CRD, name-filtered) |
-| `deployments` | `apps/v1` | Entry 2 (ObjectSelector) |
-| `services` | `v1` (core) | Entry 2 (ObjectSelector) |
-| `ingresses` | `networking.k8s.io/v1` | Entry 2 (ObjectSelector) |
+| `deployments`, `services`, `ingresses` | Orkestra internal built-ins | Entry 2 (ObjectSelector) |
+| owner CRDs (e.g. `infras`, `securityconfigs`) | `CRDEntry.APITypes` | Entry 2 (ObjectSelector) |
+| custom children (e.g. `applications`, `certificates`) | `onCreate.custom` / `onReconcile.custom` entries | Entry 2 (ObjectSelector) |
+
+Custom children — resources declared in `onCreate.custom` or `onReconcile.custom` blocks — are now included in Entry 2. Any child resource Orkestra creates on behalf of an owner CR (ArgoCD `Application`, cert-manager `Certificate`, Crossplane `PostgreSQLInstance`, etc.) is registered in the deletion-protection webhook. The `ObjectSelector` (`orkestra.io/deletion-protection=true`) ensures only labeled instances are intercepted.
 
 ## In-cluster vs local
 

--- a/pkg/katalog/generate_rbac.go
+++ b/pkg/katalog/generate_rbac.go
@@ -69,6 +69,10 @@ func (k *Katalog) GenerateRBACRules() []rbacv1.PolicyRule {
 			Resources: []string{"namespaces"},
 			Verbs:     []string{"get", "patch"},
 		})
+
+		// Custom CRs registered in the deletion-protection webhook need GET so
+		// the gateway can read the instance and check its protection label/annotation.
+		rules = append(rules, k.customResourceDeletionProtectionRBACRules()...)
 	}
 
 	// ───────────────────────────────────────────────
@@ -595,6 +599,30 @@ func customRBACRulesForCRD(crd orktypes.CRDEntry) []rbacv1.PolicyRule {
 			Resources: []string{plural},
 			Verbs:     defaultVerbs,
 		})
+	}
+	return rules
+}
+
+// customResourceDeletionProtectionRBACRules returns gateway RBAC rules granting
+// GET on every custom child resource that the deletion-protection webhook
+// intercepts. Mirrors customRBACRulesForCRD but uses get-only verbs — the
+// gateway reads each object to check its protection label before allowing the DELETE.
+func (k *Katalog) customResourceDeletionProtectionRBACRules() []rbacv1.PolicyRule {
+	seen := make(map[string]bool)
+	var rules []rbacv1.PolicyRule
+	for _, crd := range k.Enabled() {
+		for _, rule := range customRBACRulesForCRD(crd) {
+			key := strings.Join(rule.APIGroups, ",") + "/" + strings.Join(rule.Resources, ",")
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			rules = append(rules, rbacv1.PolicyRule{
+				APIGroups: rule.APIGroups,
+				Resources: rule.Resources,
+				Verbs:     []string{"get"},
+			})
+		}
 	}
 	return rules
 }

--- a/pkg/katalog/security.go
+++ b/pkg/katalog/security.go
@@ -386,7 +386,7 @@ func (k *Katalog) ConversionWindow() int {
 //   - endpoint is optional (runtime may populate it)
 //   - spec: must be present (CRDs required)
 func (k *Katalog) IsGatewayEnabled() bool {
-	return k.Gateway != nil && k.Gateway.Enabled
+	return k.Gateway != nil && (k.Gateway.Enabled || k.Gateway.Endpoint != "")
 }
 
 // IsStandaloneGateway reports whether this Katalog is deployed as a standalone

--- a/pkg/migrate/generator.go
+++ b/pkg/migrate/generator.go
@@ -20,6 +20,7 @@ type Files struct {
 	GoMod      string
 	Makefile   string
 	Dockerfile string
+	README     string
 }
 
 // Options controls what the generator emits.
@@ -57,6 +58,7 @@ func Generate(res *Result, opts Options) Files {
 		GoMod:      generateGoMod(opts),
 		Makefile:   generateMakefile(opts),
 		Dockerfile: generateDockerfile(),
+		README:     generateREADME(),
 	}
 }
 
@@ -309,6 +311,100 @@ func generateDockerfile() string {
 COPY ork /usr/local/bin/ork
 USER 65532:65532
 ENTRYPOINT ["/usr/local/bin/ork"]
+`
+}
+
+func generateREADME() string {
+	bt := "```"
+	return `# Migration output
+
+` + bt + `bash
+grep -rn "TODO(ork migrate)" .
+` + bt + `
+
+Work through each TODO in order:
+
+1. Add the Orkestra imports flagged at the top of the reconciler file
+2. Replace ` + "`" + `r.Status().Update` + "`" + ` with ` + "`" + `r.kube.PatchStatus` + "`" + `
+3. Remove ` + "`" + `SetupWithManager` + "`" + ` and ` + "`" + `main.go` + "`" + ` — Orkestra provides the informer and workqueue
+
+---
+
+## Step 1 — Generate the type registry
+
+` + bt + `bash
+make registry
+` + bt + `
+
+---
+
+## Step 2 — Build
+
+` + bt + `bash
+make build
+` + bt + `
+
+---
+
+## Step 3 — Validate
+
+` + bt + `bash
+make validate
+` + bt + `
+
+---
+
+## Step 4 — Simulate
+
+` + bt + `bash
+ork simulate
+` + bt + `
+
+---
+
+## Step 5 — Release
+
+Build the production runtime binary, package it into a Docker image, and push:
+
+` + bt + `bash
+make release IMAGE=ghcr.io/myorg/my-operator:v0.1.0
+` + bt + `
+
+---
+
+## Step 6 — Push the Katalog
+
+` + bt + `bash
+ork push .
+` + bt + `
+
+---
+
+## Inspect
+
+` + bt + `bash
+ork inspect my-operator:v0.1.0
+` + bt + `
+
+---
+
+## Step 7 — Generate bundle and deploy
+
+` + bt + `bash
+ork generate bundle -o bundle.yaml
+kubectl apply -f bundle.yaml
+` + bt + `
+
+Install Orkestra with your custom runtime image:
+
+` + bt + `bash
+helm repo add orkestra https://orkspace.github.io/orkestra
+helm upgrade --install orkestra orkestra/orkestra \
+  --set runtime.image.repository=ghcr.io/myorg/my-operator \
+  --set runtime.image.tag=v0.1.0 \
+  --namespace orkestra-system --create-namespace \
+  --wait --timeout 120s
+` + bt + `
 `
 }
 

--- a/pkg/ork/setup.go
+++ b/pkg/ork/setup.go
@@ -45,13 +45,12 @@ func HelmInstall(ctx context.Context, h orktypes.SetupHelmInstall) error {
 	for k, v := range h.Values {
 		args = append(args, "--set", fmt.Sprintf("%s=%v", k, v))
 	}
+	args = append(args, "--wait", "--timeout", "5m")
 
-	fmt.Printf("  → Installing %s...\n", release)
 	cmd := exec.CommandContext(ctx, "helm", args...)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("helm install %s/%s: %w\n%s", h.Repo, h.Chart, err, out)
 	}
-	fmt.Printf("  ✓ %s installed\n", release)
 	return nil
 }
 

--- a/pkg/reconciler/run_customresource.go
+++ b/pkg/reconciler/run_customresource.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/orkspace/orkestra/domain"
 	"github.com/orkspace/orkestra/pkg/kubeclient"
+	orklabels "github.com/orkspace/orkestra/pkg/labels"
 	"github.com/orkspace/orkestra/pkg/logger"
 	orkcust "github.com/orkspace/orkestra/pkg/resources/customresources"
 	orktmpl "github.com/orkspace/orkestra/pkg/resources/template"
@@ -21,6 +22,8 @@ func runCustomResources(
 	srcs []orktypes.CustomResourceTemplateSource,
 	update bool,
 	guard func(ctx context.Context, obj domain.Object, ns string) bool,
+	labelMgr *orklabels.Manager,
+	shouldProtect bool,
 ) error {
 	// Track active names for conditional cleanup when resources are no longer desired.
 	activeNames := make(map[string]bool, len(srcs))
@@ -92,11 +95,11 @@ func runCustomResources(
 		// Create enforces spec if resource already exists (idempotent OnCreate).
 		// Update always corrects drift — delete drift (recreate) and spec drift.
 		if update {
-			if err := orkcust.Update(ctx, kube, owner, spec); err != nil {
+			if err := orkcust.Update(ctx, kube, owner, spec, labelMgr, shouldProtect); err != nil {
 				return fmt.Errorf("custom[%d].update: %w", i, err)
 			}
 		} else {
-			if err := orkcust.Create(ctx, kube, owner, spec); err != nil {
+			if err := orkcust.Create(ctx, kube, owner, spec, labelMgr, shouldProtect); err != nil {
 				return fmt.Errorf("custom[%d].create: %w", i, err)
 			}
 		}

--- a/pkg/reconciler/run_template_reconcile.go
+++ b/pkg/reconciler/run_template_reconcile.go
@@ -18,6 +18,7 @@ import (
 	"github.com/orkspace/orkestra/domain"
 	"github.com/orkspace/orkestra/pkg/children"
 	"github.com/orkspace/orkestra/pkg/kubeclient"
+	orklabels "github.com/orkspace/orkestra/pkg/labels"
 	"github.com/orkspace/orkestra/pkg/logger"
 	orktmpl "github.com/orkspace/orkestra/pkg/resources/template"
 	orktypes "github.com/orkspace/orkestra/pkg/types"
@@ -137,6 +138,11 @@ func (r *GenericReconciler[PTR]) runResourceGroup(
 	// nil-safe: if CRD has no restrictions, guard is a no-op.
 	guard := r.namespaceGuardFunc(ctx, obj)
 
+	labelMgr := orklabels.NewManager(orklabels.Config{
+		Standalone:                r.kat.IsStandaloneGateway(),
+		DeletionProtectionEnabled: r.kat.IsDeletionProtectionEnabled(),
+	})
+
 	// Create namespaces first
 	if err := runNamespaces(ctx, kube, resolver, obj,
 		children.ExpandForEachNamespaces(resolver, t.Namespaces), update); err != nil {
@@ -164,7 +170,8 @@ func (r *GenericReconciler[PTR]) runResourceGroup(
 		return err
 	}
 	if err := runCustomResources(ctx, kube, resolver, obj,
-		children.ExpandForEachCustomResources(resolver, t.CustomResource), update, guard); err != nil {
+		children.ExpandForEachCustomResources(resolver, t.CustomResource), update, guard, labelMgr,
+		r.kat.IsDeletionProtectionEnabled() && r.crd.ShouldProtectCRs()); err != nil {
 		return err
 	}
 	if err := runReplicaSets(ctx, kube, resolver, obj,

--- a/pkg/resources/customresources/custom.go
+++ b/pkg/resources/customresources/custom.go
@@ -73,7 +73,7 @@ type ResolvedCustomResourceSpec struct {
 
 // Create creates the custom resource described by spec if it does not already exist.
 // Idempotent — skips if resource exists. Owner reference set for cascade deletion.
-func Create(ctx context.Context, kube kubeclient.KubeClient, owner domain.Object, spec ResolvedCustomResourceSpec) error {
+func Create(ctx context.Context, kube kubeclient.KubeClient, owner domain.Object, spec ResolvedCustomResourceSpec, labelMgr *orklabels.Manager, shouldProtect bool) error {
 	if err := validateSpec(spec); err != nil {
 		return fmt.Errorf("custom.Create: %w", err)
 	}
@@ -116,11 +116,14 @@ func Create(ctx context.Context, kube kubeclient.KubeClient, owner domain.Object
 	}
 	if err == nil {
 		// Resource already exists — enforce spec so OnCreate is idempotent.
-		return Update(ctx, kube, owner, spec)
+		return Update(ctx, kube, owner, spec, labelMgr, shouldProtect)
 	}
 
 	// Build unstructured object
 	obj := buildUnstructured(spec, owner, gvk, namespace)
+	if labelMgr != nil {
+		labelMgr.EnsureDeletionProtectionLabel(obj, shouldProtect)
+	}
 
 	// Create
 	_, err = resourceIfc.Create(ctx, obj, metav1.CreateOptions{})
@@ -139,7 +142,7 @@ func Create(ctx context.Context, kube kubeclient.KubeClient, owner domain.Object
 
 // Update reconciles an existing custom resource to match the resolved spec.
 // If the resource does not exist, it will be created.
-func Update(ctx context.Context, kube kubeclient.KubeClient, owner domain.Object, spec ResolvedCustomResourceSpec) error {
+func Update(ctx context.Context, kube kubeclient.KubeClient, owner domain.Object, spec ResolvedCustomResourceSpec, labelMgr *orklabels.Manager, shouldProtect bool) error {
 	if err := validateSpec(spec); err != nil {
 		return fmt.Errorf("custom.Update: %w", err)
 	}
@@ -179,7 +182,7 @@ func Update(ctx context.Context, kube kubeclient.KubeClient, owner domain.Object
 				Str("custom", name).
 				Str("namespace", namespace).
 				Msg("custom resource not found during reconcile — recreating")
-			return Create(ctx, kube, owner, spec)
+			return Create(ctx, kube, owner, spec, labelMgr, shouldProtect)
 		}
 		return fmt.Errorf("custom.Update: getting %q: %w", name, err)
 	}
@@ -216,6 +219,9 @@ func Update(ctx context.Context, kube kubeclient.KubeClient, owner domain.Object
 		// Use direct map assignment (not SetNestedField) to avoid DeepCopyJSONValue
 		// panicking on non-JSON-safe types (int, int64) produced by YAML unmarshalling.
 		updated := existing.DeepCopy()
+		if labelMgr != nil {
+			labelMgr.EnsureDeletionProtectionLabel(updated, shouldProtect)
+		}
 		if desired.Object["spec"] != nil {
 			updated.Object["spec"] = orktmpl.ToJSONSafe(desired.Object["spec"])
 		}

--- a/pkg/types/e2e.go
+++ b/pkg/types/e2e.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 
+	"github.com/orkspace/orkestra/pkg/utils"
 	"gopkg.in/yaml.v3"
 )
 
@@ -57,7 +58,11 @@ func (s *SetupConfig) UnmarshalYAML(value *yaml.Node) error {
 		}
 	}
 	type plain SetupConfig
-	return value.Decode((*plain)(s))
+	raw, err := yaml.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return utils.StrictUnmarshal(raw, (*plain)(s))
 }
 
 // SetupHelmInstall installs a Helm chart as a real release into the cluster.


### PR DESCRIPTION
## Summary

- `ork migrate` now emits `README.md` with the full migration workflow (registry → build → validate → simulate → release → push → bundle → deploy → inspect)
- Deletion protection extended to `custom:` block children — GVRs and CRD names registered in webhook, labeled via label manager at create/update, `get` RBAC added to gateway ClusterRole; gated on parent CRD's `ShouldProtectCRs()`/`ShouldProtectCRD()`
- `IsGatewayEnabled()` treats a non-empty `endpoint` as sufficient — `enabled: true` no longer required when an endpoint is present
- Strict YAML parsing (`StrictUnmarshal`) for e2e, simulate, and `SetupConfig` — unknown fields now fail loudly
- Spinner output in e2e runner for helm install, wait, and Orkestra install/upgrade steps; setup helm steps now pass `--wait --timeout 5m`

## Test plan

- [x] `ork migrate` rewrites a controller-runtime reconciler; TODOs are accurate; logging import is preserved; `README.md` emitted with correct steps
- [x] Katalog with `custom:` children and deletion protection enabled — children labeled on create and update; webhook intercepts DELETE on custom child GVR
- [x] Katalog with deletion protection disabled on owner CRD — custom children not labeled and not registered in webhook
- [x] Gateway with only `endpoint:` set and no `enabled: true` — `IsGatewayEnabled()` returns true
- [x] Unknown field in `e2e.yaml` or `simulate.yaml` returns a clear error; valid files still parse correctly
- [x] `ork e2e` helm setup steps show spinner and block until helm reports ready