### PR TITLE
feat: custom.target — universal e2e harness for any Kubernetes workload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.7.7 — New packs, typed group overrides, breaking: operatorBox.reconciler
+## v0.7.7 — New packs, typed group overrides, universal e2e, breaking: operatorBox.reconciler
 
 ### New pack: `from-controller-runtime`
 
@@ -101,6 +101,41 @@ Migration rules:
 - **Constructor katalogs**: wrap `default: false` and `constructor:` under `reconciler:`. Move both in by two spaces.
 
 `utils.StrictUnmarshal` rejects unknown fields, so an old katalog with top-level `default:` or `hooks:` under `operatorBox` will fail at parse time with a clear error before any validation runs.
+
+### `ork e2e` is now a universal Kubernetes test harness
+
+`spec.customOperator: true` is replaced by `spec.custom.target: kubernetes`. The new
+field names the thing being tested rather than describing what to skip.
+
+**Supported targets:**
+
+| Value | Status |
+|-------|--------|
+| `kubernetes` | Supported |
+| `container` | Coming soon |
+
+**Migration** — find and replace in all `e2e.yaml` files:
+
+```yaml
+# before
+spec:
+  customOperator: true
+
+# after
+spec:
+  custom:
+    target: kubernetes
+```
+
+`ork validate e2e` now fast-fails with a clear error on unknown target values. If
+`container` is specified, it exits with "coming soon" rather than silently doing nothing.
+
+The docs reframe `custom.target: kubernetes` as what it is: `ork e2e` with any
+workload that runs on Kubernetes — operators, Helm charts, raw manifests, third-party
+tools. The cluster lifecycle, assertion polling, and cleanup are Orkestra's. The
+workload is yours.
+
+New guide: `documentation/guides/e2e-universal.md` — "Test Anything That Runs in Kubernetes"
 
 ---
 

--- a/cmd/cli/validate.go
+++ b/cmd/cli/validate.go
@@ -220,12 +220,26 @@ func validateE2EFile(path string) error {
 	if doc.Metadata.Name == "" {
 		errs = append(errs, "metadata.name is required")
 	}
-	if !isAggregator {
-		if doc.Spec.Katalog == "" && doc.Spec.Init == nil && !doc.Spec.CustomOperator {
-			errs = append(errs, "spec.katalog is required (or spec.init for example packs, spec.customOperator for custom operators, or imports)")
+	isCustom := doc.Spec.Custom != nil && doc.Spec.Custom.Target != ""
+	if isCustom {
+		switch doc.Spec.Custom.Target {
+		case orktypes.CustomTargetKubernetes:
+			// valid and supported
+		case orktypes.CustomTargetContainer:
+			return fmt.Errorf("spec.custom.target \"container\" is coming soon — not yet supported in this version")
+		default:
+			errs = append(errs, fmt.Sprintf(
+				"spec.custom.target %q is not supported — valid values: kubernetes, container",
+				doc.Spec.Custom.Target,
+			))
 		}
-		if doc.Spec.CRD == "" && doc.Spec.Init == nil && !doc.Spec.CustomOperator {
-			errs = append(errs, "spec.crd is required (or spec.init for example packs, spec.customOperator for custom operators, or imports)")
+	}
+	if !isAggregator {
+		if doc.Spec.Katalog == "" && doc.Spec.Init == nil && !isCustom {
+			errs = append(errs, "spec.katalog is required (or spec.init for example packs, spec.custom.target for custom targets, or imports)")
+		}
+		if doc.Spec.CRD == "" && doc.Spec.Init == nil && !isCustom {
+			errs = append(errs, "spec.crd is required (or spec.init for example packs, spec.custom.target for custom targets, or imports)")
 		}
 		if doc.Spec.CR == "" && doc.Spec.Init == nil {
 			errs = append(errs, "spec.cr is required (or spec.init for example packs, or imports)")
@@ -266,8 +280,8 @@ func validateE2EFile(path string) error {
 		fmt.Printf("    %s\n", gray(doc.Metadata.Description))
 	}
 	if !isAggregator {
-		if doc.Spec.CustomOperator {
-			fmt.Printf("    %s\n", gray("mode    : custom operator (Orkestra install skipped)"))
+		if isCustom {
+			fmt.Printf("    %s\n", gray(fmt.Sprintf("mode    : custom target (%s — Orkestra install skipped)", doc.Spec.Custom.Target)))
 		}
 		fmt.Printf("    %s\n",
 			gray(fmt.Sprintf("katalog : %s\n    crd     : %s\n    cr      : %s",

--- a/documentation/blog/05-the-infrastructure-is-gone.md
+++ b/documentation/blog/05-the-infrastructure-is-gone.md
@@ -30,13 +30,17 @@ None of this runs in your cluster as a new stack of CRDs. The separation is clea
 
 Once the infrastructure is gone, what is left is a declaration.
 
-Orkestra gives you three ways to make it:
+Orkestra gives you five ways to make it:
 
-**Zero code.** Write a Katalog. Declare your CRD, the resources to create on `onCreate`, the status fields to write, the validation rules to enforce, the dependencies to respect. The reconciler is not yours to write — it is Orkestra's, and it runs your declaration. No Go, no build pipeline, no image.
+**No code.** Write a Katalog. Declare your CRD, the resources to create on `onCreate`, the status fields to write, the validation rules to enforce, the dependencies to respect. The reconciler is not yours to write — it is Orkestra's, and it runs your declaration. No Go, no build pipeline, no image.
+
+**Hybrid.** Combine declarative and hooks in a single operator. Declare what templates can express; attach hooks for what they cannot. The boundary is yours to draw.
 
 **Hooks.** Attach Go functions at specific points in the reconcile cycle. The declarative model handles everything it can; your hooks handle what it cannot. You write exactly the code your business logic requires, nothing else.
 
 **Constructor.** Replace the reconciler entirely with your own. Full control, typed input, Orkestra's runtime as the host. The infrastructure is still gone — you are only responsible for the domain logic.
+
+**Constructor with Orkestra resources.** Write your own reconciler and use Orkestra's resource helpers — `orkdeploy.Update`, `orksvc.Update`, and the rest of `pkg/resources` — instead of raw client Get → IsNotFound → Create → Patch sequences. Owner references and drift correction are handled automatically. The constructor signature stays yours; the resource management layer becomes Orkestra's.
 
 ---
 
@@ -48,6 +52,14 @@ Just the problem you came to solve.
 
 That is what Kubernetes intended when it introduced CRDs. The CRD was the declaration. The operator was supposed to answer one question about it: what should happen when someone creates one of these? We turned that one question into years of infrastructure work.
 
-Orkestra gives the question back. Whichever you pick — zero code, hooks, or constructor — you are solving exactly one problem.
+Orkestra gives the question back. Whichever you pick — no code, hybrid, hooks, constructor, or constructor with Orkestra resources — you are solving exactly one problem.
 
 Yours.
+
+---
+
+**Want to try it?**
+
+```bash
+ork init --pack from-controller-runtime
+```

--- a/documentation/guides/e2e-universal.md
+++ b/documentation/guides/e2e-universal.md
@@ -1,0 +1,233 @@
+# Test Anything That Runs in Kubernetes
+
+`ork e2e` is a Kubernetes behavioural verification tool. It spins up a real cluster,
+installs things, watches the API server, and asserts GVK state. Nothing in that
+pipeline requires the workload under test to be an Orkestra operator.
+
+A Helm chart installs into the same API server. A `kubectl apply` produces the same
+objects. The assertion layer does not care about the installation mechanism. It watches
+GVKs. A `Deployment/my-app` is the same object whether it was created by an Orkestra
+operator, a Helm chart, a controller-runtime reconciler, or `kubectl apply`.
+
+---
+
+## The insight
+
+Today there is no way to look at a container image, a deployment manifest, or a Helm
+chart and say it works. Signatures prove ownership. They say nothing about behaviour.
+A signed chart with a broken init container is still signed. A signed operator that
+silently drops events under load is still signed.
+
+`ork e2e` built the verification layer in the hardest context — operators with
+long-lived state, drift correction, complex status, and partial failure modes. If you
+can prove an operator works correctly before distribution, you can prove a Helm chart
+works. The machinery is the same. The e2e file is the contract. The cluster is the
+witness.
+
+---
+
+## Set `custom.target: kubernetes`
+
+Any e2e file with `spec.custom.target: kubernetes` tells Orkestra: "you own the
+cluster and the assertions, but not the workload". Bundle generation and Orkestra's
+own helm install/uninstall are skipped. Everything else — cluster setup, CRD apply,
+setup manifests, CR apply, the full assertion loop, and cleanup — runs unchanged.
+
+```yaml
+apiVersion: orkestra.orkspace.io/v1
+kind: E2E
+metadata:
+  name: my-helm-chart-e2e
+
+spec:
+  custom:
+    target: kubernetes
+
+  setup:
+    helm:
+      - repo: https://charts.example.com
+        chart: my-app
+        namespace: my-app
+        createNamespace: true
+        version: v1.2.0
+    wait:
+      - kind: Deployment
+        name: my-app
+        namespace: my-app
+        ready: true
+        timeout: 120s
+
+  cr: ./test-resource.yaml
+
+  expect:
+    - name: App is healthy
+      after: cr-applied
+      timeout: 60s
+      resources:
+        - kind: Deployment
+          name: my-app
+          namespace: my-app
+          ready: true
+
+    - name: Cleanup verified
+      after: cr-deleted
+      timeout: 30s
+      resources:
+        - kind: Deployment
+          name: my-app
+          namespace: my-app
+          count: 0
+```
+
+Run it:
+
+```bash
+ork e2e -f e2e.yaml
+```
+
+An ephemeral kind cluster is created, your chart is installed into it, assertions run,
+and the cluster is torn down. Your actual cluster is never touched. Pass or fail.
+Minutes, not hours.
+
+---
+
+## Use cases
+
+### Helm charts
+
+Write an `e2e.yaml` alongside your chart. Use `setup.helm` to install the chart
+itself, then assert the resources it creates.
+
+```yaml
+spec:
+  custom:
+    target: kubernetes
+  setup:
+    helm:
+      - chart: ./         # the chart itself
+        namespace: default
+    wait:
+      - kind: Deployment
+        name: my-app
+        ready: true
+        timeout: 120s
+  expect:
+    - name: App is healthy
+      after: cr-applied
+      timeout: 60s
+      resources:
+        - kind: Deployment
+          name: my-app
+          namespace: default
+```
+
+### Third-party operators
+
+Install an operator you did not write — cert-manager, ArgoCD, Crossplane, FluxCD —
+and assert the resources it manages.
+
+```yaml
+spec:
+  custom:
+    target: kubernetes
+  setup:
+    helm:
+      - repo: https://charts.jetstack.io
+        chart: cert-manager
+        namespace: cert-manager
+        createNamespace: true
+        version: v1.14.0
+        values:
+          installCRDs: true
+    wait:
+      - kind: Deployment
+        name: cert-manager-webhook
+        namespace: cert-manager
+        ready: true
+        timeout: 120s
+  cr: ./certificate-cr.yaml
+  expect:
+    - name: TLS Secret issued
+      after: cr-applied
+      timeout: 60s
+      resources:
+        - kind: Secret
+          name: my-tls-secret
+          namespace: default
+```
+
+### Platform stacks
+
+Install multiple tools together and assert they interact correctly.
+
+```yaml
+spec:
+  custom:
+    target: kubernetes
+  setup:
+    helm:
+      - repo: https://argoproj.github.io/argo-helm
+        chart: argo-cd
+        namespace: argocd
+        createNamespace: true
+      - repo: https://charts.jetstack.io
+        chart: cert-manager
+        namespace: cert-manager
+        createNamespace: true
+        values:
+          installCRDs: true
+  cr: ./platform-resources.yaml
+  expect:
+    - name: ArgoCD Application synced
+      after: cr-applied
+      timeout: 180s
+      commands:
+        - run: kubectl get application my-app -n argocd -o jsonpath='{.status.sync.status}'
+          outputContains: Synced
+    - name: TLS Secret issued
+      after: cr-applied
+      timeout: 60s
+      resources:
+        - kind: Secret
+          name: my-app-tls
+          namespace: default
+```
+
+---
+
+## The GitHub Actions bridge
+
+Add `e2e.yaml` to any repository and one step to any workflow:
+
+```yaml
+# .github/workflows/ci.yml
+- uses: orkspace/orkestra-action@v1   # https://github.com/orkspace/orkestra-action
+  with:
+    validate: true
+    e2e: true          # runs ork e2e before anything else
+    # or point at an explicit file:
+    e2e: ./e2e.yaml
+```
+
+The action installs `ork`, validates the spec, spins up an ephemeral kind cluster,
+runs the assertions, and tears everything down. Your real cluster is never touched.
+No other tooling required.
+
+The path to "every published artifact has a verification badge" is: add `e2e.yaml`,
+add one step to the workflow, done.
+
+---
+
+## What this is not
+
+`custom.target: kubernetes` does not add Orkestra runtime features to your workload.
+Orkestra is the test harness — the cluster lifecycle, assertion polling, and cleanup.
+Your workload runs exactly as it would in production.
+
+If you want Orkestra to manage your operator at runtime, start with
+`ork init --pack from-controller-runtime`.
+
+---
+
+→ Schema reference: [spec.custom](../reference/schema/04-e2e/05-custom-target.md)
+→ Example pack: `use-cases/custom-operator`

--- a/documentation/reference/schema/04-e2e/01-spec.md
+++ b/documentation/reference/schema/04-e2e/01-spec.md
@@ -13,7 +13,7 @@ spec:
   katalog: ./katalog.yaml
 ```
 
-Optional when `spec.customOperator: true` — see [05-custom-operator.md](05-custom-operator.md).
+Optional when `spec.custom.target` is set — see [05-custom-target.md](05-custom-target.md).
 
 ---
 
@@ -61,13 +61,14 @@ spec:
 
 ---
 
-## `spec.customOperator`
+## `spec.custom`
 
-Declares that this test uses its own operator. Skips bundle generation and Orkestra helm install/uninstall. Everything else runs unchanged.
+Declares the target runtime when Orkestra is not the operator under test. Bundle generation and Orkestra helm install/uninstall are skipped. Everything else runs unchanged.
 
 ```yaml
 spec:
-  customOperator: true
+  custom:
+    target: kubernetes
   crd: ./crd.yaml
   cr: ./cr.yaml
   setup:
@@ -76,7 +77,9 @@ spec:
         chart: my-operator
 ```
 
-See [05-custom-operator.md](05-custom-operator.md) for full documentation and use cases.
+`target` must be `kubernetes`. `container` is reserved and not yet supported.
+
+See [05-custom-target.md](05-custom-target.md) for full documentation and use cases.
 
 ---
 

--- a/documentation/reference/schema/04-e2e/05-custom-target.md
+++ b/documentation/reference/schema/04-e2e/05-custom-target.md
@@ -1,14 +1,22 @@
-# Custom Operator Mode
+# Custom Target Mode
 
-`spec.customOperator: true` declares that this test uses its own operator — not
-Orkestra's reconcile loop. Bundle generation and Orkestra helm install/uninstall are
-skipped. Everything else runs unchanged.
+`spec.custom.target` declares the runtime environment being tested when Orkestra is
+not the operator. Bundle generation and Orkestra helm install/uninstall are skipped.
+Everything else runs unchanged: cluster setup, CRD apply, setup manifests, CR apply,
+assertions, and cleanup.
+
+---
+
+## Supported targets
+
+| Value | Status | What it means |
+|-------|--------|---------------|
+| `kubernetes` | Supported | Your workload runs on Kubernetes. Orkestra manages the cluster lifecycle and assertions. Install your operator or chart via `setup.helm`. |
+| `container` | Coming soon | Test a container image directly, without a cluster. |
 
 ---
 
 ## How to activate
-
-Declare it in the spec file. The file is the source of truth — there is no CLI flag.
 
 ```yaml
 apiVersion: orkestra.orkspace.io/v1
@@ -17,7 +25,8 @@ metadata:
   name: my-operator-e2e
 
 spec:
-  customOperator: true
+  custom:
+    target: kubernetes
   crd: ./crd.yaml
   cr: ./cr.yaml
   setup:
@@ -49,8 +58,8 @@ spec:
 
 ## What runs, what is skipped
 
-| Step | Normal | `customOperator: true` |
-|------|--------|-----------------------|
+| Step | Normal | `custom.target: kubernetes` |
+|------|--------|-----------------------------|
 | Cluster setup | ✓ | ✓ |
 | CRD apply (`spec.crd`) | ✓ | ✓ |
 | Setup manifests (`spec.setup`) | ✓ | ✓ |
@@ -62,19 +71,20 @@ spec:
 | Orkestra helm uninstall | ✓ | **skipped** |
 | CRD / setup cleanup | ✓ | ✓ |
 
-`spec.katalog` is optional when `customOperator: true`. If omitted, the test has
-no katalog — only `spec.crd`, `spec.cr`, and `spec.setup` are used.
+`spec.katalog` is optional when `custom.target` is set. If omitted, only `spec.crd`,
+`spec.cr`, and `spec.setup` are used.
 
 ---
 
 ## The setup.helm pattern
 
 Almost always paired with `setup.helm` to install the operator before the CR is
-applied. The setup section installs the operator; assertions check what it creates.
+applied.
 
 ```yaml
 spec:
-  customOperator: true
+  custom:
+    target: kubernetes
   setup:
     helm:
       - repo: https://charts.jetstack.io
@@ -98,17 +108,16 @@ spec:
 
 ### Migration parity testing
 
-You are migrating from a Kubebuilder operator to Orkestra. The old operator is still
-in production. Write two e2e files — one with Orkestra, one with `customOperator` +
-`setup.helm` installing your existing binary — and use identical assertions in both.
-When both pass, the migration is verified.
+Migrating from a Kubebuilder operator to Orkestra? Write two e2e files — one with
+Orkestra, one with `custom.target: kubernetes` and `setup.helm` pointing at your
+existing binary — with identical assertions. When both pass, the migration is verified.
 
 ```text
 my-operator/
-├── e2e-orkestra.yaml        # spec.katalog: ./katalog.yaml
-└── e2e-kubebuilder.yaml     # spec.customOperator: true
-                             # setup.helm: my-old-operator-chart
-                             # same assertions as e2e-orkestra.yaml
+├── e2e-orkestra.yaml          # spec.katalog: ./katalog.yaml
+└── e2e-kubebuilder.yaml       # spec.custom.target: kubernetes
+                               # setup.helm: my-old-operator-chart
+                               # same assertions as e2e-orkestra.yaml
 ```
 
 ### Third-party operator smoke tests
@@ -118,7 +127,8 @@ ArgoCD. Install via `setup.helm`, apply a CR, assert what the operator creates.
 
 ```yaml
 spec:
-  customOperator: true
+  custom:
+    target: kubernetes
   crd: ./certificate-crd.yaml
   cr: ./cr-certificate.yaml
   setup:
@@ -143,7 +153,8 @@ correctly. Neither needs to be Orkestra.
 
 ```yaml
 spec:
-  customOperator: true
+  custom:
+    target: kubernetes
   setup:
     helm:
       - repo: https://operator-a.example.com
@@ -160,19 +171,9 @@ spec:
           outputContains: "true"
 ```
 
-### ork e2e as a universal test harness
-
-The assertion infrastructure — polling loops, count checks, command assertions,
-cleanup verification — is valuable regardless of which operator framework is under
-test. `customOperator: true` exposes it to any team writing Kubernetes operators:
-controller-runtime, Operator SDK, kube-rs, kopf, or anything else. They all get
-the same CI harness as first-class Orkestra users.
-
 ---
 
 ## Example suite
-
-For two runnable examples, run:
 
 ```bash
 ork init --pack use-cases/custom-operator
@@ -181,8 +182,10 @@ cd use-cases/custom-operator
 
 | Example | What it shows |
 |---------|---------------|
-| `01-pure-custom` | `customOperator: true` with a Kubebuilder-style operator installed via `setup.helm` |
-| `02-side-by-side` | The same CR tested twice — once with Orkestra, once with a custom operator — identical assertions |
+| `01-pure-custom` | `custom.target: kubernetes` with cert-manager installed via `setup.helm` |
+| `02-side-by-side` | The same CR tested twice — once with Orkestra, once with a custom target — identical assertions |
+
+→ See also: [Test anything that runs in Kubernetes](../../guides/e2e-universal.md)
 
 ---
 

--- a/documentation/reference/schema/04-e2e/06-discovery.md
+++ b/documentation/reference/schema/04-e2e/06-discovery.md
@@ -77,4 +77,4 @@ No cluster is created. No tests are run.
 
 ---
 
-→ Back: [05-custom-operator.md](05-custom-operator.md) | [Schema index](index.md)
+→ Back: [05-custom-target.md](05-custom-target.md) | [Schema index](index.md)

--- a/documentation/reference/schema/04-e2e/index.md
+++ b/documentation/reference/schema/04-e2e/index.md
@@ -154,11 +154,11 @@ See [06-discovery.md](06-discovery.md).
 
 | Page | Covers |
 |------|--------|
-| [01-spec.md](01-spec.md) | `katalog`, `crd`, `cr`, `cluster`, `customOperator` |
+| [01-spec.md](01-spec.md) | `katalog`, `crd`, `cr`, `cluster`, `custom` |
 | [02-setup.md](02-setup.md) | `setup.apply`, `setup.helm`, `setup.wait` |
 | [03-expect.md](03-expect.md) | `expect` — resources, commands, after, timeout |
 | [04-imports.md](04-imports.md) | `imports` — test suites, `wait:`, cluster strategy, pure aggregators |
-| [05-custom-operator.md](05-custom-operator.md) | `customOperator: true` — test any operator without Orkestra |
+| [05-custom-target.md](05-custom-target.md) | `custom.target: kubernetes` — test any Kubernetes workload without Orkestra |
 | [06-discovery.md](06-discovery.md) | `./...` discovery, `--wait`, `--skip`, `--dry-run` |
 
 ---

--- a/examples/use-cases/custom-operator/01-pure-custom/e2e.yaml
+++ b/examples/use-cases/custom-operator/01-pure-custom/e2e.yaml
@@ -3,12 +3,13 @@ kind: E2E
 metadata:
   name: cert-manager-e2e
   description: >
-    customOperator: true — cert-manager installed via setup.helm.
+    custom.target: kubernetes — cert-manager installed via setup.helm.
     Applies a self-signed Certificate CR and asserts the TLS Secret is created.
     No Orkestra bundle or helm install — ork e2e is the test harness only.
 
 spec:
-  customOperator: true
+  custom:
+    target: kubernetes
   cr: ./cr.yaml
 
   cluster:

--- a/examples/use-cases/custom-operator/02-side-by-side/e2e-custom.yaml
+++ b/examples/use-cases/custom-operator/02-side-by-side/e2e-custom.yaml
@@ -3,12 +3,13 @@ kind: E2E
 metadata:
   name: appcert-custom-e2e
   description: >
-    AppCert via customOperator: true — cert-manager manages the Certificate directly,
+    AppCert via custom.target: kubernetes — cert-manager manages the Certificate directly,
     no Orkestra. The AppCert CR is applied and deleted manually; cert-manager issues
     the TLS Secret. Assertions are identical to e2e-orkestra.yaml.
 
 spec:
-  customOperator: true
+  custom:
+    target: kubernetes
   crd: ./crd.yaml
   cr: ./cr.yaml
 

--- a/pkg/e2e/README.md
+++ b/pkg/e2e/README.md
@@ -20,4 +20,4 @@ ork e2e init --suite             # write a suite aggregator from discovered leaf
 | Understand cluster lifecycle (kind, reuse, context restore, shared Orkestra) | [docs/04-cluster.md](docs/04-cluster.md) |
 | Compose test suites with imports and the `wait:` field | [docs/05-imports.md](docs/05-imports.md) |
 | Use `./...` discovery mode, `--wait`, `--skip`, `--dry-run` | [docs/06-discovery.md](docs/06-discovery.md) |
-| Test any operator without Orkestra (`customOperator: true`) | [docs/07-custom-operator.md](docs/07-custom-operator.md) |
+| Test any Kubernetes workload without Orkestra (`custom.target: kubernetes`) | [docs/07-custom-operator.md](docs/07-custom-operator.md) |

--- a/pkg/e2e/discover.go
+++ b/pkg/e2e/discover.go
@@ -162,14 +162,16 @@ func isPureAggregatorFile(path string) bool {
 	var doc struct {
 		Imports []interface{} `yaml:"imports"`
 		Spec    struct {
-			Katalog        string `yaml:"katalog"`
-			CR             string `yaml:"cr"`
-			CustomOperator bool   `yaml:"customOperator"`
+			Katalog string `yaml:"katalog"`
+			CR      string `yaml:"cr"`
+			Custom  *struct {
+				Target string `yaml:"target"`
+			} `yaml:"custom"`
 		} `yaml:"spec"`
 	}
 	if err := yaml.Unmarshal(data, &doc); err != nil {
 		return false
 	}
-	hasSpec := doc.Spec.Katalog != "" || doc.Spec.CR != "" || doc.Spec.CustomOperator
+	hasSpec := doc.Spec.Katalog != "" || doc.Spec.CR != "" || (doc.Spec.Custom != nil && doc.Spec.Custom.Target != "")
 	return len(doc.Imports) > 0 && !hasSpec
 }

--- a/pkg/e2e/docs/01-spec.md
+++ b/pkg/e2e/docs/01-spec.md
@@ -10,11 +10,11 @@ metadata:
   description: What this test verifies
 
 spec:
-  katalog: ./katalog.yaml   # required (optional when customOperator: true)
+  katalog: ./katalog.yaml   # required (optional when custom.target: true)
   crd: ./crd.yaml           # required — the operator's CRD
   cr: ./cr.yaml             # required — the CR to apply
 
-  customOperator: false     # true = skip bundle + Orkestra install (see below)
+  custom.target: false     # true = skip bundle + Orkestra install (see below)
 
   cluster:
     provider: kind           # only "kind" is supported
@@ -59,7 +59,7 @@ spec:
 ### `spec.katalog`
 Path to the Katalog (or Komposer) file. The runner resolves `crdFile` entries in it and embeds them in the bundle so the in-cluster runtime doesn't need local file access.
 
-Optional when `spec.customOperator: true`.
+Optional when `spec.custom.target: true`.
 
 ### `spec.crd`
 Path to the CRD YAML to apply before the operator starts. If omitted, the runner falls back to `crdFile` entries in the Katalog.
@@ -67,10 +67,10 @@ Path to the CRD YAML to apply before the operator starts. If omitted, the runner
 ### `spec.cr`
 Path to the CR to apply. Applied when the first `after: cr-applied` expectation is reached, deleted when the first `after: cr-deleted` expectation is reached.
 
-### `spec.customOperator`
-When `true`, skips bundle generation and Orkestra helm install/uninstall. Use when your operator is installed via `setup.helm` or is already present in the cluster. `spec.katalog` is optional. Everything else (CRD apply, setup, CR apply, assertions, cleanup) runs unchanged.
+### `spec.custom.target`
+Declares the target runtime when Orkestra is not the operator under test. Supported value: `kubernetes`. Skips bundle generation and Orkestra helm install/uninstall. `spec.katalog` is optional. Everything else (CRD apply, setup, CR apply, assertions, cleanup) runs unchanged.
 
-See [05-custom-operator.md](05-custom-operator.md).
+See [07-custom-operator.md](07-custom-operator.md) (now covers `custom.target`).
 
 ### `spec.setup`
 Prerequisites applied after the cluster is ready but before the CR. Shorthand (plain list of strings) applies each file:

--- a/pkg/e2e/docs/03-pipeline.md
+++ b/pkg/e2e/docs/03-pipeline.md
@@ -7,12 +7,12 @@
  2. Ensure cluster                    (create kind cluster, or use --cluster / --use-current)
  3. Check dependencies                (kubectl, helm, kind available)
  4. Apply CRD                         (from spec.crd or katalog crdFile entries)
- 5. Pre-pull OCI imports              (skipped when customOperator: true)
- 6. Generate + apply bundle           (skipped when customOperator: true)
+ 5. Pre-pull OCI imports              (skipped when custom.target: kubernetes)
+ 6. Generate + apply bundle           (skipped when custom.target: kubernetes)
  7. Apply setup files                 (spec.setup.apply, in order)
  8. Install setup Helm charts         (spec.setup.helm, in order)
  9. Wait for setup resources          (spec.setup.wait, in order)
-10. Install or sync Orkestra          (skipped when customOperator: true — see below)
+10. Install or sync Orkestra          (skipped when custom.target: kubernetes — see below)
 11. Run expectations                  (cr-applied / cr-deleted, in order)
 12. Print results
 13. Run imports                       (if any — see imports.md)
@@ -33,7 +33,7 @@
 **Already installed** (bundle update only — silent):
 The runtime is restarted silently to pick up the new bundle. No messages are printed. The health check still runs to ensure the runtime is ready before the CR is applied.
 
-**customOperator: true** — step 10 is skipped entirely. Your operator is responsible for reconciling the CR.
+**`custom.target: kubernetes`** — step 10 is skipped entirely. Your operator is responsible for reconciling the CR.
 
 ## Teardown
 

--- a/pkg/e2e/docs/07-custom-operator.md
+++ b/pkg/e2e/docs/07-custom-operator.md
@@ -1,6 +1,8 @@
-# Custom Operator Mode
+# Custom Target Mode
 
-`spec.customOperator: true` declares that this test uses its own operator — not Orkestra's reconcile loop. Bundle generation and Orkestra helm install/uninstall are skipped. Everything else runs unchanged.
+`spec.custom.target` declares the runtime environment being tested when Orkestra is
+not the operator. Bundle generation and Orkestra helm install/uninstall are skipped.
+Everything else runs unchanged.
 
 ## Activation
 
@@ -8,7 +10,8 @@ Declare it in the spec file — the file is the source of truth, there is no CLI
 
 ```yaml
 spec:
-  customOperator: true
+  custom:
+    target: kubernetes
   crd: ./crd.yaml
   cr: ./cr.yaml
   setup:
@@ -19,17 +22,19 @@ spec:
         createNamespace: true
 ```
 
+Supported targets: `kubernetes`. `container` is coming soon.
+
 ## What is skipped
 
-| Step | Normal | `customOperator: true` |
-|------|--------|-----------------------|
+| Step | Normal | `custom.target: kubernetes` |
+|------|--------|-----------------------------|
 | Bundle generate + apply | ✓ | skipped |
 | OCI import pre-pull | ✓ | skipped |
 | Orkestra helm install | ✓ | skipped |
 | Orkestra helm uninstall | ✓ | skipped |
 | Everything else | ✓ | ✓ |
 
-`spec.katalog` is optional when `customOperator: true`. The spec only needs `spec.cr` at minimum.
+`spec.katalog` is optional when `custom.target` is set. The spec only needs `spec.cr` at minimum.
 
 ## Use cases
 
@@ -38,7 +43,8 @@ Install cert-manager, FluxCD, Crossplane via `setup.helm`, apply a CR, assert wh
 
 ```yaml
 spec:
-  customOperator: true
+  custom:
+    target: kubernetes
   cr: ./cr-certificate.yaml
   setup:
     helm:
@@ -55,16 +61,18 @@ spec:
 ```
 
 ### Migration parity testing
-Two e2e files, same CRD, same assertions — one via Orkestra katalog, one via `customOperator`. When both pass, the implementations are equivalent:
+Two e2e files, same CRD, same assertions — one via Orkestra katalog, one via `custom.target`. When both pass, the implementations are equivalent:
 
 ```
 my-operator/
 ├── e2e-orkestra.yaml   # spec.katalog: ./katalog.yaml
-└── e2e-custom.yaml     # spec.customOperator: true + setup.helm: my-old-operator
+└── e2e-custom.yaml     # spec.custom.target: kubernetes + setup.helm: my-old-operator
 ```
 
 ### Universal test harness
-`customOperator: true` exposes `ork e2e`'s assertion infrastructure — polling loops, count checks, command assertions, cleanup verification — to any operator framework: controller-runtime, Operator SDK, kube-rs, kopf.
+`custom.target: kubernetes` exposes `ork e2e`'s assertion infrastructure — polling loops,
+count checks, command assertions, cleanup verification — to any workload that runs on
+Kubernetes: controller-runtime operators, Helm charts, raw manifests, third-party tools.
 
 ## Example
 See [`examples/use-cases/custom-operator/`](../../../examples/use-cases/custom-operator/README.md) for two runnable examples.

--- a/pkg/e2e/runner.go
+++ b/pkg/e2e/runner.go
@@ -65,7 +65,7 @@ type Runner struct {
 	devServer bool
 
 	// customOperator skips bundle generation and Orkestra helm install/uninstall.
-	// Set from spec.customOperator — the file is the source of truth.
+	// Set when spec.custom.target == "kubernetes" — the file is the source of truth.
 	customOperator bool
 
 	// sharedOrkestra means Orkestra is managed by the parent runImports coordinator.
@@ -111,7 +111,11 @@ func New(e2eFile, clusterCtx string, useCurrentCtx, keepCluster, devServer bool,
 		orkestraVersion: orkestraVersion,
 		valueFiles:      allValueFiles,
 		helmArgs:        helmArgs,
-		customOperator:  e2e.Spec.CustomOperator,
+		customOperator:  e2e.Spec.Custom != nil && e2e.Spec.Custom.Target == orktypes.CustomTargetKubernetes,
+	}
+
+	if e2e.Spec.Custom != nil && e2e.Spec.Custom.Target == orktypes.CustomTargetContainer {
+		return nil, fmt.Errorf("spec.custom.target \"container\" is coming soon — not yet supported in this version")
 	}
 
 	if err := r.resolveSource(); err != nil {
@@ -145,8 +149,8 @@ func (r *Runner) resolveSource() error {
 		r.katalogFile = r.abs(spec.Katalog)
 		r.crFile = r.abs(spec.CR)
 
-	case spec.CR != "" && spec.CustomOperator:
-		// customOperator: katalog is optional — no bundle or Orkestra install.
+	case spec.CR != "" && spec.Custom != nil && spec.Custom.Target != "":
+		// custom.target: katalog is optional — no bundle or Orkestra install.
 		r.crFile = r.abs(spec.CR)
 
 	case len(r.e2e.Imports) > 0:
@@ -284,7 +288,7 @@ func (r *Runner) Run(ctx context.Context) (*Result, error) {
 
 		// ── 7. Install Orkestra ──────────────────────────────────────────
 		// ── 8. Wait for Orkestra ready ───────────────────────────────────
-		// Both steps skipped when customOperator: true.
+		// Both steps skipped when custom.target is set.
 		if !r.customOperator {
 			text := "..."
 

--- a/pkg/types/e2e.go
+++ b/pkg/types/e2e.go
@@ -178,11 +178,37 @@ type E2EMeta struct {
 	Description string `yaml:"description,omitempty"`
 }
 
+// CustomTarget identifies the runtime environment being tested when Orkestra
+// is not the operator. Validation rejects values outside the known set.
+type CustomTarget string
+
+const (
+	// CustomTargetKubernetes tests a workload that runs on Kubernetes — an operator,
+	// Helm chart, or raw manifests. Orkestra manages the cluster lifecycle and
+	// assertions; bundle generation and Orkestra helm install/uninstall are skipped.
+	CustomTargetKubernetes CustomTarget = "kubernetes"
+
+	// CustomTargetContainer tests a container image directly without a cluster.
+	// Future: build image → run container gate → embed OCI annotations → push.
+	// Not yet implemented; validation accepts the value but no runner path exists.
+	CustomTargetContainer CustomTarget = "container"
+)
+
+// String implements fmt.Stringer.
+func (t CustomTarget) String() string { return string(t) }
+
+// E2ECustomConfig declares the target runtime when testing non-Orkestra workloads.
+type E2ECustomConfig struct {
+	// Target is the runtime environment under test. Supported values: "kubernetes".
+	// "container" is reserved for future use.
+	Target CustomTarget `yaml:"target"`
+}
+
 type E2ESpec struct {
 	// Core operator spec — the three files that define every Orkestra operator.
 
 	// Katalog is the path to the katalog.yaml file.
-	// Optional when customOperator is true.
+	// Optional when spec.custom.target is set.
 	Katalog string `yaml:"katalog,omitempty"`
 	// CRD is the path to the CRD YAML file for this operator.
 	// Applied before the bundle and before Orkestra starts.
@@ -190,14 +216,15 @@ type E2ESpec struct {
 	// CR is the path to the CR YAML file to apply during the test.
 	CR string `yaml:"cr,omitempty"`
 
-	// CustomOperator declares that this test uses its own operator rather than
-	// Orkestra's reconcile loop. Bundle generation and Orkestra helm install/uninstall
-	// are skipped. Everything else runs unchanged: cluster setup, CRD apply, setup
-	// manifests, CR apply, assertions, and cleanup.
+	// Custom declares the target runtime for this e2e test when it is not an
+	// Orkestra-managed operator. Orkestra still owns the cluster lifecycle, setup,
+	// CR apply, assertions, and cleanup — only the bundle generation and
+	// Orkestra helm install/uninstall are skipped.
 	//
-	// Use this when your operator is installed via setup.helm or is already present
-	// in the cluster. See documentation/reference/schema/04-e2e/05-custom-operator.md.
-	CustomOperator bool `yaml:"customOperator,omitempty"`
+	// Use this when your operator, Helm chart, or any Kubernetes workload is
+	// installed via setup.helm or is already present in the cluster.
+	// See documentation/reference/schema/04-e2e/05-custom-target.md.
+	Custom *E2ECustomConfig `yaml:"custom,omitempty"`
 
 	// Init uses an example pack — for Orkestra's own CI.
 	Init *E2EInit `yaml:"init,omitempty"`


### PR DESCRIPTION
## Summary

- `spec.customOperator: bool` → `spec.custom.target: kubernetes` — names what you're testing, not what to skip
- New `CustomTarget` string type with `CustomTargetKubernetes` and `CustomTargetContainer` constants
- `ork validate e2e` fast-fails on unknown targets; `container` exits with "coming soon"
- New guide: `documentation/guides/e2e-universal.md` — "Test Anything That Runs in Kubernetes"
- `documentation/reference/schema/04-e2e/05-custom-operator.md` → `05-custom-target.md`, rewritten
- Blog `05-the-infrastructure-is-gone.md`: three → five modes; constructor-with-Orkestra-resources as the 5th; CTA added
- CHANGELOG v0.7.7 updated

## Migration

```yaml
# before
spec:
  customOperator: true

# after
spec:
  custom:
    target: kubernetes
```

## Test plan

- [x] `ork validate e2e` on a file with `custom.target: kubernetes` — passes, prints `mode: custom target (kubernetes — Orkestra install skipped)`
- [x] `ork validate e2e` on a file with `custom.target: container` — exits with "coming soon"
- [x] `ork validate e2e` on a file with `custom.target: unknown` — clear error naming valid values
- [x] `ork e2e` with `custom.target: kubernetes` — cluster spins up, Orkestra install skipped, assertions run
- [x] Old `customOperator: true` file — parse error (StrictUnmarshal rejects unknown field)