### PR TITLE
refactor: extract resource runners into pkg/runners

### DIFF
--- a/documentation/concepts/typed-operators/05-migration.md
+++ b/documentation/concepts/typed-operators/05-migration.md
@@ -37,7 +37,7 @@ ork migrate ./controller/webapp_controller.go -o ./my-operator
 
 Output:
 
-```
+```text
 my-operator/
   webapp_controller.go   rewritten — signature changed, ctrl.Result collapsed
   katalog.yaml           constructor Katalog stub — fill in group, kind, location

--- a/documentation/contributing/contributing-resources.md
+++ b/documentation/contributing/contributing-resources.md
@@ -102,9 +102,11 @@ func (r *Resolver) ResolveMyResourceTemplate(src *orktypes.MyResourceSource) (*m
 
 Use `r.Resolve(expr)` for any field that may contain a `{{ .spec.something }}` expression.
 
-### 4. Wire the runner in `pkg/reconciler/generic.go`
+### 4. Write the runner in `pkg/runners/`
 
-Find `runResources` and add your resource type alongside the existing ones.
+Create `pkg/runners/myresources.go` — see [pkg/runners/docs/01-runner-contract.md](../../pkg/runners/docs/01-runner-contract.md) for the canonical shape. Then wire it into `pkg/reconciler/run_template_reconcile.go` via `runners.RunMyResources(...)` and add `expandForEachMyResources` to `run_foreach.go`.
+
+The full end-to-end walkthrough is in [pkg/reconciler/docs/07-adding-a-resource.md](../../pkg/reconciler/docs/07-adding-a-resource.md).
 
 ### 5. Write tests
 

--- a/documentation/guides/registry/10-deprecation.md
+++ b/documentation/guides/registry/10-deprecation.md
@@ -59,7 +59,7 @@ Komposers that import a deprecated Katalog will surface the warning at `ork vali
 
 ## The deprecation lifecycle
 
-```
+```text
 v1.0.0  ← active
           │
           │  v1.1.0 ships (backwards-compatible)

--- a/documentation/guides/registry/index.md
+++ b/documentation/guides/registry/index.md
@@ -16,7 +16,7 @@ author writes Go → builds image → pushes to registry → consumer deploys im
 
 Orkestra's distribution model:
 
-```
+```text
 author writes YAML → simulate gate (no cluster) → e2e gate (real cluster) → push to OCI registry
 consumer inspects quality signal → pulls artifact → imports into Komposer → deploy
 ```

--- a/documentation/reference/cli/migrate.md
+++ b/documentation/reference/cli/migrate.md
@@ -47,7 +47,7 @@ ork migrate ./controller/webapp_controller.go
 
 When `-o` is provided:
 
-```
+```text
 my-operator/
   webapp_controller.go   rewritten reconciler
   katalog.yaml           constructor Katalog stub

--- a/pkg/reconciler/README.md
+++ b/pkg/reconciler/README.md
@@ -10,13 +10,15 @@ The reconciler package is the execution engine of every Orkestra operator. It ta
 | `ptr_hooks.go` | Design note: explains the PTR naming convention, the ObjectHooks adapter, and why the two-type-parameter form was not used |
 | `generic_autoscale.go` | `AutoscaleTarget`, `AutoscalerRunner`, `ResyncLoopStarter`, `QueueInjector`, `QueueDepthReporter` implementations; `SetSpawnWorker`, `SetRollbackNotifiers`, `GetAutoMetrics`, `WorkerInfo` wiring helpers |
 | `rollback.go` | Rollback subsystem — spec snapshotting, trigger evaluation, `onRollback` template execution, annotation lifecycle |
-| `run_template_reconcile.go` | Declarative pipeline: normalize → resolver → onCreate → onReconcile → providers |
+| `run_template_reconcile.go` | Declarative pipeline: normalize → resolver → onCreate → onReconcile → providers; calls runners in [`pkg/runners`](../runners/README.md) |
 | `normalize.go` | `applyNormalize` — in-memory spec normalization before mutation/validation |
-| `run_*.go` | Per-resource-type runners (deployments, services, secrets, cronjobs, roles, rolebindings, …) |
+| `run_delete_ordered.go` | Sequential staged deletion with completion gates (`onDelete.ordered: true`) |
 | `run_customresource.go` | Resolves, conditions-checks, and applies Custom Resource declarations; skips gracefully when target CRD is missing |
 | `conditions.go` | `EvaluateWhen` wrappers and helpers |
 | `run_namespace_guard.go` | `CheckNamespace` — allowed/restricted namespace enforcement |
 | `gvr.go` | GVR aliases used by `run_delete_ordered.go`; authoritative GVR definitions live in `pkg/children` |
+
+Per-resource-type runners (deployments, services, secrets, roles, …) live in [`pkg/runners`](../runners/README.md).
 
 Child resource reading, forEach expansion, enrichment, and the built-in kind registry live in [`pkg/children`](../children/README.md).
 
@@ -27,7 +29,8 @@ Full step-by-step documentation is in [docs/](docs/README.md).
 | I want to… | Go to |
 |-----------|-------|
 | Understand the full reconcile pipeline (including rollback gate) | [01 — Architecture](docs/01-architecture.md) |
-| Understand what every `run_*.go` must implement | [02 — The run_*.go Contract](docs/02-run-pattern.md) |
+| Understand the runner contract and canonical shape | [pkg/runners — 01 Runner Contract](../runners/docs/01-runner-contract.md) |
+| Quick runner reference (reconciler-scoped) | [02 — Runner Function Contract](docs/02-run-pattern.md) |
 | Understand the registry layer | [03 — Registry Layer](docs/03-registry-layer.md) |
 | Debug condition / activeNames issues | [04 — Conditions](docs/04-conditions.md) |
 | Understand `forEach:` expansion | [05 — forEach](docs/05-foreach.md) |

--- a/pkg/reconciler/docs/01-architecture.md
+++ b/pkg/reconciler/docs/01-architecture.md
@@ -4,7 +4,7 @@
 
 Every CR (Custom Resource) that Orkestra manages goes through one shared reconcile pipeline. The pipeline is implemented in `generic.go` and `run_template_reconcile.go`. Resource-specific logic lives in isolated `run_*.go` files.
 
-```
+```text
 Kubernetes event (Add/Update/Delete)
          │
          ▼
@@ -54,7 +54,7 @@ For non-autoscaled CRDs the semaphore is always uncontested.
 
 `run_template_reconcile.go` is the declarative path. It builds a resolver, enriches it with external data, then dispatches to resource-type runners.
 
-```
+```text
 Step 1   NewResolver(obj)
             .spec.*, .status.*, .metadata.*
             .children.* (owned child resources)
@@ -93,14 +93,14 @@ Each step can reference data produced by all earlier steps. The resolver is pass
 
 `runResourceGroup` calls each resource runner with the same signature:
 
-```
+```text
 expandForEach*(resolver, t.<Resource>)   →   []TypedTemplateSource
 runXxx(ctx, kube, resolver, owner, srcs, update, guard)
 ```
 
 The `expandForEach*` call happens **before** the runner is invoked. Every runner receives an already-expanded slice and does not need to know about `forEach`. The field can be a list (`.item` = element) or a map (`.item` = key, `.value` = map value).
 
-```
+```text
 runResourceGroup()
    │
    ├── expandForEachNamespaces           → runNamespaces

--- a/pkg/reconciler/docs/02-run-pattern.md
+++ b/pkg/reconciler/docs/02-run-pattern.md
@@ -1,6 +1,8 @@
-# 02 — The run_*.go Function Contract
+# 02 — The Runner Function Contract
 
-Every `run_<resource>.go` file follows the same structure. This document describes each section of the contract in the order it appears in the file.
+> **Note:** Per-resource runner functions have moved to [`pkg/runners/`](../../runners/README.md). The canonical shape and full reference documentation are in [pkg/runners/docs/01-runner-contract.md](../../runners/docs/01-runner-contract.md). This page remains as a quick reference for readers navigating the reconciler docs.
+
+Every runner file follows the same structure. This document describes each section in the order it appears.
 
 ## Canonical shape
 

--- a/pkg/reconciler/docs/03-registry-layer.md
+++ b/pkg/reconciler/docs/03-registry-layer.md
@@ -4,7 +4,7 @@ Each resource type has a dedicated package under `pkg/resources/<kind>/`. The re
 
 ## Package structure
 
-```
+```text
 pkg/resources/
     deployments/
         types.go       — DeploymentTemplateSource, ResolvedDeploymentSpec
@@ -147,7 +147,7 @@ The `Namespace` field is optional — if empty, the registry functions fall back
 
 Template source types live in `pkg/types/`, not in the registry package. The registry package imports `orktypes` for the source type, and the template resolver package imports `orktypes` for the same type. This keeps the dependency graph acyclic:
 
-```
+```text
 pkg/types             ← source structs, condition types
 pkg/resources ← imports pkg/types
 pkg/reconciler        ← imports both

--- a/pkg/reconciler/docs/06-normalize.md
+++ b/pkg/reconciler/docs/06-normalize.md
@@ -46,7 +46,7 @@ onCreate:
 
 ## Pipeline position
 
-```
+```text
 informer cache
      │
      ▼

--- a/pkg/reconciler/docs/07-adding-a-resource.md
+++ b/pkg/reconciler/docs/07-adding-a-resource.md
@@ -1,10 +1,10 @@
 # 07 — Adding a New Resource Type
 
-This document walks through every file that must change to add a new resource type. The worked example is `run_ingress.go`. Every step is labelled so you can use the checklist at the bottom to track progress.
+This document walks through every file that must change to add a new resource type. The worked example is `ingresses.go`. Every step is labelled so you can use the checklist at the bottom to track progress.
 
 **Recent additions you can use as further reference:**
-- `run_roles.go` + `pkg/resources/roles/role.go` — namespaced Role (RBAC)
-- `run_rolebindings.go` + `pkg/resources/rolebindings/rolebinding.go` — RoleBinding; demonstrates the immutable `roleRef` delete-recreate pattern in `Update`
+- `pkg/runners/roles.go` + `pkg/resources/roles/role.go` — namespaced Role (RBAC)
+- `pkg/runners/rolebindings.go` + `pkg/resources/rolebindings/rolebinding.go` — RoleBinding; demonstrates the immutable `roleRef` delete-recreate pattern in `Update`
 
 ## Overview of files to touch
 
@@ -21,10 +21,12 @@ pkg/resources/
 pkg/resources/template/
     resolver.go                 — add ResolveIngressTemplate method
 
+pkg/runners/
+    ingresses.go                — RunIngresses function (new file)
+
 pkg/reconciler/
-    run_ingress.go              — runIngresses function (new file)
     run_foreach.go              — add expandForEachIngresses
-    run_template_reconcile.go   — wire runIngresses into runResourceGroup
+    run_template_reconcile.go   — wire runners.RunIngresses into runResourceGroup
 ```
 
 ---
@@ -338,13 +340,13 @@ Look at `ResolveDeploymentTemplate` or `ResolveServiceTemplate` in the same file
 
 ---
 
-## Step 5 — Write run_ingress.go
+## Step 5 — Write the runner
 
-Create `pkg/reconciler/run_ingress.go`:
+Create `pkg/runners/ingresses.go`. The canonical shape is in [pkg/runners/docs/01-runner-contract.md](../../runners/docs/01-runner-contract.md); apply it here with `Ingress` as the resource type:
 
 ```go
-// pkg/reconciler/run_ingress.go
-package reconciler
+// pkg/runners/ingresses.go
+package runners
 
 import (
     "context"
@@ -358,18 +360,18 @@ import (
     orktypes "github.com/orkspace/orkestra/pkg/types"
 )
 
-func runIngresses(
-    ctx context.Context,
-    kube kubeclient.KubeClient,
+func RunIngresses(
+    ctx      context.Context,
+    kube     kubeclient.KubeClient,
     resolver *orktmpl.Resolver,
-    owner domain.Object,
-    srcs []orktypes.IngressTemplateSource,
-    update bool,
-    guard func(ctx context.Context, obj domain.Object, ns string) bool,
+    owner    domain.Object,
+    srcs     []orktypes.IngressTemplateSource,
+    update   bool,
+    guard    func(ctx context.Context, obj domain.Object, ns string) bool,
 ) error {
     activeNames := make(map[string]bool, len(srcs))
     for _, s := range srcs {
-        if !orktypes.EvaluateWhen(resolver.Data(), s.Conditions, s.AnyOf) {
+        if !orktypes.EvaluateWhen(resolver.Data(), s.Conditions, s.AnyOf, resolver.TemplateEvaluator()) {
             continue
         }
         n, _   := resolver.Resolve(s.Name)
@@ -381,7 +383,7 @@ func runIngresses(
     }
 
     for i, src := range srcs {
-        conditionPassed := orktypes.EvaluateWhen(resolver.Data(), src.Conditions, src.AnyOf)
+        conditionPassed := orktypes.EvaluateWhen(resolver.Data(), src.Conditions, src.AnyOf, resolver.TemplateEvaluator())
 
         name, _ := resolver.Resolve(src.Name)
         ns, _   := resolver.Resolve(src.Namespace)
@@ -476,10 +478,10 @@ func expandForEachIngresses(
 
 ## Step 7 — Wire into runResourceGroup
 
-In `pkg/reconciler/run_template_reconcile.go`, inside `runResourceGroup`, add the call after `runCronJobs`:
+In `pkg/reconciler/run_template_reconcile.go`, inside `runResourceGroup`, add the call after the CronJobs call:
 
 ```go
-if err := runIngresses(ctx, kube, resolver, obj,
+if err := runners.RunIngresses(ctx, kube, resolver, obj,
     expandForEachIngresses(resolver, t.Ingresses), update, guard); err != nil {
     return err
 }
@@ -506,9 +508,9 @@ A clean build is the acceptance criterion. No new tests are required for the run
 - [ ] `pkg/resources/ingresses/types.go` — `ResolvedIngressSpec`
 - [ ] `pkg/resources/ingresses/ingress.go` — `Create`, `Update`, `DeleteIfOwned`, `Resolve`
 - [ ] `pkg/resources/template/resolver.go` — `ResolveIngressTemplate`
-- [ ] `pkg/reconciler/run_ingress.go` — `runIngresses` with activeNames pre-pass
+- [ ] `pkg/runners/ingresses.go` — `RunIngresses` with activeNames pre-pass
 - [ ] `pkg/reconciler/run_foreach.go` — `expandForEachIngresses`
-- [ ] `pkg/reconciler/run_template_reconcile.go` — call `runIngresses` in `runResourceGroup`
+- [ ] `pkg/reconciler/run_template_reconcile.go` — call `runners.RunIngresses` in `runResourceGroup`
 - [ ] `go build ./...` passes
 
 ## Common mistakes

--- a/pkg/reconciler/docs/07-adding-a-resource.md
+++ b/pkg/reconciler/docs/07-adding-a-resource.md
@@ -8,7 +8,7 @@ This document walks through every file that must change to add a new resource ty
 
 ## Overview of files to touch
 
-```
+```text
 pkg/types/
     katalog_spec_hooks.go       — add IngressTemplateSource field to HookTemplates
     ingress.go                  — declare IngressTemplateSource (new file)

--- a/pkg/reconciler/docs/08-rollback.md
+++ b/pkg/reconciler/docs/08-rollback.md
@@ -31,7 +31,7 @@ operatorBox:
 
 Rollback adds two phases to `reconcileImpl`:
 
-```
+```text
 Phase 1 — Rollback gate
     isRollbackActive() → true:
         runRollback()     ← applies onRollback templates with .previous.*

--- a/pkg/reconciler/docs/09-ptr-hooks.md
+++ b/pkg/reconciler/docs/09-ptr-hooks.md
@@ -7,7 +7,7 @@ conventions), but the runtime registry passes those hooks through a type-erased
 path that resolves the reconciler's type parameter to `domain.Object` (an
 interface). A direct type assertion fails at startup with a panic:
 
-```
+```text
 hooks type mismatch — got domain.ReconcileHooks[*Database]
 ```
 
@@ -111,7 +111,7 @@ If the wrong type somehow ends up in the store the assertion panics with a clear
 
 ## End-to-end call path
 
-```
+```text
 1. User writes DatabaseHooks() returning ReconcileHooks[*Database]
        │
 2. Generated registry puts it in HookRegistry[GVK]

--- a/pkg/reconciler/run_delete_ordered.go
+++ b/pkg/reconciler/run_delete_ordered.go
@@ -20,6 +20,7 @@ import (
 	"github.com/orkspace/orkestra/pkg/kubeclient"
 	"github.com/orkspace/orkestra/pkg/logger"
 	orktmpl "github.com/orkspace/orkestra/pkg/resources/template"
+	"github.com/orkspace/orkestra/pkg/runners"
 	orktypes "github.com/orkspace/orkestra/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -125,7 +126,7 @@ func (r *GenericReconciler[PTR]) submitGroupDeletion(
 				// Cluster-scoped
 				err = dc.Resource(rd.gvr).Delete(ctx, item.name, delOpts)
 			}
-			if err != nil && !isNotFoundErr(err) {
+			if err != nil && !runners.IsNotFoundErr(err) {
 				return nil, fmt.Errorf("delete %s/%s: %w", rd.gvr.Resource, item.name, err)
 			}
 			pending = append(pending, orderedDeleteEntry{
@@ -223,7 +224,7 @@ func waitForDeletion(ctx context.Context, kube kubeclient.KubeClient, pending []
 			}
 			if err == nil {
 				remaining = append(remaining, e) // still exists
-			} else if !isNotFoundErr(err) {
+			} else if !runners.IsNotFoundErr(err) {
 				return fmt.Errorf("polling %s/%s: %w", e.gvr.Resource, e.name, err)
 			}
 		}

--- a/pkg/reconciler/run_template_reconcile.go
+++ b/pkg/reconciler/run_template_reconcile.go
@@ -20,7 +20,9 @@ import (
 	"github.com/orkspace/orkestra/pkg/kubeclient"
 	orklabels "github.com/orkspace/orkestra/pkg/labels"
 	"github.com/orkspace/orkestra/pkg/logger"
+	orkns "github.com/orkspace/orkestra/pkg/resources/namespaces"
 	orktmpl "github.com/orkspace/orkestra/pkg/resources/template"
+	"github.com/orkspace/orkestra/pkg/runners"
 	orktypes "github.com/orkspace/orkestra/pkg/types"
 )
 
@@ -144,28 +146,28 @@ func (r *GenericReconciler[PTR]) runResourceGroup(
 	})
 
 	// Create namespaces first
-	if err := runNamespaces(ctx, kube, resolver, obj,
+	if err := runners.RunNamespaces(ctx, kube, resolver, obj,
 		children.ExpandForEachNamespaces(resolver, t.Namespaces), update); err != nil {
 		return err
 	}
 
-	if err := runSecrets(ctx, kube, resolver, obj,
+	if err := runners.RunSecrets(ctx, kube, resolver, obj,
 		children.ExpandForEachSecrets(resolver, t.Secrets), update, guard); err != nil {
 		return err
 	}
-	if err := runConfigMaps(ctx, kube, resolver, obj,
+	if err := runners.RunConfigMaps(ctx, kube, resolver, obj,
 		children.ExpandForEachConfigMaps(resolver, t.ConfigMaps), update, guard); err != nil {
 		return err
 	}
-	if err := runServiceAccounts(ctx, kube, resolver, obj,
+	if err := runners.RunServiceAccounts(ctx, kube, resolver, obj,
 		children.ExpandForEachServiceAccounts(resolver, t.ServiceAccounts), update, guard); err != nil {
 		return err
 	}
-	if err := runRoles(ctx, kube, resolver, obj,
+	if err := runners.RunRoles(ctx, kube, resolver, obj,
 		children.ExpandForEachRoles(resolver, t.Roles), update, guard); err != nil {
 		return err
 	}
-	if err := runRoleBindings(ctx, kube, resolver, obj,
+	if err := runners.RunRoleBindings(ctx, kube, resolver, obj,
 		children.ExpandForEachRoleBindings(resolver, t.RoleBindings), update, guard); err != nil {
 		return err
 	}
@@ -174,51 +176,51 @@ func (r *GenericReconciler[PTR]) runResourceGroup(
 		r.kat.IsDeletionProtectionEnabled() && r.crd.ShouldProtectCRs()); err != nil {
 		return err
 	}
-	if err := runReplicaSets(ctx, kube, resolver, obj,
+	if err := runners.RunReplicaSets(ctx, kube, resolver, obj,
 		children.ExpandForEachReplicaSets(resolver, t.ReplicaSets), update, guard); err != nil {
 		return err
 	}
-	if err := runDeployments(ctx, kube, resolver, obj,
+	if err := runners.RunDeployments(ctx, kube, resolver, obj,
 		children.ExpandForEachDeployments(resolver, t.Deployments), update, guard); err != nil {
 		return err
 	}
-	if err := runServices(ctx, kube, resolver, obj,
+	if err := runners.RunServices(ctx, kube, resolver, obj,
 		children.ExpandForEachServices(resolver, t.Services), update, guard); err != nil {
 		return err
 	}
-	if err := runJobs(ctx, kube, resolver, obj,
+	if err := runners.RunJobs(ctx, kube, resolver, obj,
 		children.ExpandForEachJobs(resolver, t.Jobs), guard); err != nil {
 		return err
 	}
-	if err := runCronJobs(ctx, kube, resolver, obj,
+	if err := runners.RunCronJobs(ctx, kube, resolver, obj,
 		children.ExpandForEachCronJobs(resolver, t.CronJobs), update, guard); err != nil {
 		return err
 	}
-	if err := runStatefulSets(ctx, kube, resolver, obj,
+	if err := runners.RunStatefulSets(ctx, kube, resolver, obj,
 		children.ExpandForEachStatefulSets(resolver, t.StatefulSets), update, guard); err != nil {
 		return err
 	}
-	if err := runPVs(ctx, kube, resolver, obj,
+	if err := runners.RunPVs(ctx, kube, resolver, obj,
 		children.ExpandForEachPVs(resolver, t.PersistentVolumes), update); err != nil {
 		return err
 	}
-	if err := runPVCs(ctx, kube, resolver, obj,
+	if err := runners.RunPVCs(ctx, kube, resolver, obj,
 		children.ExpandForEachPVCs(resolver, t.PersistentVolumeClaims), update, guard); err != nil {
 		return err
 	}
-	if err := runIngresses(ctx, kube, resolver, obj,
+	if err := runners.RunIngresses(ctx, kube, resolver, obj,
 		children.ExpandForEachIngresses(resolver, t.Ingresses), update, guard); err != nil {
 		return err
 	}
-	if err := runHPAs(ctx, kube, resolver, obj,
+	if err := runners.RunHPAs(ctx, kube, resolver, obj,
 		children.ExpandForEachHPAs(resolver, t.HorizontalPodAutoscalers), update, guard); err != nil {
 		return err
 	}
-	if err := runPDBs(ctx, kube, resolver, obj,
+	if err := runners.RunPDBs(ctx, kube, resolver, obj,
 		children.ExpandForEachPDBs(resolver, t.PodDisruptionBudgets), update, guard); err != nil {
 		return err
 	}
-	if err := runPods(ctx, kube, resolver, obj,
+	if err := runners.RunPods(ctx, kube, resolver, obj,
 		children.ExpandForEachPods(resolver, t.Pods), update, guard); err != nil {
 		return err
 	}
@@ -240,7 +242,7 @@ func (r *GenericReconciler[PTR]) runTemplateOnDelete(ctx context.Context, resolv
 				return err
 			}
 		} else {
-			if err := runJobs(ctx, kube, resolver, obj,
+			if err := runners.RunJobs(ctx, kube, resolver, obj,
 				children.ExpandForEachJobs(resolver, t.Jobs), guard); err != nil {
 				return err
 			}
@@ -260,6 +262,42 @@ func (r *GenericReconciler[PTR]) runTemplateOnDelete(ctx context.Context, resolv
 		return fmt.Errorf("namespace cleanup: %w", err)
 	}
 
+	return nil
+}
+
+// deleteOwnedNamespaces explicitly deletes all Namespaces declared across
+// onCreate, onReconcile, and onDelete that are owned by this CR.
+//
+// Kubernetes GC does not handle this automatically: owner references from
+// namespace-scoped resources (CRs) to cluster-scoped resources (Namespaces)
+// are not honoured by the garbage collector. Explicit deletion is required.
+func deleteOwnedNamespaces(
+	ctx context.Context,
+	kube kubeclient.KubeClient,
+	resolver *orktmpl.Resolver,
+	obj domain.Object,
+	box orktypes.OperatorBoxConfig,
+) error {
+	var srcs []orktypes.NamespaceTemplateSource
+	if box.OnCreate != nil {
+		srcs = append(srcs, box.OnCreate.Namespaces...)
+	}
+	if box.OnReconcile != nil {
+		srcs = append(srcs, box.OnReconcile.Namespaces...)
+	}
+	if box.OnDelete != nil {
+		srcs = append(srcs, box.OnDelete.Namespaces...)
+	}
+
+	for i, src := range srcs {
+		name, err := resolver.Resolve(src.Name)
+		if err != nil || name == "" {
+			continue
+		}
+		if err := orkns.DeleteIfOwned(ctx, kube, obj, name); err != nil {
+			return fmt.Errorf("namespace[%d] %q: %w", i, name, err)
+		}
+	}
 	return nil
 }
 

--- a/pkg/runners/README.md
+++ b/pkg/runners/README.md
@@ -1,0 +1,48 @@
+# pkg/runners
+
+Resource runners — one file per Kubernetes resource type.
+
+Each runner takes a resolved list of template sources and applies them to the cluster: creating, updating, or deleting the corresponding Kubernetes objects according to the CR's declared state.
+
+## What lives here
+
+| File | Resource |
+|------|----------|
+| `secrets.go` | Secret (includes `once:`, `rotateAfter:`, `tls:`, `toNamespaces:`) |
+| `configmaps.go` | ConfigMap (includes `toNamespaces:`, `fromConfigMap:`) |
+| `serviceaccounts.go` | ServiceAccount |
+| `roles.go` | Role |
+| `rolebindings.go` | RoleBinding |
+| `deployments.go` | Deployment |
+| `statefulsets.go` | StatefulSet |
+| `replicasets.go` | ReplicaSet |
+| `services.go` | Service |
+| `ingresses.go` | Ingress |
+| `jobs.go` | Job |
+| `cronjobs.go` | CronJob |
+| `pods.go` | Pod |
+| `pvcs.go` | PersistentVolumeClaim |
+| `pvs.go` | PersistentVolume |
+| `hpas.go` | HorizontalPodAutoscaler |
+| `pdbs.go` | PodDisruptionBudget |
+| `namespaces.go` | Namespace (create-only; no drift correction) |
+| `secrets_once.go` | Helper: `once:` guard, `IsNotFoundErr` |
+| `secret_tls.go` | Helper: TLS secret rotation |
+
+## What does NOT live here
+
+Runners that are specific to the reconciler's dispatch logic stay in `pkg/reconciler/`:
+
+- `run_template_reconcile.go` — the dispatcher that calls each runner in sequence
+- `run_admission.go`, `run_validations.go`, `run_mutations.go` — admission/validation/mutation pipeline
+- `run_status.go` — status field writing
+- `run_namespace_guard.go` — namespace allow/restrict enforcement
+- `run_delete_ordered.go` — sequential staged deletion
+- `run_external.go`, `run_git.go`, `run_docker.go` — external integration runners
+- `run_providers.go`, `run_cross.go`, `run_customresource.go` — provider and cross-CRD runners
+
+## Adding a new resource type
+
+See [docs/01-runner-contract.md](docs/01-runner-contract.md) for the canonical shape every runner must follow.
+
+For the full end-to-end walkthrough (types → resource package → resolver → runner → dispatcher), see [pkg/reconciler/docs/07-adding-a-resource.md](../reconciler/docs/07-adding-a-resource.md).

--- a/pkg/runners/configmaps.go
+++ b/pkg/runners/configmaps.go
@@ -1,5 +1,5 @@
 // pkg/reconciler/run_configmaps.go
-package reconciler
+package runners
 
 import (
 	"context"
@@ -13,7 +13,7 @@ import (
 	orktypes "github.com/orkspace/orkestra/pkg/types"
 )
 
-// runConfigMaps resolves and applies ConfigMap template declarations.
+// RunConfigMaps resolves and applies ConfigMap template declarations.
 //
 // ConfigMaps support the same fromConfigMap and toNamespaces patterns as Secrets:
 //
@@ -26,7 +26,7 @@ import (
 // reconcile: true — re-reads the source ConfigMap on every reconcile
 // and syncs any changes. When logLevel changes in the CR spec, the
 // ConfigMap in every namespace updates automatically.
-func runConfigMaps(
+func RunConfigMaps(
 	ctx context.Context,
 	kube kubeclient.KubeClient,
 	resolver *orktmpl.Resolver,

--- a/pkg/runners/cronjobs.go
+++ b/pkg/runners/cronjobs.go
@@ -1,5 +1,5 @@
 // pkg/reconciler/run_cronjobs.go
-package reconciler
+package runners
 
 import (
 	"context"
@@ -13,7 +13,7 @@ import (
 	orktypes "github.com/orkspace/orkestra/pkg/types"
 )
 
-// runCronJobs resolves and applies CronJob template declarations.
+// RunCronJobs resolves and applies CronJob template declarations.
 //
 // CronJobs are long-lived scheduled resources — created under onCreate and
 // drift-corrected under onReconcile (or reconcile: true).
@@ -29,7 +29,7 @@ import (
 //
 //	schedule: "0 * * * *"               static — every hour
 //	schedule: "{{ .spec.syncSchedule }}" dynamic — from CR spec
-func runCronJobs(
+func RunCronJobs(
 	ctx context.Context,
 	kube kubeclient.KubeClient,
 	resolver *orktmpl.Resolver,

--- a/pkg/runners/deployments.go
+++ b/pkg/runners/deployments.go
@@ -1,5 +1,5 @@
 // pkg/reconciler/run_deployments.go
-package reconciler
+package runners
 
 import (
 	"context"
@@ -13,7 +13,7 @@ import (
 	orktypes "github.com/orkspace/orkestra/pkg/types"
 )
 
-// runDeployments resolves and applies Deployment template declarations.
+// RunDeployments resolves and applies Deployment template declarations.
 //
 // update=false  onCreate path  — idempotent Create
 // update=true   onReconcile path — Update for drift correction
@@ -21,7 +21,7 @@ import (
 // reconcile: true on an onCreate entry means also call Update on that
 // same reconcile loop — the shorthand for "create it and keep it in sync"
 // without a separate onReconcile declaration.
-func runDeployments(
+func RunDeployments(
 	ctx context.Context,
 	kube kubeclient.KubeClient,
 	resolver *orktmpl.Resolver,

--- a/pkg/runners/docs/01-runner-contract.md
+++ b/pkg/runners/docs/01-runner-contract.md
@@ -1,0 +1,231 @@
+# 01 — The Runner Contract
+
+Every file in `pkg/runners/` follows the same structure. This document describes each section in the order it appears.
+
+## Canonical shape
+
+```go
+// pkg/runners/widgets.go
+package runners
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/orkspace/orkestra/domain"
+    "github.com/orkspace/orkestra/pkg/kubeclient"
+    "github.com/orkspace/orkestra/pkg/logger"
+    orkwidget "github.com/orkspace/orkestra/pkg/resources/widgets"
+    orktmpl "github.com/orkspace/orkestra/pkg/resources/template"
+    orktypes "github.com/orkspace/orkestra/pkg/types"
+)
+
+func RunWidgets(
+    ctx      context.Context,
+    kube     kubeclient.KubeClient,
+    resolver *orktmpl.Resolver,
+    owner    domain.Object,
+    srcs     []orktypes.WidgetTemplateSource,
+    update   bool,
+    guard    func(ctx context.Context, obj domain.Object, ns string) bool,
+) error {
+
+    // ── Section A: activeNames pre-pass ──────────────────────────────────────
+    activeNames := make(map[string]bool, len(srcs))
+    for _, s := range srcs {
+        if !orktypes.EvaluateWhen(resolver.Data(), s.Conditions, s.AnyOf, resolver.TemplateEvaluator()) {
+            continue
+        }
+        n, _   := resolver.Resolve(s.Name)
+        nsp, _ := resolver.Resolve(s.Namespace)
+        if nsp == "" {
+            nsp = owner.GetNamespace()
+        }
+        activeNames[nsp+"/"+n] = true
+    }
+
+    // ── Section B: main loop ──────────────────────────────────────────────────
+    for i, src := range srcs {
+
+        // B1. Evaluate conditions
+        conditionPassed := orktypes.EvaluateWhen(resolver.Data(), src.Conditions, src.AnyOf, resolver.TemplateEvaluator())
+
+        // B2. Early name/namespace resolution
+        name, _ := resolver.Resolve(src.Name)
+        ns, _   := resolver.Resolve(src.Namespace)
+        if ns == "" {
+            ns = owner.GetNamespace()
+        }
+
+        // B3. Namespace guard
+        if guard != nil && !guard(ctx, owner, ns) {
+            continue
+        }
+
+        // B4. Condition failure path
+        if !conditionPassed {
+            if update || src.Reconcile {
+                if !activeNames[ns+"/"+name] {
+                    if err := orkwidget.DeleteIfOwned(ctx, kube, owner, name, ns); err != nil {
+                        return fmt.Errorf("widgets[%d]: conditional cleanup: %w", i, err)
+                    }
+                }
+            }
+            logger.FromContext(ctx).Debug().
+                Str("resource", "Widget").
+                Int("index", i).
+                Msg("conditions not met — skipping resource")
+            continue
+        }
+
+        // B5. Resolve template expressions
+        resolved, err := resolver.ResolveWidgetTemplate(src)
+        if err != nil {
+            return fmt.Errorf("widgets[%d]: %w", i, err)
+        }
+
+        // B6. Build registry spec and apply
+        spec := orkwidget.Resolve(resolved, resolver.OwnerName())
+
+        if update {
+            if err := orkwidget.Update(ctx, kube, owner, spec); err != nil {
+                return fmt.Errorf("widgets[%d].update: %w", i, err)
+            }
+        } else {
+            if err := orkwidget.Create(ctx, kube, owner, spec); err != nil {
+                return fmt.Errorf("widgets[%d].create: %w", i, err)
+            }
+            if src.Reconcile {
+                if err := orkwidget.Update(ctx, kube, owner, spec); err != nil {
+                    return fmt.Errorf("widgets[%d].reconcile: %w", i, err)
+                }
+            }
+        }
+    }
+    return nil
+}
+```
+
+---
+
+## Section A — activeNames pre-pass
+
+**Why it exists.** When two declarations target the same resource name but have mutually exclusive conditions (`when: typeOf == A` vs `when: typeOf == B`), the failing path's cleanup (`DeleteIfOwned`) would delete what the passing path just created. The pre-pass builds the set of `ns/name` pairs that have at least one passing condition. The main loop only calls `DeleteIfOwned` when the target is NOT in that set.
+
+**When to omit it.** If the resource never calls `DeleteIfOwned` on the condition-failure path (e.g. `RunJobs` — jobs are terminal), omit Section A and the `activeNames` guard in B4.
+
+---
+
+## Section B1 — Condition evaluation
+
+Always call `orktypes.EvaluateWhen(resolver.Data(), src.Conditions, src.AnyOf, resolver.TemplateEvaluator())`.
+
+- `resolver.Data()` — the full CR data map including `.children.*`, `.external.*`, `.cross.*`. Do NOT pass the `owner` object directly — it does not have these injected fields.
+- `src.Conditions` — the `when:` block (AND semantics).
+- `src.AnyOf` — the `anyOf:` block (OR semantics).
+
+---
+
+## Section B2 — Early name/namespace resolution
+
+Resolve before the guard and before the condition-failure cleanup. `Resolve` is cheap; the full `ResolveXxxTemplate` in B5 re-resolves internally.
+
+```go
+name, _ := resolver.Resolve(src.Name)
+ns, _   := resolver.Resolve(src.Namespace)
+if ns == "" {
+    ns = owner.GetNamespace()
+}
+```
+
+The blank identifier on the error is intentional — resolution errors on name/namespace are surfaced in B5 during full resolution.
+
+---
+
+## Section B3 — Namespace guard
+
+```go
+if guard != nil && !guard(ctx, owner, ns) {
+    continue
+}
+```
+
+Always nil-check. The guard is nil when the CRD has no namespace restrictions. Call it after namespace resolution so the actual target namespace is known.
+
+---
+
+## Section B4 — Condition failure path
+
+Only attempt cleanup when `update || src.Reconcile` — on first create (update=false, reconcile=false) there is nothing to clean up yet.
+
+Wrap `DeleteIfOwned` with `if !activeNames[ns+"/"+name]` to prevent the failing path from deleting a resource the passing path owns.
+
+---
+
+## Section B5 — Template resolution
+
+Call `resolver.ResolveXxxTemplate(src)`. This evaluates all `{{ }}` expressions in the source struct. Errors here are real — return them.
+
+---
+
+## Section B6 — Apply
+
+```go
+if update {
+    orkwidget.Update(...)   // onReconcile — drift correction
+} else {
+    orkwidget.Create(...)   // onCreate — idempotent create
+    if src.Reconcile {
+        orkwidget.Update(...) // reconcile: true shorthand
+    }
+}
+```
+
+Resources that are create-only (ServiceAccount, Job) skip the `update` branch entirely.
+
+---
+
+## Signature variations
+
+| Runner | `update bool` | `guard` | Notes |
+|--------|--------------|---------|-------|
+| `RunDeployments` | yes | yes | Full create/update |
+| `RunServices` | yes | yes | Full create/update |
+| `RunSecrets` | yes | yes | Extra: `once:`, `rotateAfter:`, `tls:`, `toNamespaces:` |
+| `RunConfigMaps` | yes | yes | Extra: `toNamespaces:`, `fromConfigMap:` |
+| `RunServiceAccounts` | yes | yes | Create-only (no update branch) |
+| `RunCronJobs` | yes | yes | Full create/update |
+| `RunJobs` | no | yes | Create-only, no activeNames pre-pass |
+| `RunNamespaces` | yes | no | Create-only, no guard (cluster-scoped) |
+| `RunPVs` | yes | no | No guard (cluster-scoped) |
+
+---
+
+## Error format convention
+
+```go
+return fmt.Errorf("widgets[%d]: %w", i, err)                     // resolution errors
+return fmt.Errorf("widgets[%d].create: %w", i, err)              // apply errors
+return fmt.Errorf("widgets[%d].update: %w", i, err)
+return fmt.Errorf("widgets[%d]: conditional cleanup: %w", i, err)
+```
+
+The `[%d]` index tells operators exactly which declaration in the YAML failed.
+
+---
+
+## Common mistakes
+
+**Forgetting the activeNames pre-pass.** Causes create/delete loops when two declarations target the same resource with mutually exclusive conditions.
+
+**Passing `owner` to EvaluateWhen instead of `resolver.Data()`.** The `owner` object does not have `.children.*`, `.external.*`, or `.cross.*` — conditions referencing those fields silently fail.
+
+**Not nil-checking the guard.** `guard` is nil when the CRD has no namespace restrictions. A nil dereference panics.
+
+**Forgetting `reconcile: true` support.** The `if src.Reconcile { Update(...) }` block in the non-update branch is how `reconcile: true` works on onCreate. Without it, the shorthand is silently ignored.
+
+**Not exporting the function name.** Functions in `pkg/runners/` are exported (`RunWidgets`, not `runWidgets`) — they are called from `pkg/reconciler/` and can be called from anywhere else that needs the same resource logic.
+
+---
+
+→ Back: [README](../README.md)

--- a/pkg/runners/hpas.go
+++ b/pkg/runners/hpas.go
@@ -1,5 +1,5 @@
-// pkg/reconciler/run_pvcs.go
-package reconciler
+// pkg/reconciler/run_hpas.go
+package runners
 
 import (
 	"context"
@@ -8,18 +8,18 @@ import (
 	"github.com/orkspace/orkestra/domain"
 	"github.com/orkspace/orkestra/pkg/kubeclient"
 	"github.com/orkspace/orkestra/pkg/logger"
-	orkpvc "github.com/orkspace/orkestra/pkg/resources/pvcs"
+	orkhpa "github.com/orkspace/orkestra/pkg/resources/hpas"
 	orktmpl "github.com/orkspace/orkestra/pkg/resources/template"
 	orktypes "github.com/orkspace/orkestra/pkg/types"
 )
 
-// runPVCs resolves and applies PersistentVolumeClaim template declarations.
-func runPVCs(
+// RunHPAs resolves and applies HorizontalPodAutoscaler template declarations.
+func RunHPAs(
 	ctx context.Context,
 	kube kubeclient.KubeClient,
 	resolver *orktmpl.Resolver,
 	owner domain.Object,
-	srcs []orktypes.PVCTemplateSource,
+	srcs []orktypes.HPATemplateSource,
 	update bool,
 	guard func(ctx context.Context, obj domain.Object, ns string) bool,
 ) error {
@@ -52,36 +52,36 @@ func runPVCs(
 		if !conditionPassed {
 			if update || src.Reconcile {
 				if !activeNames[ns+"/"+name] {
-					if err := orkpvc.DeleteIfOwned(ctx, kube, owner, name, ns); err != nil {
-						return fmt.Errorf("pvcs[%d]: conditional cleanup: %w", i, err)
+					if err := orkhpa.DeleteIfOwned(ctx, kube, owner, name, ns); err != nil {
+						return fmt.Errorf("hpas[%d]: conditional cleanup: %w", i, err)
 					}
 				}
 			}
 			logger.FromContext(ctx).Debug().
-				Str("resource", "PersistentVolumeClaim").
+				Str("resource", "HorizontalPodAutoscaler").
 				Int("index", i).
 				Msg("conditions not met — skipping resource")
 			continue
 		}
 
-		resolved, err := resolver.ResolvePVCTemplate(src)
+		resolved, err := resolver.ResolveHPATemplate(src)
 		if err != nil {
-			return fmt.Errorf("pvcs[%d]: %w", i, err)
+			return fmt.Errorf("hpas[%d]: %w", i, err)
 		}
 
-		spec := orkpvc.Resolve(resolved, resolver.OwnerName())
+		spec := orkhpa.Resolve(resolved, resolver.OwnerName())
 
 		if update {
-			if err := orkpvc.Update(ctx, kube, owner, spec); err != nil {
-				return fmt.Errorf("pvcs[%d].update: %w", i, err)
+			if err := orkhpa.Update(ctx, kube, owner, spec); err != nil {
+				return fmt.Errorf("hpas[%d].update: %w", i, err)
 			}
 		} else {
-			if err := orkpvc.Create(ctx, kube, owner, spec); err != nil {
-				return fmt.Errorf("pvcs[%d].create: %w", i, err)
+			if err := orkhpa.Create(ctx, kube, owner, spec); err != nil {
+				return fmt.Errorf("hpas[%d].create: %w", i, err)
 			}
 			if src.Reconcile {
-				if err := orkpvc.Update(ctx, kube, owner, spec); err != nil {
-					return fmt.Errorf("pvcs[%d].reconcile: %w", i, err)
+				if err := orkhpa.Update(ctx, kube, owner, spec); err != nil {
+					return fmt.Errorf("hpas[%d].reconcile: %w", i, err)
 				}
 			}
 		}

--- a/pkg/runners/ingresses.go
+++ b/pkg/runners/ingresses.go
@@ -1,5 +1,5 @@
 // pkg/reconciler/run_ingresses.go
-package reconciler
+package runners
 
 import (
 	"context"
@@ -15,10 +15,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// runIngresses resolves and applies Ingress template declarations.
+// RunIngresses resolves and applies Ingress template declarations.
 // When tls.enabled is true on an Ingress, a kubernetes.io/tls Secret is created
 // before the Ingress so the Ingress can reference it immediately.
-func runIngresses(
+func RunIngresses(
 	ctx context.Context,
 	kube kubeclient.KubeClient,
 	resolver *orktmpl.Resolver,
@@ -126,7 +126,7 @@ func ensureIngressTLSSecret(
 			Msg("ingress tls secret already exists — skipping")
 		return nil
 	}
-	if !isNotFoundErr(err) {
+	if !IsNotFoundErr(err) {
 		return fmt.Errorf("checking tls secret %q: %w", secretName, err)
 	}
 

--- a/pkg/runners/jobs.go
+++ b/pkg/runners/jobs.go
@@ -1,5 +1,5 @@
 // pkg/reconciler/run_jobs.go
-package reconciler
+package runners
 
 import (
 	"context"
@@ -13,7 +13,7 @@ import (
 	orktypes "github.com/orkspace/orkestra/pkg/types"
 )
 
-// runJobs resolves and applies Job template declarations.
+// RunJobs resolves and applies Job template declarations.
 //
 // Jobs are fire-and-forget — they run once to completion and are not updated
 // after creation. They are therefore always idempotent creates.
@@ -29,7 +29,7 @@ import (
 //
 // Owner references are NOT set on onDelete Jobs because the owner CR is
 // being deleted — the Job must complete independently after the CR is gone.
-func runJobs(
+func RunJobs(
 	ctx context.Context,
 	kube kubeclient.KubeClient,
 	resolver *orktmpl.Resolver,

--- a/pkg/runners/namespaces.go
+++ b/pkg/runners/namespaces.go
@@ -1,5 +1,5 @@
 // pkg/reconciler/run_namespace.go
-package reconciler
+package runners
 
 import (
 	"context"
@@ -13,44 +13,7 @@ import (
 	orktypes "github.com/orkspace/orkestra/pkg/types"
 )
 
-// deleteOwnedNamespaces explicitly deletes all Namespaces declared across
-// onCreate and onReconcile that are owned by this CR.
-//
-// Kubernetes GC does not handle this automatically: owner references from
-// namespace-scoped resources (CRs) to cluster-scoped resources (Namespaces)
-// are not honoured by the garbage collector. Explicit deletion is required.
-func deleteOwnedNamespaces(
-	ctx context.Context,
-	kube kubeclient.KubeClient,
-	resolver *orktmpl.Resolver,
-	obj domain.Object,
-	box orktypes.OperatorBoxConfig,
-) error {
-	// Collect all declared namespace sources across template blocks.
-	var srcs []orktypes.NamespaceTemplateSource
-	if box.OnCreate != nil {
-		srcs = append(srcs, box.OnCreate.Namespaces...)
-	}
-	if box.OnReconcile != nil {
-		srcs = append(srcs, box.OnReconcile.Namespaces...)
-	}
-	if box.OnDelete != nil {
-		srcs = append(srcs, box.OnDelete.Namespaces...)
-	}
-
-	for i, src := range srcs {
-		name, err := resolver.Resolve(src.Name)
-		if err != nil || name == "" {
-			continue
-		}
-		if err := orkns.DeleteIfOwned(ctx, kube, obj, name); err != nil {
-			return fmt.Errorf("namespace[%d] %q: %w", i, name, err)
-		}
-	}
-	return nil
-}
-
-// runNamespaces resolves and applies Namespace template declarations.
+// RunNamespaces resolves and applies Namespace template declarations.
 //
 // Namespaces are create-only — there is nothing meaningful to update
 // on a Namespace after creation (no spec fields that drift). They are
@@ -58,7 +21,7 @@ func deleteOwnedNamespaces(
 // from onCreate or onReconcile.
 //
 // Owner references ensure cleanup when the CR is deleted.
-func runNamespaces(
+func RunNamespaces(
 	ctx context.Context,
 	kube kubeclient.KubeClient,
 	resolver *orktmpl.Resolver,

--- a/pkg/runners/pdbs.go
+++ b/pkg/runners/pdbs.go
@@ -1,5 +1,5 @@
-// pkg/reconciler/run_rolebindings.go
-package reconciler
+// pkg/reconciler/run_pdbs.go
+package runners
 
 import (
 	"context"
@@ -8,22 +8,18 @@ import (
 	"github.com/orkspace/orkestra/domain"
 	"github.com/orkspace/orkestra/pkg/kubeclient"
 	"github.com/orkspace/orkestra/pkg/logger"
-	orkrb "github.com/orkspace/orkestra/pkg/resources/rolebindings"
+	orkpdb "github.com/orkspace/orkestra/pkg/resources/pdbs"
 	orktmpl "github.com/orkspace/orkestra/pkg/resources/template"
 	orktypes "github.com/orkspace/orkestra/pkg/types"
 )
 
-// runRoleBindings resolves and applies RoleBinding template declarations.
-//
-// On onCreate: idempotent create only.
-// On onReconcile (update=true): creates or updates (or recreates when roleRef changed).
-// Owner references ensure cleanup when the CR is deleted.
-func runRoleBindings(
+// RunPDBs resolves and applies PodDisruptionBudget template declarations.
+func RunPDBs(
 	ctx context.Context,
 	kube kubeclient.KubeClient,
 	resolver *orktmpl.Resolver,
 	owner domain.Object,
-	srcs []orktypes.RoleBindingTemplateSource,
+	srcs []orktypes.PDBTemplateSource,
 	update bool,
 	guard func(ctx context.Context, obj domain.Object, ns string) bool,
 ) error {
@@ -56,32 +52,37 @@ func runRoleBindings(
 		if !conditionPassed {
 			if update || src.Reconcile {
 				if !activeNames[ns+"/"+name] {
-					if err := orkrb.DeleteIfOwned(ctx, kube, owner, name, ns); err != nil {
-						return fmt.Errorf("roleBindings[%d]: conditional cleanup: %w", i, err)
+					if err := orkpdb.DeleteIfOwned(ctx, kube, owner, name, ns); err != nil {
+						return fmt.Errorf("pdbs[%d]: conditional cleanup: %w", i, err)
 					}
 				}
 			}
 			logger.FromContext(ctx).Debug().
-				Str("resource", "RoleBinding").
+				Str("resource", "PodDisruptionBudget").
 				Int("index", i).
 				Msg("conditions not met — skipping resource")
 			continue
 		}
 
-		resolved, err := resolver.ResolveRoleBindingTemplate(src)
+		resolved, err := resolver.ResolvePDBTemplate(src)
 		if err != nil {
-			return fmt.Errorf("roleBindings[%d]: %w", i, err)
+			return fmt.Errorf("pdbs[%d]: %w", i, err)
 		}
 
-		spec := orkrb.Resolve(resolved, resolver.OwnerName())
+		spec := orkpdb.Resolve(resolved, resolver.OwnerName())
 
-		if update || src.Reconcile {
-			if err := orkrb.Update(ctx, kube, owner, spec); err != nil {
-				return fmt.Errorf("roleBindings[%d].update: %w", i, err)
+		if update {
+			if err := orkpdb.Update(ctx, kube, owner, spec); err != nil {
+				return fmt.Errorf("pdbs[%d].update: %w", i, err)
 			}
 		} else {
-			if err := orkrb.Create(ctx, kube, owner, spec); err != nil {
-				return fmt.Errorf("roleBindings[%d].create: %w", i, err)
+			if err := orkpdb.Create(ctx, kube, owner, spec); err != nil {
+				return fmt.Errorf("pdbs[%d].create: %w", i, err)
+			}
+			if src.Reconcile {
+				if err := orkpdb.Update(ctx, kube, owner, spec); err != nil {
+					return fmt.Errorf("pdbs[%d].reconcile: %w", i, err)
+				}
 			}
 		}
 	}

--- a/pkg/runners/pods.go
+++ b/pkg/runners/pods.go
@@ -1,5 +1,5 @@
 // pkg/reconciler/run_pods.go
-package reconciler
+package runners
 
 import (
 	"context"
@@ -13,7 +13,7 @@ import (
 	orktypes "github.com/orkspace/orkestra/pkg/types"
 )
 
-// runPods resolves and applies Pod template declarations.
+// RunPods resolves and applies Pod template declarations.
 //
 // update=false  onCreate path  — idempotent Create
 // update=true   onReconcile path — Update for drift correction (delete + recreate on image drift)
@@ -21,7 +21,7 @@ import (
 // reconcile: true on an onCreate entry means also call Update on that
 // same reconcile loop — the shorthand for "create it and keep it in sync"
 // without a separate onReconcile declaration.
-func runPods(
+func RunPods(
 	ctx context.Context,
 	kube kubeclient.KubeClient,
 	resolver *orktmpl.Resolver,

--- a/pkg/runners/pvcs.go
+++ b/pkg/runners/pvcs.go
@@ -1,5 +1,5 @@
-// pkg/reconciler/run_pdbs.go
-package reconciler
+// pkg/reconciler/run_pvcs.go
+package runners
 
 import (
 	"context"
@@ -8,18 +8,18 @@ import (
 	"github.com/orkspace/orkestra/domain"
 	"github.com/orkspace/orkestra/pkg/kubeclient"
 	"github.com/orkspace/orkestra/pkg/logger"
-	orkpdb "github.com/orkspace/orkestra/pkg/resources/pdbs"
+	orkpvc "github.com/orkspace/orkestra/pkg/resources/pvcs"
 	orktmpl "github.com/orkspace/orkestra/pkg/resources/template"
 	orktypes "github.com/orkspace/orkestra/pkg/types"
 )
 
-// runPDBs resolves and applies PodDisruptionBudget template declarations.
-func runPDBs(
+// RunPVCs resolves and applies PersistentVolumeClaim template declarations.
+func RunPVCs(
 	ctx context.Context,
 	kube kubeclient.KubeClient,
 	resolver *orktmpl.Resolver,
 	owner domain.Object,
-	srcs []orktypes.PDBTemplateSource,
+	srcs []orktypes.PVCTemplateSource,
 	update bool,
 	guard func(ctx context.Context, obj domain.Object, ns string) bool,
 ) error {
@@ -52,36 +52,36 @@ func runPDBs(
 		if !conditionPassed {
 			if update || src.Reconcile {
 				if !activeNames[ns+"/"+name] {
-					if err := orkpdb.DeleteIfOwned(ctx, kube, owner, name, ns); err != nil {
-						return fmt.Errorf("pdbs[%d]: conditional cleanup: %w", i, err)
+					if err := orkpvc.DeleteIfOwned(ctx, kube, owner, name, ns); err != nil {
+						return fmt.Errorf("pvcs[%d]: conditional cleanup: %w", i, err)
 					}
 				}
 			}
 			logger.FromContext(ctx).Debug().
-				Str("resource", "PodDisruptionBudget").
+				Str("resource", "PersistentVolumeClaim").
 				Int("index", i).
 				Msg("conditions not met — skipping resource")
 			continue
 		}
 
-		resolved, err := resolver.ResolvePDBTemplate(src)
+		resolved, err := resolver.ResolvePVCTemplate(src)
 		if err != nil {
-			return fmt.Errorf("pdbs[%d]: %w", i, err)
+			return fmt.Errorf("pvcs[%d]: %w", i, err)
 		}
 
-		spec := orkpdb.Resolve(resolved, resolver.OwnerName())
+		spec := orkpvc.Resolve(resolved, resolver.OwnerName())
 
 		if update {
-			if err := orkpdb.Update(ctx, kube, owner, spec); err != nil {
-				return fmt.Errorf("pdbs[%d].update: %w", i, err)
+			if err := orkpvc.Update(ctx, kube, owner, spec); err != nil {
+				return fmt.Errorf("pvcs[%d].update: %w", i, err)
 			}
 		} else {
-			if err := orkpdb.Create(ctx, kube, owner, spec); err != nil {
-				return fmt.Errorf("pdbs[%d].create: %w", i, err)
+			if err := orkpvc.Create(ctx, kube, owner, spec); err != nil {
+				return fmt.Errorf("pvcs[%d].create: %w", i, err)
 			}
 			if src.Reconcile {
-				if err := orkpdb.Update(ctx, kube, owner, spec); err != nil {
-					return fmt.Errorf("pdbs[%d].reconcile: %w", i, err)
+				if err := orkpvc.Update(ctx, kube, owner, spec); err != nil {
+					return fmt.Errorf("pvcs[%d].reconcile: %w", i, err)
 				}
 			}
 		}

--- a/pkg/runners/pvs.go
+++ b/pkg/runners/pvs.go
@@ -1,5 +1,5 @@
 // pkg/reconciler/run_pvs.go
-package reconciler
+package runners
 
 import (
 	"context"
@@ -13,9 +13,9 @@ import (
 	orktypes "github.com/orkspace/orkestra/pkg/types"
 )
 
-// runPVs resolves and applies PersistentVolume template declarations.
+// RunPVs resolves and applies PersistentVolume template declarations.
 // PVs are cluster-scoped; the namespace guard is intentionally not applied.
-func runPVs(
+func RunPVs(
 	ctx context.Context,
 	kube kubeclient.KubeClient,
 	resolver *orktmpl.Resolver,

--- a/pkg/runners/replicasets.go
+++ b/pkg/runners/replicasets.go
@@ -1,5 +1,5 @@
 // pkg/reconciler/run_replicasets.go
-package reconciler
+package runners
 
 import (
 	"context"
@@ -13,7 +13,7 @@ import (
 	orktypes "github.com/orkspace/orkestra/pkg/types"
 )
 
-// runReplicaSets resolves and applies ReplicaSet template declarations.
+// RunReplicaSets resolves and applies ReplicaSet template declarations.
 //
 // update=false  onCreate path  — idempotent Create
 // update=true   onReconcile path — Update for drift correction
@@ -21,7 +21,7 @@ import (
 // reconcile: true on an onCreate entry means also call Update on that
 // same reconcile loop — the shorthand for "create it and keep it in sync"
 // without a separate onReconcile declaration.
-func runReplicaSets(
+func RunReplicaSets(
 	ctx context.Context,
 	kube kubeclient.KubeClient,
 	resolver *orktmpl.Resolver,

--- a/pkg/runners/rolebindings.go
+++ b/pkg/runners/rolebindings.go
@@ -1,5 +1,5 @@
-// pkg/reconciler/run_hpas.go
-package reconciler
+// pkg/reconciler/run_rolebindings.go
+package runners
 
 import (
 	"context"
@@ -8,18 +8,22 @@ import (
 	"github.com/orkspace/orkestra/domain"
 	"github.com/orkspace/orkestra/pkg/kubeclient"
 	"github.com/orkspace/orkestra/pkg/logger"
-	orkhpa "github.com/orkspace/orkestra/pkg/resources/hpas"
+	orkrb "github.com/orkspace/orkestra/pkg/resources/rolebindings"
 	orktmpl "github.com/orkspace/orkestra/pkg/resources/template"
 	orktypes "github.com/orkspace/orkestra/pkg/types"
 )
 
-// runHPAs resolves and applies HorizontalPodAutoscaler template declarations.
-func runHPAs(
+// RunRoleBindings resolves and applies RoleBinding template declarations.
+//
+// On onCreate: idempotent create only.
+// On onReconcile (update=true): creates or updates (or recreates when roleRef changed).
+// Owner references ensure cleanup when the CR is deleted.
+func RunRoleBindings(
 	ctx context.Context,
 	kube kubeclient.KubeClient,
 	resolver *orktmpl.Resolver,
 	owner domain.Object,
-	srcs []orktypes.HPATemplateSource,
+	srcs []orktypes.RoleBindingTemplateSource,
 	update bool,
 	guard func(ctx context.Context, obj domain.Object, ns string) bool,
 ) error {
@@ -52,37 +56,32 @@ func runHPAs(
 		if !conditionPassed {
 			if update || src.Reconcile {
 				if !activeNames[ns+"/"+name] {
-					if err := orkhpa.DeleteIfOwned(ctx, kube, owner, name, ns); err != nil {
-						return fmt.Errorf("hpas[%d]: conditional cleanup: %w", i, err)
+					if err := orkrb.DeleteIfOwned(ctx, kube, owner, name, ns); err != nil {
+						return fmt.Errorf("roleBindings[%d]: conditional cleanup: %w", i, err)
 					}
 				}
 			}
 			logger.FromContext(ctx).Debug().
-				Str("resource", "HorizontalPodAutoscaler").
+				Str("resource", "RoleBinding").
 				Int("index", i).
 				Msg("conditions not met — skipping resource")
 			continue
 		}
 
-		resolved, err := resolver.ResolveHPATemplate(src)
+		resolved, err := resolver.ResolveRoleBindingTemplate(src)
 		if err != nil {
-			return fmt.Errorf("hpas[%d]: %w", i, err)
+			return fmt.Errorf("roleBindings[%d]: %w", i, err)
 		}
 
-		spec := orkhpa.Resolve(resolved, resolver.OwnerName())
+		spec := orkrb.Resolve(resolved, resolver.OwnerName())
 
-		if update {
-			if err := orkhpa.Update(ctx, kube, owner, spec); err != nil {
-				return fmt.Errorf("hpas[%d].update: %w", i, err)
+		if update || src.Reconcile {
+			if err := orkrb.Update(ctx, kube, owner, spec); err != nil {
+				return fmt.Errorf("roleBindings[%d].update: %w", i, err)
 			}
 		} else {
-			if err := orkhpa.Create(ctx, kube, owner, spec); err != nil {
-				return fmt.Errorf("hpas[%d].create: %w", i, err)
-			}
-			if src.Reconcile {
-				if err := orkhpa.Update(ctx, kube, owner, spec); err != nil {
-					return fmt.Errorf("hpas[%d].reconcile: %w", i, err)
-				}
+			if err := orkrb.Create(ctx, kube, owner, spec); err != nil {
+				return fmt.Errorf("roleBindings[%d].create: %w", i, err)
 			}
 		}
 	}

--- a/pkg/runners/roles.go
+++ b/pkg/runners/roles.go
@@ -1,5 +1,5 @@
-// pkg/reconciler/run_statefulsets.go
-package reconciler
+// pkg/reconciler/run_roles.go
+package runners
 
 import (
 	"context"
@@ -8,18 +8,22 @@ import (
 	"github.com/orkspace/orkestra/domain"
 	"github.com/orkspace/orkestra/pkg/kubeclient"
 	"github.com/orkspace/orkestra/pkg/logger"
-	orksts "github.com/orkspace/orkestra/pkg/resources/statefulsets"
+	orkroles "github.com/orkspace/orkestra/pkg/resources/roles"
 	orktmpl "github.com/orkspace/orkestra/pkg/resources/template"
 	orktypes "github.com/orkspace/orkestra/pkg/types"
 )
 
-// runStatefulSets resolves and applies StatefulSet template declarations.
-func runStatefulSets(
+// RunRoles resolves and applies Role template declarations.
+//
+// On onCreate: idempotent create only.
+// On onReconcile (update=true): creates or updates rules on existing Roles.
+// Owner references ensure cleanup when the CR is deleted.
+func RunRoles(
 	ctx context.Context,
 	kube kubeclient.KubeClient,
 	resolver *orktmpl.Resolver,
 	owner domain.Object,
-	srcs []orktypes.StatefulSetTemplateSource,
+	srcs []orktypes.RoleTemplateSource,
 	update bool,
 	guard func(ctx context.Context, obj domain.Object, ns string) bool,
 ) error {
@@ -52,37 +56,32 @@ func runStatefulSets(
 		if !conditionPassed {
 			if update || src.Reconcile {
 				if !activeNames[ns+"/"+name] {
-					if err := orksts.DeleteIfOwned(ctx, kube, owner, name, ns); err != nil {
-						return fmt.Errorf("statefulsets[%d]: conditional cleanup: %w", i, err)
+					if err := orkroles.DeleteIfOwned(ctx, kube, owner, name, ns); err != nil {
+						return fmt.Errorf("roles[%d]: conditional cleanup: %w", i, err)
 					}
 				}
 			}
 			logger.FromContext(ctx).Debug().
-				Str("resource", "StatefulSet").
+				Str("resource", "Role").
 				Int("index", i).
 				Msg("conditions not met — skipping resource")
 			continue
 		}
 
-		resolved, err := resolver.ResolveStatefulSetTemplate(src)
+		resolved, err := resolver.ResolveRoleTemplate(src)
 		if err != nil {
-			return fmt.Errorf("statefulsets[%d]: %w", i, err)
+			return fmt.Errorf("roles[%d]: %w", i, err)
 		}
 
-		spec := orksts.Resolve(resolved, resolver.OwnerName())
+		spec := orkroles.Resolve(resolved, resolver.OwnerName())
 
-		if update {
-			if err := orksts.Update(ctx, kube, owner, spec); err != nil {
-				return fmt.Errorf("statefulsets[%d].update: %w", i, err)
+		if update || src.Reconcile {
+			if err := orkroles.Update(ctx, kube, owner, spec); err != nil {
+				return fmt.Errorf("roles[%d].update: %w", i, err)
 			}
 		} else {
-			if err := orksts.Create(ctx, kube, owner, spec); err != nil {
-				return fmt.Errorf("statefulsets[%d].create: %w", i, err)
-			}
-			if src.Reconcile {
-				if err := orksts.Update(ctx, kube, owner, spec); err != nil {
-					return fmt.Errorf("statefulsets[%d].reconcile: %w", i, err)
-				}
+			if err := orkroles.Create(ctx, kube, owner, spec); err != nil {
+				return fmt.Errorf("roles[%d].create: %w", i, err)
 			}
 		}
 	}

--- a/pkg/runners/secret_tls.go
+++ b/pkg/runners/secret_tls.go
@@ -23,7 +23,7 @@
 // The CA is unique per Secret — appropriate for self-signed operator webhooks.
 // For shared CAs across multiple services, store the CA in a separate Secret
 // and reference it (planned: ca.secretRef field).
-package reconciler
+package runners
 
 import (
 	"context"
@@ -56,7 +56,7 @@ func secretNeedsRotation(ctx context.Context, kube kubeclient.KubeClient, namesp
 		ResourceVersion: "0", // watch cache
 	})
 	if err != nil {
-		if isNotFoundErr(err) {
+		if IsNotFoundErr(err) {
 			return false, nil // does not exist — needs creation, not rotation
 		}
 		return false, fmt.Errorf("checking secret %s/%s for rotation: %w", namespace, name, err)
@@ -98,7 +98,7 @@ func annotateSecret(ctx context.Context, kube kubeclient.KubeClient, namespace, 
 // then generates new credentials and annotates with the current time.
 func deleteSecretForRotation(ctx context.Context, kube kubeclient.KubeClient, namespace, name string) error {
 	err := kube.Clientset().CoreV1().Secrets(namespace).Delete(ctx, name, metav1.DeleteOptions{})
-	if err != nil && !isNotFoundErr(err) {
+	if err != nil && !IsNotFoundErr(err) {
 		return fmt.Errorf("deleting secret %s/%s for rotation: %w", namespace, name, err)
 	}
 	return nil

--- a/pkg/runners/secrets.go
+++ b/pkg/runners/secrets.go
@@ -16,7 +16,7 @@
 //  4. TLS generation (if tls: is set)      — generate CA + cert, skip data resolution
 //  5. Create/Update/CopyToNamespaces
 //  6. Annotate with generated-at           — only when rotateAfter is set
-package reconciler
+package runners
 
 import (
 	"context"
@@ -32,7 +32,7 @@ import (
 	orktypes "github.com/orkspace/orkestra/pkg/types"
 )
 
-func runSecrets(
+func RunSecrets(
 	ctx context.Context,
 	kube kubeclient.KubeClient,
 	resolver *orktmpl.Resolver,
@@ -152,7 +152,7 @@ func runSecrets(
 		// When tls: is declared, ignore the data: block entirely and generate
 		// a self-signed CA + signed certificate instead.
 		if src.TLS != nil {
-			if err := runTLSSecret(ctx, kube, resolver, owner, src, name, ns, update); err != nil {
+			if err := RunTLSSecret(ctx, kube, resolver, owner, src, name, ns, update); err != nil {
 				return fmt.Errorf("secrets[%d].tls: %w", i, err)
 			}
 			continue
@@ -225,9 +225,9 @@ func runSecrets(
 	return nil
 }
 
-// runTLSSecret handles the tls: path — generates a self-signed CA and server
+// RunTLSSecret handles the tls: path — generates a self-signed CA and server
 // certificate and creates/updates a kubernetes.io/tls Secret.
-func runTLSSecret(
+func RunTLSSecret(
 	ctx context.Context,
 	kube kubeclient.KubeClient,
 	resolver *orktmpl.Resolver,

--- a/pkg/runners/secrets_once.go
+++ b/pkg/runners/secrets_once.go
@@ -31,7 +31,7 @@
 // once: guard — the caller opted into continuous reconciliation.
 //
 // once: false (default): standard create/update behavior, unchanged.
-package reconciler
+package runners
 
 import (
 	"context"
@@ -50,7 +50,7 @@ func secretExists(ctx context.Context, kube kubeclient.KubeClient, namespace, na
 		ResourceVersion: "0", // watch cache — avoids etcd round-trip
 	})
 	if err != nil {
-		if isNotFoundErr(err) {
+		if IsNotFoundErr(err) {
 			return false, nil
 		}
 		return false, fmt.Errorf("checking secret %s/%s: %w", namespace, name, err)
@@ -58,8 +58,8 @@ func secretExists(ctx context.Context, kube kubeclient.KubeClient, namespace, na
 	return true, nil
 }
 
-// isNotFoundErr returns true when err is a Kubernetes 404 Not Found error.
-func isNotFoundErr(err error) bool {
+// IsNotFoundErr returns true when err is a Kubernetes 404 Not Found error.
+func IsNotFoundErr(err error) bool {
 	if err == nil {
 		return false
 	}

--- a/pkg/runners/serviceaccounts.go
+++ b/pkg/runners/serviceaccounts.go
@@ -1,5 +1,5 @@
-// pkg/reconciler/run_services.go
-package reconciler
+// pkg/reconciler/run_serviceaccounts.go
+package runners
 
 import (
 	"context"
@@ -8,19 +8,25 @@ import (
 	"github.com/orkspace/orkestra/domain"
 	"github.com/orkspace/orkestra/pkg/kubeclient"
 	"github.com/orkspace/orkestra/pkg/logger"
-	orksvc "github.com/orkspace/orkestra/pkg/resources/services"
+	orksa "github.com/orkspace/orkestra/pkg/resources/serviceaccounts"
 	orktmpl "github.com/orkspace/orkestra/pkg/resources/template"
 	orktypes "github.com/orkspace/orkestra/pkg/types"
 )
 
-// runServices resolves and applies Service template declarations.
-// Same update/reconcile: true semantics as runDeployments.
-func runServices(
+// RunServiceAccounts resolves and applies ServiceAccount template declarations.
+//
+// ServiceAccounts are create-only — there is nothing meaningful to update
+// on a ServiceAccount after creation (no spec fields that drift). They are
+// therefore always idempotent creates regardless of whether this is called
+// from onCreate or onReconcile.
+//
+// Owner references ensure cleanup when the CR is deleted.
+func RunServiceAccounts(
 	ctx context.Context,
 	kube kubeclient.KubeClient,
 	resolver *orktmpl.Resolver,
 	owner domain.Object,
-	srcs []orktypes.ServiceTemplateSource,
+	srcs []orktypes.ServiceAccountTemplateSource,
 	update bool,
 	guard func(ctx context.Context, obj domain.Object, ns string) bool,
 ) error {
@@ -41,15 +47,14 @@ func runServices(
 		// 1. Evaluate conditions BEFORE resolving templates
 		conditionPassed := orktypes.EvaluateWhen(resolver.Data(), src.Conditions, src.AnyOf, resolver.TemplateEvaluator())
 
+		// Early name/ns resolution — needed for guard check and DeleteIfOwned cleanup.
 		name, _ := resolver.Resolve(src.Name)
 		ns, _ := resolver.Resolve(src.Namespace)
 		if ns == "" {
 			ns = owner.GetNamespace()
 		}
 
-		// ── Namespace guard ───────────────────────────────────────────────
-		// Called after namespace resolution so the actual target namespace
-		// is known. Before this point the namespace may be a template expression.
+		// ── Namespace guard ───────────────────────────────────────────────────
 		if guard != nil && !guard(ctx, owner, ns) {
 			continue // skipped — CheckNamespace already logged the reason
 		}
@@ -57,13 +62,13 @@ func runServices(
 		if !conditionPassed {
 			if update || src.Reconcile {
 				if !activeNames[ns+"/"+name] {
-					if err := orksvc.DeleteIfOwned(ctx, kube, owner, name, ns); err != nil {
-						return fmt.Errorf("services[%d]: conditional cleanup: %w", i, err)
+					if err := orksa.DeleteIfOwned(ctx, kube, owner, name, ns); err != nil {
+						return fmt.Errorf("serviceAccounts[%d]: conditional cleanup: %w", i, err)
 					}
 				}
 			}
 			logger.FromContext(ctx).Debug().
-				Str("resource", "ConfigMap").
+				Str("resource", "ServiceAccount").
 				Int("index", i).
 				Msg("conditions not met — skipping resource")
 
@@ -71,29 +76,17 @@ func runServices(
 		}
 
 		// 2. Resolve template expressions
-		resolved, err := resolver.ResolveServiceTemplate(src)
+		resolved, err := resolver.ResolveServiceAccountTemplate(src)
 		if err != nil {
-			return fmt.Errorf("services[%d]: %w", i, err)
+			return fmt.Errorf("serviceaccounts[%d]: %w", i, err)
 		}
 
 		// 3. Build registry spec and apply
-		spec := orksvc.Resolve(resolved, resolver.OwnerName())
+		spec := orksa.Resolve(resolved, resolver.OwnerName())
 
-		if update {
-			if err := orksvc.Update(ctx, kube, owner, spec); err != nil {
-				return fmt.Errorf("services[%d].update: %w", i, err)
-			}
-		} else {
-			if err := orksvc.Create(ctx, kube, owner, spec); err != nil {
-				return fmt.Errorf("services[%d].create: %w", i, err)
-			}
-
-			// reconcile: true
-			if src.Reconcile {
-				if err := orksvc.Update(ctx, kube, owner, spec); err != nil {
-					return fmt.Errorf("services[%d].reconcile: %w", i, err)
-				}
-			}
+		// Always create — ServiceAccounts have no meaningful drift to correct
+		if err := orksa.Create(ctx, kube, owner, spec); err != nil {
+			return fmt.Errorf("serviceaccounts[%d].create: %w", i, err)
 		}
 	}
 	return nil

--- a/pkg/runners/services.go
+++ b/pkg/runners/services.go
@@ -1,5 +1,5 @@
-// pkg/reconciler/run_serviceaccounts.go
-package reconciler
+// pkg/reconciler/run_services.go
+package runners
 
 import (
 	"context"
@@ -8,25 +8,19 @@ import (
 	"github.com/orkspace/orkestra/domain"
 	"github.com/orkspace/orkestra/pkg/kubeclient"
 	"github.com/orkspace/orkestra/pkg/logger"
-	orksa "github.com/orkspace/orkestra/pkg/resources/serviceaccounts"
+	orksvc "github.com/orkspace/orkestra/pkg/resources/services"
 	orktmpl "github.com/orkspace/orkestra/pkg/resources/template"
 	orktypes "github.com/orkspace/orkestra/pkg/types"
 )
 
-// runServiceAccounts resolves and applies ServiceAccount template declarations.
-//
-// ServiceAccounts are create-only — there is nothing meaningful to update
-// on a ServiceAccount after creation (no spec fields that drift). They are
-// therefore always idempotent creates regardless of whether this is called
-// from onCreate or onReconcile.
-//
-// Owner references ensure cleanup when the CR is deleted.
-func runServiceAccounts(
+// RunServices resolves and applies Service template declarations.
+// Same update/reconcile: true semantics as RunDeployments.
+func RunServices(
 	ctx context.Context,
 	kube kubeclient.KubeClient,
 	resolver *orktmpl.Resolver,
 	owner domain.Object,
-	srcs []orktypes.ServiceAccountTemplateSource,
+	srcs []orktypes.ServiceTemplateSource,
 	update bool,
 	guard func(ctx context.Context, obj domain.Object, ns string) bool,
 ) error {
@@ -47,14 +41,15 @@ func runServiceAccounts(
 		// 1. Evaluate conditions BEFORE resolving templates
 		conditionPassed := orktypes.EvaluateWhen(resolver.Data(), src.Conditions, src.AnyOf, resolver.TemplateEvaluator())
 
-		// Early name/ns resolution — needed for guard check and DeleteIfOwned cleanup.
 		name, _ := resolver.Resolve(src.Name)
 		ns, _ := resolver.Resolve(src.Namespace)
 		if ns == "" {
 			ns = owner.GetNamespace()
 		}
 
-		// ── Namespace guard ───────────────────────────────────────────────────
+		// ── Namespace guard ───────────────────────────────────────────────
+		// Called after namespace resolution so the actual target namespace
+		// is known. Before this point the namespace may be a template expression.
 		if guard != nil && !guard(ctx, owner, ns) {
 			continue // skipped — CheckNamespace already logged the reason
 		}
@@ -62,13 +57,13 @@ func runServiceAccounts(
 		if !conditionPassed {
 			if update || src.Reconcile {
 				if !activeNames[ns+"/"+name] {
-					if err := orksa.DeleteIfOwned(ctx, kube, owner, name, ns); err != nil {
-						return fmt.Errorf("serviceAccounts[%d]: conditional cleanup: %w", i, err)
+					if err := orksvc.DeleteIfOwned(ctx, kube, owner, name, ns); err != nil {
+						return fmt.Errorf("services[%d]: conditional cleanup: %w", i, err)
 					}
 				}
 			}
 			logger.FromContext(ctx).Debug().
-				Str("resource", "ServiceAccount").
+				Str("resource", "ConfigMap").
 				Int("index", i).
 				Msg("conditions not met — skipping resource")
 
@@ -76,17 +71,29 @@ func runServiceAccounts(
 		}
 
 		// 2. Resolve template expressions
-		resolved, err := resolver.ResolveServiceAccountTemplate(src)
+		resolved, err := resolver.ResolveServiceTemplate(src)
 		if err != nil {
-			return fmt.Errorf("serviceaccounts[%d]: %w", i, err)
+			return fmt.Errorf("services[%d]: %w", i, err)
 		}
 
 		// 3. Build registry spec and apply
-		spec := orksa.Resolve(resolved, resolver.OwnerName())
+		spec := orksvc.Resolve(resolved, resolver.OwnerName())
 
-		// Always create — ServiceAccounts have no meaningful drift to correct
-		if err := orksa.Create(ctx, kube, owner, spec); err != nil {
-			return fmt.Errorf("serviceaccounts[%d].create: %w", i, err)
+		if update {
+			if err := orksvc.Update(ctx, kube, owner, spec); err != nil {
+				return fmt.Errorf("services[%d].update: %w", i, err)
+			}
+		} else {
+			if err := orksvc.Create(ctx, kube, owner, spec); err != nil {
+				return fmt.Errorf("services[%d].create: %w", i, err)
+			}
+
+			// reconcile: true
+			if src.Reconcile {
+				if err := orksvc.Update(ctx, kube, owner, spec); err != nil {
+					return fmt.Errorf("services[%d].reconcile: %w", i, err)
+				}
+			}
 		}
 	}
 	return nil

--- a/pkg/runners/statefulsets.go
+++ b/pkg/runners/statefulsets.go
@@ -1,5 +1,5 @@
-// pkg/reconciler/run_roles.go
-package reconciler
+// pkg/reconciler/run_statefulsets.go
+package runners
 
 import (
 	"context"
@@ -8,22 +8,18 @@ import (
 	"github.com/orkspace/orkestra/domain"
 	"github.com/orkspace/orkestra/pkg/kubeclient"
 	"github.com/orkspace/orkestra/pkg/logger"
-	orkroles "github.com/orkspace/orkestra/pkg/resources/roles"
+	orksts "github.com/orkspace/orkestra/pkg/resources/statefulsets"
 	orktmpl "github.com/orkspace/orkestra/pkg/resources/template"
 	orktypes "github.com/orkspace/orkestra/pkg/types"
 )
 
-// runRoles resolves and applies Role template declarations.
-//
-// On onCreate: idempotent create only.
-// On onReconcile (update=true): creates or updates rules on existing Roles.
-// Owner references ensure cleanup when the CR is deleted.
-func runRoles(
+// RunStatefulSets resolves and applies StatefulSet template declarations.
+func RunStatefulSets(
 	ctx context.Context,
 	kube kubeclient.KubeClient,
 	resolver *orktmpl.Resolver,
 	owner domain.Object,
-	srcs []orktypes.RoleTemplateSource,
+	srcs []orktypes.StatefulSetTemplateSource,
 	update bool,
 	guard func(ctx context.Context, obj domain.Object, ns string) bool,
 ) error {
@@ -56,32 +52,37 @@ func runRoles(
 		if !conditionPassed {
 			if update || src.Reconcile {
 				if !activeNames[ns+"/"+name] {
-					if err := orkroles.DeleteIfOwned(ctx, kube, owner, name, ns); err != nil {
-						return fmt.Errorf("roles[%d]: conditional cleanup: %w", i, err)
+					if err := orksts.DeleteIfOwned(ctx, kube, owner, name, ns); err != nil {
+						return fmt.Errorf("statefulsets[%d]: conditional cleanup: %w", i, err)
 					}
 				}
 			}
 			logger.FromContext(ctx).Debug().
-				Str("resource", "Role").
+				Str("resource", "StatefulSet").
 				Int("index", i).
 				Msg("conditions not met — skipping resource")
 			continue
 		}
 
-		resolved, err := resolver.ResolveRoleTemplate(src)
+		resolved, err := resolver.ResolveStatefulSetTemplate(src)
 		if err != nil {
-			return fmt.Errorf("roles[%d]: %w", i, err)
+			return fmt.Errorf("statefulsets[%d]: %w", i, err)
 		}
 
-		spec := orkroles.Resolve(resolved, resolver.OwnerName())
+		spec := orksts.Resolve(resolved, resolver.OwnerName())
 
-		if update || src.Reconcile {
-			if err := orkroles.Update(ctx, kube, owner, spec); err != nil {
-				return fmt.Errorf("roles[%d].update: %w", i, err)
+		if update {
+			if err := orksts.Update(ctx, kube, owner, spec); err != nil {
+				return fmt.Errorf("statefulsets[%d].update: %w", i, err)
 			}
 		} else {
-			if err := orkroles.Create(ctx, kube, owner, spec); err != nil {
-				return fmt.Errorf("roles[%d].create: %w", i, err)
+			if err := orksts.Create(ctx, kube, owner, spec); err != nil {
+				return fmt.Errorf("statefulsets[%d].create: %w", i, err)
+			}
+			if src.Reconcile {
+				if err := orksts.Update(ctx, kube, owner, spec); err != nil {
+					return fmt.Errorf("statefulsets[%d].reconcile: %w", i, err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- New `pkg/runners/` package — 20 resource runner files extracted from `pkg/reconciler/`
- Files renamed: `run_secrets.go` → `secrets.go` (the `run_` prefix was redundant inside a package already named `runners`)
- Functions exported: `runSecrets` → `RunSecrets`, `runDeployments` → `RunDeployments`, etc.
- `pkg/reconciler/run_template_reconcile.go` imports `pkg/runners` and calls the exported functions
- `deleteOwnedNamespaces` stays in `pkg/reconciler/` — it's reconciler-specific deletion logic, not a generic resource runner
- `isNotFoundErr` exported as `runners.IsNotFoundErr` — used by both runners (secrets) and reconciler (ordered delete)
- No behaviour change

## Why

`pkg/reconciler/` was accumulating a `run_*.go` file per resource type. At 20+ files and counting, that boundary was gone — the reconciler owned both the dispatch logic and the resource implementations. `pkg/runners/` is now the home for resource-level reconcile functions; `pkg/reconciler/` is the dispatcher that calls them in order.

New resource types add a file to `pkg/runners/`, wire into the dispatcher — no growth in `pkg/reconciler/`.

## Test plan

- [x] `make ork` — clean build
- [x] `go test ./pkg/reconciler/...` — passes
- [x] `go test ./pkg/...` — no regressions